### PR TITLE
Initial support for coreir register primitive

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,3 +9,5 @@ def magma_test():
     """
     import magma.circuit
     magma.circuit.__magma_clear_circuit_cache()
+    import magma.config
+    magma.config.set_compile_dir('callee_file_dir')

--- a/magma/bit_vector.py
+++ b/magma/bit_vector.py
@@ -132,3 +132,6 @@ class BitVector:
 
     def as_bool_list(self):
         return [bool(x) for x in self._bits]
+
+    def __len__(self):
+        return self.num_bits

--- a/notebooks/Counter (4-bit).ipynb
+++ b/notebooks/Counter (4-bit).ipynb
@@ -4,20 +4,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "import verilog\n",
-      "import mantle lattice ice40\n",
-      "import mantle lattice mantle40\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from magma import *\n",
-    "from mantle.lattice.mantle40 import DefineRegister"
+    "from magma.primitives import DefineRegister"
    ]
   },
   {
@@ -26,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Reg4 = DefineRegister(4, _type=UInt)\n",
+    "Reg4 = DefineRegister(4, T=UInt)\n",
     "\n",
     "class Counter4(Circuit):\n",
     "    name = \"Counter4\"\n",
@@ -34,10 +24,10 @@
     "    @classmethod\n",
     "    def definition(io):\n",
     "        reg4 = Reg4()\n",
-    "        count = reg4.O + int2seq(1, 4)\n",
-    "        wire(count, reg4.I)\n",
-    "        wire(reg4.O, io.count)\n",
-    "        wireclock(io, reg4)"
+    "        count = reg4.Q + int2seq(1, 4)\n",
+    "        wire(count, reg4.D)\n",
+    "        wire(reg4.Q, io.count)\n",
+    "        wire(io.CLK, reg4.clk)"
    ]
   },
   {
@@ -75,7 +65,7 @@
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAD8CAYAAACRkhiPAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADRlJREFUeJzt3WuoZeddx/Hvz0yTZoix2iJox2hrE7TjpZK0QlFpB7yk\ncahBBvqm0xjyQrQggYI2aBVpEF9ECHipJZBoEIxCLuKMvjCGgIKRpkkMiZjpaEhiiyRUjXEyzaX/\nvjj7cHZOJjl7zl579jPz/37gkDPPedaz/uvJmv2bddYtVYUkqadvWncBkqT1MQQkqTFDQJIaMwQk\nqTFDQJIaMwQkqTFDQJIaMwQkqTFDQJIaMwQkqTFDQJIaMwQkqTFDQJIaMwQkqTFDQJIaMwQkqTFD\nQJIaMwQkqTFDQJIaMwQkqTFDQJIaMwQkqTFDQJIaMwQkqTFDQJIaMwQkqTFDQJIaMwQkqTFDQJIa\nMwQkqbH1h0BSC3wdeZPljyy1/ChjLLb8+HNx5rbDuXAu+s7FhFJVZ2I9b1JBFiugKitZfpQxFl1+\nijHOle2YYgznYuflpxjDuTj95XeqYyJ7Vr2CHe20kSNMuDvfdDWMMoZzcfrLTzGGc7Hz8qdbx5LW\n/+sgSdLaGAKS1NiuQiDJbyX51C6W+1CSv97NOiVJ0/NIQJIaWygEkhxO8i9JHkly+7afvS/JP81+\nfleSb521vyfJ382W+WKS79223PuTPLS9XZJ05uwYAkn2A78OHKiqHwZ+ZVuXPwV+tap+CHgU+M1Z\n+58BfzBb5oPAV+bG/CDwOeCjVXV86a2QJO3KIkcCB4C/rKrnAKrqq5s/SPItwNuq6v5Z058AP5Hk\nm4F3VtVds2VOVtWJWZ/vBz4PHKyqpybaDknSLqzjnMBXgJPAj6xh3ZKkOYuEwN8Dh5K8HSDJt23+\noKr+F/jvJD8+a/o4cH9V/R/wTJKfmy1zQZK9sz7/A1wF/E6SD02zGZKk3djxjuGqeizJjcD9SV4F\nHgKenOvyCeBzsw/5fwd+Ydb+ceCPk/w28DJwaG7M/0rys8DfJLm2qh6YZGskSadl/c8O2snm7dM7\n3aK925+PMobrOPfqdC7O7DrOljqnWMeEvE9AkhozBCSpMUNAkhozBCSpMUNAkhozBCSpMUNAkhoz\nBCSpsfW/Y3hRy75zc4p3dp4rY4xQwyhjjFDDKGOMUMMoY4xQw05jTHQj2dlwJHB0yT6LLD/KGDv1\nOVvmYtXbMcUYzsXpLT/FGM7F4n0WrWNp4z82QpK0MmfDkYAkaUUMAUlqzBCQpMYMAUlqzBCQpMYM\nAUlqzBCQpMYMAUlqzBCQpMYMAUlqzBCQpMYMAUlqzBCQpMYMAUlqzBCQpMYMAUlqzBCQpMYMAUlq\nzBCQpMbO/hBIjpDUBF9HBqhjhBqWq2OEGkapY4QaRqljhBpGqWOqGiZy9r9ofsLJoCprr2OEGpap\nY4QaRqljhBpGqWOEGkapY4TPijl7phhkCO4Yy9cwZR0j1DBKHSPUMEodI9QwSh0TfYgv6+z/dZAk\nadcMAUlqbKEQSLIvyT1JjiU5nuTmJOcnuSbJs0lumev76SRfSvJvSX561nZhkoeTvJTkHavaGEnS\n6dkxBJIEuBO4u6ouBS4DLgJunHW5o6qum/V9L/AxYD/wM8AfJjmvql6sqvcBX17BNkiSdmmRI4ED\nwMmquhWgql4FrgeuBfZu6/tR4M+r6mtV9R/Al4APTFivJGlCi4TAfuDB+Yaqeh54itdfXfRO4Om5\nPz8za5MkDcgTw5LU2CIh8Dhw+XxDkouBS4BXtvX9T+C75v68b9YmSRrQIiFwL7A3yWGAJOcBNwG3\nASe29f0r4GNJLkjyLuBS4J+nK1eSNKUdQ6A2nitxNXAoyTHgCeAkcMMp+j4G/AUbRw9/C/zy7ESy\nJGlACz02oqqeBg5ub9+4evR1fW9k6/JRSdLAlj0x/CJw5fzNYqeyebMY8Bbg60uuU5I0kXPnKaJT\nPBBqnWOMUMMUY4xQwyhjjFDDKGOMUMMoY0xRw4S8RFSSGjMEJKkxQ0CSGjMEJKkxQ0CSGlv/6yWn\nfGXcskaoZYQaYIw6RqgBxqhjhBpgjDpGqAHGqWNJ58qRwNE1Lz/FOCPUMMXyo9QwxTjOxXTLj1LD\nFOOMMBeTOfvvE5Ak7dq5ciQgSdoFQ0CSGjMEJKkxQ0CSGjMEJKkxQ0CSGjMEJKkxQ0CSGjMEJKkx\nQ0CSGjMEJKkxQ0CSGjMEJKkxQ0CSGjMEJKkxQ0CSGjMEJKkxQ0CSGjMEJKkxQwAgOUJSA3wdWfdU\nOBfOhXNxlszFVJvji+ZhygldWlXWun7nYotzscW52DLKXEw0D3umGOScsc6da5Qda5NzscW52OJc\nbFl3GE3EXwdJUmOGgCQ1ZghIUmMLhUCSfUnuSXIsyfEkNyc5P8k1SZ5Ncsus39uT3JfkhSS/v22M\nzfYrVrEhkqTTt2MIJAlwJ3B3VV0KXAZcBNw463JHVV03+/4k8BvAp7aPU1UfBr4wRdGSpGksciRw\nADhZVbcCVNWrwPXAtcDe+Y5V9f9V9Q9shIEkaXCLhMB+4MH5hqp6HngKLzGVpLOaJ4YlqbFFQuBx\n4PL5hiQXA5cAr6yiKEnSmbFICNwL7E1yGCDJecBNwG3AidWVJklatR1DoDYeLnQ1cCjJMeAJNk78\n3nCq/kmeBH4PuCbJM0neO125kqQpLXRit6qeBg5ub9+4evR1fb9n6aokSWfEsieGXwSu3LxZ7M0k\nuQ94N/DykuuUJE3ER0nD1tMJR3hC4rqfTDhCHSPUMEodI9QwSh0j1DBSHRPxElFJaswQkKTGDAFJ\naswQkKTGDAFJamz9D4Ab7b2h6+Z8bHEutjgXW5yLSXkksOVo8/XPW3ct617/vHXXsu71z1t3Lete\n/7yRalmK9wlIUmMeCUhSY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDVm\nCEhSY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDVmCEhSY3vWXYBmkiPAR9ZdxkCOUnXV\nuotYO/eL7dwvJuaL5keR+D9iu6qsu4S1c794PfeLSXkkMBp3cD/4TsX9wv1iRTwnIEmNGQKS1NhC\nIZBkX5J7khxLcjzJzUnOT3JNkmeT3DLr95NJHkzy6Oy/B+bGuC/JC0muWNXGSJJOz44hkCTAncDd\nVXUpcBlwEXDjrMsdVXXd7PvngINV9YPAJ4DbN8epqg8DX5iwdknSkhY5EjgAnKyqWwGq6lXgeuBa\nYO98x6p6qKq+PPvjY8CFSS6YsF5J0oQWCYH9wIPzDVX1PPAUb3510c8DX6yqr+2+PEnSKq3kEtEk\n+4HfBX5qFeNLkqaxyJHA48Dl8w1JLgYuAV7Z3jnJPuAu4HBVHZ+iSEnSaiwSAvcCe5McBkhyHnAT\ncBtwYr5jkrcBR4Bfq6p/nLZUSdLUdgyB2niuxNXAoSTHgCeAk8ANp+j+SeA9wGeSPDz7+vYpC5Yk\nTWehcwJV9TRwcHv7xtWjr+n3WeCzk1QmSVq5Ze8YfhG4cvNmsTeT5D7g3cDLS65TkjQRnyI6is2H\nY/mgMOdinnOxxblYCZ8dJEmNGQKS1JghIEmNGQKS1JghIEmNrf/1kr4yTm/EfUOn4n6xYaKrpDwS\nGMvRdRcwCOfhtZyPDc7DCnifgCQ15pGAJDVmCEhSY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDVmCEhS\nY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDVmCEhSY4aAJDW2Z90FSK+T\nHAE+su4yNKSjVF217iLOJb5oXuNJ3Cn1xqqy7hLOJR4JaFz+Zdc8/3GwEp4TkKTGDAFJaswQkKTG\nFgqBJPuS3JPkWJLjSW5Ocn6Sa5I8m+SWWb8PJHl49vVIkqtn7RfO2l5K8o5VbpAkaXE7Xh2UJMAD\nwB9V1a1JzgM+D3wVeAy4oqo+Oeu7F3ipql5J8h3AI8B3VtUrs58/Oev/3Ko2SOeAzROAnhjWPPeL\nlVjkSOAAcLKqbgWoqleB64Frgb3zHavqxOYHPvBWwLP5kjSwRUJgP/DgfENVPQ88xSkuMU3yo0ke\nAx4FfnEuFCRJg5n8xHBVPVBV+4H3A59O8tap1yFJmsYiIfA4cPl8Q5KLgUuAN/xXflX9K/AC8APL\nFChJWp1FQuBeYG+SwwCzE8M3AbcBJ+Y7JnlXkj2z778b+D7gyQnrlSRNaMcQqI3Lh64GDiU5BjwB\nnARuOEX3HwMeSfIwcBfwS14JJEnjWujZQVX1NHBwe/vG1aOv6Xc7cPsklUmSVm7ZE8MvAldu3iz2\nRjZvFgPeAnx9yXVKkibio6Q1Hm8K0qm4X6yEzw6SpMYMAUlqzBCQpMYMAUlqzBCQpMbW/45h3xsq\n6XT4mbFhoqukvERUkhrz10GS1JghIEmNGQKS1JghIEmNGQKS1JghIEmNGQKS1JghIEmNGQKS1Jgh\nIEmNGQKS1JghIEmNGQKS1JghIEmNGQKS1JghIEmNGQKS1JghIEmNGQKS1JghIEmNGQKS1JghIEmN\nGQKS1Ng3AMWacDIKG7CbAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x11211d4e0>"
+       "<matplotlib.figure.Figure at 0x1117b97b8>"
       ]
      },
      "metadata": {},

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,0 +1,32 @@
+import magma
+from magma import In, Out, Bit, UInt, Circuit
+from magma.primitives import DefineRegister
+from magma.bit_vector import BitVector
+from magma.verilator.verilator import compile as compileverilator
+from magma.verilator.verilator import run_verilator_test
+
+from test_expressions import insert_coreir_stdlib_include
+
+def test_register():
+    N = 4
+    Register4 = DefineRegister(N, T=UInt)
+    class TestCircuit(Circuit):
+        name = "test_register"
+        IO = ["CLK", In(Bit), "out", Out(UInt(N))]
+        @classmethod
+        def definition(circuit):
+            reg = Register4()
+            magma.wire(reg.Q, circuit.out)
+            magma.wire(reg.D, reg.Q + magma.int2seq(1, N))
+            magma.wire(circuit.CLK, reg.clk)
+
+    magma.compile("build/test_register", TestCircuit)
+    expected_sequence = [BitVector(x, num_bits=N) for x in range(1, 1 << N)]
+    test_vectors = [[BitVector(0, num_bits=1), BitVector(0, num_bits=N)]]  # We hardcode the first ouput
+    for output in expected_sequence:
+        test_vectors.append([BitVector(1, num_bits=1), output])
+        test_vectors.append([BitVector(0, num_bits=1), output])
+
+    compileverilator('build/sim_test_register_main.cpp', TestCircuit, test_vectors)
+    insert_coreir_stdlib_include("build/test_register.v")
+    run_verilator_test('test_register', 'sim_test_register_main', 'test_register')


### PR DESCRIPTION
* Adds initial support for the coreir register primitive (doesn't support the various permutations with enable, reset, set, etc..), including a Python simulator function based on @shacklettbp 's implementation of the SB_DFF for mantle40
* Tests the register primitive through the verilator test harness
* Updates the 4-Bit counter notebook example to use this primitive

One thing of note here:
Clocked circuits *do* work with the verilator harness, just need to generate the test vectors with the correct clock input logic. **N.B.** this is only true with testvector input, not providing a Python function. We should definitely improve this interface to better support defining test vectors for clocked circuits.