### PR TITLE
Patch fromverilog to handle 1-bit ports

### DIFF
--- a/magma/fromverilog.py
+++ b/magma/fromverilog.py
@@ -40,7 +40,7 @@ def ParseVerilogModule(node):
         elif isinstance(io, Output):
             dir = Out
         else:
-            dir = InOot
+            dir = InOut
 
         if io.width is None:
             t = Bit

--- a/magma/fromverilog.py
+++ b/magma/fromverilog.py
@@ -36,21 +36,21 @@ def ParseVerilogModule(node):
         args.append(io.name)
 
         if isinstance(io, Input):
-            dir = In
+            direction = In
         elif isinstance(io, Output):
-            dir = Out
+            direction = Out
         else:
-            dir = InOut
+            direction = InOut
 
         if io.width is None:
-            t = Bit
+            type_ = Bit
         else:
             msb = int(io.width.msb.value)
             lsb = int(io.width.lsb.value)
 
-            t = Array(msb-lsb+1, Bit)
+            type_ = Array(msb-lsb+1, Bit)
 
-        args.append(dir(t))
+        args.append(direction(type_))
 
     return node.name, args
 

--- a/magma/fromverilog.py
+++ b/magma/fromverilog.py
@@ -6,7 +6,7 @@ from mako.template import Template
 from pyverilog.vparser.parser import VerilogParser, Node, Input, Output, ModuleDef
 from pyverilog.dataflow.visit import NodeVisitor
 
-from .t import In, Out
+from .t import In, Out, InOut
 from .bit import Bit
 from .array import Array
 from .circuit import DeclareCircuit, DefineCircuit, EndDefine
@@ -34,16 +34,23 @@ def ParseVerilogModule(node):
     for port in node.portlist.ports:
         io = port.first
         args.append(io.name)
-        msb = int(io.width.msb.value)
-        lsb = int(io.width.lsb.value)
-        if   isinstance(io, Input):  dir = 'In'
-        elif isinstance(io, Output): dir = 'Out'
-        else: continue
-        if msb == 0 and lsb == 0:
+
+        if isinstance(io, Input):
+            dir = In
+        elif isinstance(io, Output):
+            dir = Out
+        else:
+            dir = InOot
+
+        if io.width is None:
             t = Bit
         else:
+            msb = int(io.width.msb.value)
+            lsb = int(io.width.lsb.value)
+
             t = Array(msb-lsb+1, Bit)
-        args.append( In(t) if dir == 'In' else Out(t) )
+
+        args.append(dir(t))
 
     return node.name, args
 

--- a/magma/tests.py
+++ b/magma/tests.py
@@ -12,3 +12,5 @@ def magma_check_files_equal(callee_file, file1, file2):
     file_path = os.path.dirname(callee_file)
     return filecmp.cmp(os.path.join(file_path, file1), 
                        os.path.join(file_path, file2), shallow=False)
+
+check_files_equal = magma_check_files_equal

--- a/tests/test_verilog/gold/test_rxmod.v
+++ b/tests/test_verilog/gold/test_rxmod.v
@@ -1,0 +1,53 @@
+module RXMOD(
+  input RX, 
+  input CLK,
+  output [7:0] data,
+  output valid);
+
+reg RX_1;
+reg RX_2;
+always @(posedge CLK) begin
+  RX_1 <= RX;
+  RX_2 <= RX_1;
+end
+
+wire RXi;
+assign RXi = RX_2;
+
+reg [8:0] dataReg;
+reg validReg = 0;
+assign data = dataReg[7:0];
+assign valid = validReg;
+
+reg [12:0] readClock = 0; // which subclock?
+reg [3:0] readBit = 0; // which bit? (0-8)
+reg reading = 0;
+
+
+always @ (posedge CLK)
+begin
+  if(RXi==0 && reading==0) begin
+    reading <= 1;
+    readClock <= 150; // sample to middle of second byte
+    readBit <= 0;
+    validReg <= 0;
+  end else if(reading==1 && readClock==0 && readBit==8) begin
+    // we're done
+    reading <= 0;
+    dataReg[8] <= RXi;
+    validReg <= 1;
+  end else if(reading==1 && readClock==0) begin
+    // read a byte
+    dataReg[readBit] <= RXi;
+    readClock <= 100;
+    readBit <= readBit + 1;
+    validReg <= 0;
+  end else if(reading==1 && readClock>0) begin
+    readClock <= readClock - 1;
+    validReg <= 0;
+  end else begin
+    validReg <= 0;
+  end
+end
+endmodule
+

--- a/tests/test_verilog/rxmod.v
+++ b/tests/test_verilog/rxmod.v
@@ -1,0 +1,52 @@
+module RXMOD(
+  input RX, 
+  input CLK,
+  output [7:0] data,
+  output valid);
+
+reg RX_1;
+reg RX_2;
+always @(posedge CLK) begin
+  RX_1 <= RX;
+  RX_2 <= RX_1;
+end
+
+wire RXi;
+assign RXi = RX_2;
+
+reg [8:0] dataReg;
+reg validReg = 0;
+assign data = dataReg[7:0];
+assign valid = validReg;
+
+reg [12:0] readClock = 0; // which subclock?
+reg [3:0] readBit = 0; // which bit? (0-8)
+reg reading = 0;
+
+
+always @ (posedge CLK)
+begin
+  if(RXi==0 && reading==0) begin
+    reading <= 1;
+    readClock <= 150; // sample to middle of second byte
+    readBit <= 0;
+    validReg <= 0;
+  end else if(reading==1 && readClock==0 && readBit==8) begin
+    // we're done
+    reading <= 0;
+    dataReg[8] <= RXi;
+    validReg <= 1;
+  end else if(reading==1 && readClock==0) begin
+    // read a byte
+    dataReg[readBit] <= RXi;
+    readClock <= 100;
+    readBit <= readBit + 1;
+    validReg <= 0;
+  end else if(reading==1 && readClock>0) begin
+    readClock <= readClock - 1;
+    validReg <= 0;
+  end else begin
+    validReg <= 0;
+  end
+end
+endmodule

--- a/tests/test_verilog/test_from_file.py
+++ b/tests/test_verilog/test_from_file.py
@@ -1,0 +1,27 @@
+import magma as m
+import magma.tests
+import os
+
+def check_port(definition, port, type, direction):
+    assert hasattr(definition, port)
+    port = getattr(definition, port)
+    assert isinstance(port, type)
+    if direction == "input":
+        assert port.isoutput()
+    elif direction == "output":
+        assert port.isinput()
+    else:
+        raise NotImplementedError(direction)
+
+def test():
+    file_path = os.path.dirname(__file__)
+    RXMOD = m.DefineFromVerilogFile(os.path.join(file_path, "rxmod.v"))[0]
+
+    check_port(RXMOD, "RX", m.BitType, "input")
+    check_port(RXMOD, "CLK", m.BitType, "input")
+    check_port(RXMOD, "data", m.ArrayType, "output")
+    check_port(RXMOD, "valid", m.BitType, "output")
+
+    m.compile("build/test_rxmod", RXMOD)
+    assert m.tests.check_files_equal(__file__, "build/test_rxmod.v",
+            "gold/test_rxmod.v")


### PR DESCRIPTION
@phanrahan can you explain why port.isinput()/isoutput() is flipped when querying the definition? My guess is that from the definition's perspective, an input to the module acts as an output (i.e. you can wire an input to an input of any instances). This is a slightly confusing for testing the module definition from verilog because we have to say:
```python
    if direction == "input":
        assert port.isoutput()
```