### PR TITLE
Resolve name collision with 2 uint functions

### DIFF
--- a/magma/bitutils.py
+++ b/magma/bitutils.py
@@ -74,7 +74,7 @@ def lutinit(init, n=None):
     return init, n
 
 
-def uint(x, nbits):
+def int2uint(x, nbits):
     return x & ((1 << nbits)-1)
 
 # base 32


### PR DESCRIPTION
I propose `int2uint` to be consistent with the `int2seq` style functions.