### PR TITLE
[refactor] ce -> has_ce

### DIFF
--- a/magma/primitives.py
+++ b/magma/primitives.py
@@ -231,7 +231,7 @@ def arithmetic_shift_right(self, other):
 SIntType.arithmetic_shift_right = arithmetic_shift_right
 
 
-def gen_sim_register(N, ce):
+def gen_sim_register(N, has_ce):
     def sim_register(self, value_store, state_store):
         """
         Adapted from Brennan's SB_DFF simulation in mantle
@@ -260,7 +260,7 @@ def gen_sim_register(N, ce):
             input_val = value_store.get_value(self.D)
 
             enable = True
-            if ce:
+            if has_ce:
                 enable = value_store.get_value(self.en)
 
             if enable:
@@ -283,12 +283,12 @@ def gen_sim_register(N, ce):
     return sim_register
 
 @lru_cache(maxsize=None)
-def DefineRegister(N, ce=False, T=Bits):
+def DefineRegister(N, has_ce=False, T=Bits):
     name = "Reg_P"  # TODO: Add support for clock interface
     io = ["D", In(T(N)), "clk", In(Bit), "Q", Out(T(N))]
-    if ce:
+    if has_ce:
         io.extend(["en", In(Bit)])
         name += "E"  # TODO: This assumes ordering of clock parameters
     def wrapper(*args, **kwargs):
-        return DeclareCircuit(name, *io, stateful=True, simulate=gen_sim_register(N, ce))(WIDTH=N, *args, **kwargs)
+        return DeclareCircuit(name, *io, stateful=True, simulate=gen_sim_register(N, has_ce))(WIDTH=N, *args, **kwargs)
     return wrapper

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -42,7 +42,7 @@ def test_register():
 
 def test_register_ce():
     N = 4
-    Register4 = DefineRegister(N, ce=True, T=UInt)
+    Register4 = DefineRegister(N, has_ce=True, T=UInt)
     class TestCircuit(Circuit):
         name = "test_register_ce"
         IO = ["CLK", In(Bit), "CE", In(Bit), "out", Out(UInt(N))]


### PR DESCRIPTION
This updates the Register primitive to follow the `has_ce` convention