### PR TITLE
Updates for new clock types Reset and Enable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ ENV/
 # Rope project settings
 .ropeproject
 tests/build
+
+.DS_Store

--- a/magma/backend/verilog.py
+++ b/magma/backend/verilog.py
@@ -7,7 +7,7 @@ from ..port import INPUT, OUTPUT, INOUT, flip
 from ..ref import DefnRef
 from ..compatibility import IntegerTypes
 from ..bit import BitType, VCC, GND
-from ..clock import ClockType
+from ..clock import ClockType, EnableType, ResetType
 from ..array import ArrayKind, ArrayType
 from ..bits import SIntType
 from ..circuit import *
@@ -69,7 +69,7 @@ def vdecl(t):
         signed = "signed " if isinstance(t, SIntType) else ""
         return '{}[{}:{}]'.format(signed, t.N-1, 0)
     else:
-        assert isinstance(t, (BitType, ClockType))
+        assert isinstance(t, (BitType, ClockType, EnableType, ResetType))
         return ""
 
 # return the verilog module args

--- a/magma/bit.py
+++ b/magma/bit.py
@@ -5,7 +5,8 @@ from .t import Type, Kind, In, Out
 from .compatibility import IntegerTypes
 from .debug import debug_wire, get_callee_frame_info
 
-__all__  = ['BitType', 'BitKind']
+__all__  = ['_BitType', '_BitKind']
+__all__ += ['BitType', 'BitKind']
 __all__ += ['Bit', 'BitIn', 'BitOut', 'BitInOut']
 __all__ += ['VCC', 'GND', 'HIGH', 'LOW']
 

--- a/magma/braid.py
+++ b/magma/braid.py
@@ -112,15 +112,15 @@ def joinarg(arg, interfaces):
     return [arg, array(args)]
 
 # return [arg, array] from a list of interfaces
-def flatarg(arg, interfaces):
-    args = getarg(arg, interfaces)
-    #direction = getdirection(args)
-    #print('flatarg', args)
-    flatargs = []
-    for a in args:
-        for i in range(len(a)):
-            flatargs.append(a[i])
-    return [arg, array(flatargs)]
+#def flatarg(arg, interfaces):
+#    args = getarg(arg, interfaces)
+#    #direction = getdirection(args)
+#    #print('flatarg', args)
+#    flatargs = []
+#    for a in args:
+#        for i in range(len(a)):
+#            flatargs.append(a[i])
+#    return [arg, array(flatargs)]
 
 
 # all powerful braid functions
@@ -131,8 +131,6 @@ def flatarg(arg, interfaces):
 #   this argument is wired to all the circuits
 #  joinargs : list of argument names to join
 #   this argument is equal an array of all the arguments from circuits
-#  flatargs : list of argument names to flatten
-#   this argument is equal an array of all the flatted arguments from circuits
 #  foldargs : dict of argument namein:nameout, set namein[i+1] to namout[u]
 #  rfoldargs : dict of argument namein:nameout, set namein[i-1] to namout[u]
 #    namein[0] is retained in the result, 
@@ -150,7 +148,6 @@ def flatarg(arg, interfaces):
 def braid(circuits, 
             forkargs=[],
             joinargs=[],
-            flatargs=[],
             foldargs={}, rfoldargs={},
             scanargs={}, rscanargs={}):
 
@@ -163,7 +160,6 @@ def braid(circuits,
     for clkarg in interfaces[0].clockargnames():
         if clkarg in forkargs: continue
         if clkarg in joinargs: continue
-        if clkarg in flatargs: continue
         if clkarg in foldargs.keys(): continue
         if clkarg in rfoldargs.keys(): continue
         if clkarg in scanargs.keys(): continue
@@ -171,7 +167,7 @@ def braid(circuits,
         forkargs.append(clkarg)
 
     # do NOT join arguments if they appear in another keyword
-    nojoinargs = forkargs + flatargs
+    nojoinargs = list(forkargs)
     nojoinargs += flatten( [[k, v] for k, v in foldargs.items()] )
     nojoinargs += flatten( [[k, v] for k, v in rfoldargs.items()] )
     nojoinargs += flatten( [[k, v] for k, v in scanargs.items()] )
@@ -225,9 +221,9 @@ def braid(circuits,
             #print('joining', key)
             args += joinarg(key, interfaces)
 
-        elif key in flatargs:
-            #print('flattening', key)
-            args += flatarg(key, interfaces)
+        #elif key in flatargs:
+        #    #print('flattening', key)
+        #    args += flatarg(key, interfaces)
 
     #print(args)
     return AnonymousCircuit(args)

--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -2,7 +2,7 @@ from collections import Sequence, OrderedDict
 from .compatibility import IntegerTypes
 from .t import In, Out
 from .bit import BitKind, BitType, Bit, VCC, GND, BitIn, BitOut, BitInOut
-from .clock import ClockType, Clock, ClockIn, ClockOut, ClockInOut
+from .clock import ClockType, Clock, ClockIn, ClockOut, ResetType, EnableType
 from .array import ArrayType, Array
 from .bits import BitsType, Bits, UIntType, UInt, SIntType, SInt
 from .tuple import TupleType, Tuple
@@ -20,7 +20,7 @@ def bit(value):
     if isinstance(value, BitType):
         return value
 
-    if not isinstance(value, (ClockType, ArrayType, BitsType, UIntType, SIntType, IntegerTypes)):
+    if not isinstance(value, (ClockType, ResetType, EnableType, ArrayType, BitsType, UIntType, SIntType, IntegerTypes)):
         raise ValueError(
             "bit can only be used with a Clock, Array, Bits, UInt, SInt, or int, not : {}".format(type(value)))
 
@@ -31,10 +31,9 @@ def bit(value):
     if isinstance(value, IntegerTypes):
         return VCC if value else GND
 
-    if isinstance(value, ClockType):
+    if isinstance(value, (ClockType, ResetType, EnableType)):
         if   value.isinput():  b = BitIn()
         elif value.isoutput(): b = BitOut()
-        elif value.isinout():  b = BitInOut()
         else: b = Bit()
         b.port = value.port
         return b
@@ -57,10 +56,9 @@ def clock(value):
     if isinstance(value, IntegerTypes):
         return VCC if value else GND
 
-    if isinstance(value, BitType):
+    if isinstance(value, (BitType, EnableType, ResetType)):
         if   value.isinput():  c = ClockIn()
         elif value.isoutput(): c = ClockOut()
-        elif value.isinout():  c = ClockInOut()
         else: c = Clock()
         c.port = value.port
         return c
@@ -68,7 +66,7 @@ def clock(value):
     return value
 
 def convertbits(value, n, totype, checkbit):
-    if not isinstance(value, (BitType, ClockType, TupleType, ArrayType, BitsType, UIntType, SIntType, IntegerTypes, Sequence)):
+    if not isinstance(value, (BitType, ClockType, ResetType, EnableType, TupleType, ArrayType, BitsType, UIntType, SIntType, IntegerTypes, Sequence)):
         raise ValueError(
             "bits can only be used with a Bit, Clock, Tuple, Array, Bits, UInt, SInt, int, or Sequence, not : {}".format(type(value)))
 
@@ -81,7 +79,7 @@ def convertbits(value, n, totype, checkbit):
         ts = int2seq(value, n)
     elif isinstance(value, Sequence):
         ts =  list(value)
-    elif isinstance(value, (BitType, ClockType)):
+    elif isinstance(value, (BitType, ClockType, ResetType, EnableType)):
         if n is None:
             ts = [value]
         else:
@@ -144,7 +142,7 @@ def tuple_(value):
 
     if isinstance(value, IntegerTypes):
         value = int2seq(value, max(value.bit_length(),1) )
-    elif isinstance(value, (BitType, ClockType)):
+    elif isinstance(value, (BitType, ClockType, ResetType, EnableType)):
         value = [value]
     elif isinstance(value, ArrayType):
         value = [value[i] for i in range(len(value))]

--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -1,77 +1,73 @@
 from collections import Sequence, OrderedDict
 from .compatibility import IntegerTypes
 from .t import In, Out
-from .bit import BitKind, BitType, Bit, VCC, GND, BitIn, BitOut, BitInOut
-from .clock import ClockType, Clock, ClockIn, ClockOut, ResetType, EnableType
+from .bit import _BitKind, _BitType, Bit, BitKind, BitType, VCC, GND
+from .clock import ClockType, Clock, \
+    Reset, ResetType, \
+    Enable, EnableType
 from .array import ArrayType, Array
 from .bits import BitsType, Bits, UIntType, UInt, SIntType, SInt
 from .tuple import TupleType, Tuple
 from .bitutils import int2seq
 
 __all__  = ['bit']
-__all__ += ['clock']
+__all__ += ['clock', 'reset', 'enable']
 
 __all__ += ['array']
 __all__ += ['bits', 'uint', 'sint']
 
 __all__ += ['tuple_']
 
-def bit(value):
-    if isinstance(value, BitType):
+def convertbit(value, totype, T):
+    if isinstance(value, totype):
         return value
 
-    if not isinstance(value, (ClockType, ResetType, EnableType, ArrayType, BitsType, UIntType, SIntType, IntegerTypes)):
+    if not isinstance(value, (_BitType, ArrayType, TupleType, IntegerTypes)):
         raise ValueError(
-            "bit can only be used with a Clock, Array, Bits, UInt, SInt, or int, not : {}".format(type(value)))
+            "bit can only be used on a Bit, an Array, or an int; not {}".format(type(value)))
 
-    if isinstance(value, (ArrayType, BitsType, UIntType, SIntType)):
-        assert len(value) == 1
+    if isinstance(value, (ArrayType, TupleType)):
+        if len(value) != 1:
+            raise ValueError(
+            "bit can only be used on arrays and tuples of length 1; not {}".format(len(value)))
         value = value[0]
+        if not isinstance(value, _BitType):
+            raise ValueError(
+                "bit can only be used on arrays and tuples of bits; not {}".format(type(value)))
+
+    assert isinstance(value, (IntegerTypes, _BitType))
 
     if isinstance(value, IntegerTypes):
-        return VCC if value else GND
+        value = VCC if value else GND
 
-    if isinstance(value, (ClockType, ResetType, EnableType)):
-        if   value.isinput():  b = BitIn()
-        elif value.isoutput(): b = BitOut()
-        else: b = Bit()
-        b.port = value.port
-        return b
+    if   value.isinput():  b = In(T)()
+    elif value.isoutput(): b = Out(T)()
+    else: b = T()
+    b.port = value.port
+    return b
 
-    return value
 
+def bit(value):
+    return convertbit(value, BitType, Bit)
 
 def clock(value):
-    if isinstance(value, ClockType):
+    return convertbit(value, ClockType, Clock)
+
+def reset(value):
+    return convertbit(value, ResetType, Reset)
+
+def enable(value):
+    return convertbit(value, EnableType, Enable)
+
+
+
+def convertbits(value, n, totype, totypeconstructor, checkbit):
+    if isinstance(value, totype):
         return value
 
-    if not isinstance(value, (BitType, ArrayType, BitsType, UIntType, SIntType, IntegerTypes)):
+    if not isinstance(value, (_BitType, TupleType, ArrayType, IntegerTypes, Sequence)):
         raise ValueError(
-            "clock can only be used with a Bit, Array, Bits, UInt, SInt, or int, not : {}".format(type(value)))
-
-    if isinstance(value, (ArrayType, BitsType, UIntType, SIntType)):
-        assert len(value) == 1
-        value = value[0]
-
-    if isinstance(value, IntegerTypes):
-        return VCC if value else GND
-
-    if isinstance(value, (BitType, EnableType, ResetType)):
-        if   value.isinput():  c = ClockIn()
-        elif value.isoutput(): c = ClockOut()
-        else: c = Clock()
-        c.port = value.port
-        return c
-
-    return value
-
-def convertbits(value, n, totype, checkbit):
-    if not isinstance(value, (BitType, ClockType, ResetType, EnableType, TupleType, ArrayType, BitsType, UIntType, SIntType, IntegerTypes, Sequence)):
-        raise ValueError(
-            "bits can only be used with a Bit, Clock, Tuple, Array, Bits, UInt, SInt, int, or Sequence, not : {}".format(type(value)))
-
-    if not isinstance(value, (IntegerTypes, BitType, ClockType)):
-        assert n is None
+            "bits can only be used on a Bit, an Array, a Tuple, an int, or a Sequence; not : {}".format(type(value)))
 
     if isinstance(value, IntegerTypes):
         if n is None:
@@ -79,7 +75,7 @@ def convertbits(value, n, totype, checkbit):
         ts = int2seq(value, n)
     elif isinstance(value, Sequence):
         ts =  list(value)
-    elif isinstance(value, (BitType, ClockType, ResetType, EnableType)):
+    elif isinstance(value, _BitType):
         if n is None:
             ts = [value]
         else:
@@ -97,36 +93,34 @@ def convertbits(value, n, totype, checkbit):
 
     # check that they are all the same
     for t in Ts:
-       # make this test optional ...
+       # this should be converted to error()
        if checkbit:
-           assert isinstance(t, BitKind)
-       assert t == T
+            if not isinstance(t, _BitKind):
+                raise ValueError(
+                    "bits can only be used on Arrays or Tuples containing bits, not : {}".format(type(value)))
+       if t != T:
+            raise ValueError("All fields in a Array or a Tuple must be the same type")
 
-    return totype(len(Ts), T)(*ts)
+    assert len(Ts)
+
+    return totypeconstructor(len(Ts), T)(*ts)
 
 def array(value, n=None):
-    if isinstance(value, ArrayType):
-        return value
-    return convertbits(value, n, Array, False)
+    return convertbits(value, n, ArrayType, Array, False)
 
 def bits(value, n=None):
-    if isinstance(value, BitsType):
-        return value
-    return convertbits(value, n, Bits, True)
+    return convertbits(value, n, BitsType, Bits, True)
 
 def uint(value, n=None):
-    if isinstance(value, UIntType):
-        return value
     if isinstance(value, SIntType):
         raise ValueError( "uint cannot convert SInt" ) 
-    return convertbits(value, n, UInt, True)
+    return convertbits(value, n, UIntType, UInt, True)
 
 def sint(value, n=None):
-    if isinstance(value, SIntType):
-        return value
     if isinstance(value, UIntType):
         raise ValueError( "uint cannot convert SInt" ) 
-    return convertbits(value, n, SInt, True)
+    return convertbits(value, n, SIntType, SInt, True)
+
 
 #
 # convert value to a tuple

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -4,7 +4,7 @@ from .ref import AnonRef, InstRef, DefnRef
 from .t import Type, Kind, In, Out, Flip
 from .port import INPUT, OUTPUT, INOUT
 #from .bit import *
-from .clock import ClockType
+from .clock import ClockType, ResetType, EnableType
 from .array import ArrayType
 from .tuple import TupleType
 from .compatibility import IntegerTypes, StringTypes
@@ -97,7 +97,9 @@ class _Interface(Type):
         return [port for name, port in self.ports.items() \
                     if port.isinput() and \
                         not isinstance(port, ClockType) and \
-                            name not in ['RESET', 'SET', 'CE', 'CIN']]
+                            not isinstance(port, ResetType) and \
+                                not isinstance(port, EnableType) and \
+                                    name not in ['SET', 'CIN']]
 
     # return all the argument output ports
     def outputs(self):
@@ -121,7 +123,9 @@ class _Interface(Type):
         return flatten( [[name, port] for name, port in self.ports.items() \
                             if port.isinput() and \
                                 not isinstance(port, ClockType) and \
-                                    name not in ['RESET', 'SET', 'CE', 'CIN']] )
+                                    not isinstance(port, ResetType) and \
+                                        not isinstance(port, EnableType) and \
+                                    name not in ['SET', 'CIN']] )
 
     # return all the output arguments as name, port
     def outputargs(self):
@@ -132,13 +136,17 @@ class _Interface(Type):
     def clockargs(self):
         return flatten( [[name, port] for name, port in self.ports.items() \
                             if isinstance(port, ClockType) 
-                                or name in ['RESET', 'SET', 'CE'] ] )
+                                or isinstance(port, ResetType) 
+                                    or isinstance(port, EnableType) 
+                                        or name in ['SET'] ] )
 
     # return all the clock argument names
     def clockargnames(self):
         return [name for name, port in self.ports.items() \
                     if isinstance(port, ClockType) 
-                        or name in ['RESET', 'SET', 'CE'] ]
+                        or isinstance(port, ResetType) 
+                            or isinstance(port, EnableType) 
+                                or name in ['SET'] ]
 
 
     # return True if this interface has a Clock

--- a/magma/primitives.py
+++ b/magma/primitives.py
@@ -1,7 +1,7 @@
 from magma import cache_definition
 from magma.t import Type
 from magma.bit import Bit, BitType, In, Out
-from magma.clock import Clock
+from magma.clock import Clock, Reset, Enable
 from magma.bits import Bits, BitsType, SInt, SIntType, UInt, UIntType
 from magma.circuit import DeclareCircuit, circuit_type_method, DefineCircuit, EndDefine
 from magma.compatibility import IntegerTypes
@@ -567,7 +567,7 @@ def DefineRegister(N, has_ce=False, has_reset=False, T=Bits):
         return self
 
     if has_reset:
-        io.extend(["rst", In(Bit)])
+        io.extend(["rst", In(Reset)])
         name += "R"  # TODO: This assumes ordering of clock parameters
         methods.append(circuit_type_method("reset", reset))
 
@@ -576,7 +576,7 @@ def DefineRegister(N, has_ce=False, has_reset=False, T=Bits):
         return self
 
     if has_ce:
-        io.extend(["en", In(Bit)])
+        io.extend(["en", In(Enable)])
         name += "E"  # TODO: This assumes ordering of clock parameters
         methods.append(circuit_type_method("when", when))
 

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -1,7 +1,7 @@
 from collections import namedtuple, OrderedDict
 from .circuit import *
 from .bit import *
-from .clock import ClockType, wiredefaultclock
+from .clock import ClockType, EnableType, ResetType, wiredefaultclock
 from .array import *
 from .wire import wire
 from .conversions import array
@@ -39,7 +39,8 @@ class TransformedCircuit:
                 raise MagmaTransformException("Could not find bit in transform mapping. bit={}, scope={}".format(orig_bit, scope))
 
     def set_new_bit(self, orig_bit, orig_scope, new_bit):
-        assert isinstance(new_bit, (BitType, ClockType)) or isinstance(new_bit, ArrayType)
+        assert isinstance(new_bit,
+                (BitType, ArrayType, ClockType, EnableType, ResetType))
 
         if isinstance(orig_bit, ArrayType):
             # Map the individual bits

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,7 +1,8 @@
 import operator
 from functools import reduce
 import magma as m
-from magma import In, Out, Bit, Clock, UInt, SInt, Circuit, Bits, uint, wire, compile
+from magma import In, Out, Bit, Clock, UInt, SInt, Circuit, Bits, uint, wire, \
+    compile, Enable, Reset
 from magma.primitives import DefineRegister, DefineMux, DefineMemory
 
 from magma.primitives import DefineAnd, And, and_
@@ -176,7 +177,7 @@ def test_register_ce():
     Register4 = DefineRegister(N, has_ce=True, T=UInt)
     class TestCircuit(Circuit):
         name = "test_register_ce"
-        IO = ["CLK", In(m.Clock), "enable", In(Bit), "out", Out(UInt(N))]
+        IO = ["CLK", In(m.Clock), "enable", In(Enable), "out", Out(UInt(N))]
         @classmethod
         def definition(circuit):
             reg = Register4().when(circuit.enable)
@@ -209,7 +210,7 @@ def test_register_reset():
     Register4 = DefineRegister(N, has_reset=True, T=UInt)
     class TestCircuit(Circuit):
         name = "test_register_reset"
-        IO = ["CLK", In(m.Clock), "reset", In(Bit), "out", Out(UInt(N))]
+        IO = ["CLK", In(m.Clock), "reset", In(Reset), "out", Out(UInt(N))]
         @classmethod
         def definition(circuit):
             reg = Register4().reset(circuit.reset)

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -1,4 +1,7 @@
-from magma import Clock, ClockType, ClockKind, In, Out, Flip
+from magma import In, Out, Flip, \
+    Clock, ClockType, ClockKind, \
+    Reset, ResetType, ResetKind, \
+    Enable, EnableType, EnableKind
 
 def test_clock():
     assert isinstance(Clock, ClockKind)
@@ -36,4 +39,78 @@ def test_clock_val():
     assert isinstance(b, Clock)
     assert not b.isinput()
     assert not b.isoutput()
+
+def test_reset():
+    assert isinstance(Reset, ResetKind)
+    assert Reset == Reset
+    assert str(Reset) == 'Reset'
+
+def test_reset_flip():
+    ResetOut = Out(Reset)
+    assert isinstance(ResetOut, ResetKind)
+    assert str(ResetOut) == 'Out(Reset)'
+
+    ResetIn = In(Reset)
+    assert isinstance(ResetIn, ResetKind)
+    assert str(ResetIn) == 'In(Reset)'
+
+    resetin = In(ResetIn)
+    resetout = Out(ResetIn)
+    assert resetout == ResetOut
+    assert resetin == ResetIn
+
+    resetin = In(ResetOut)
+    resetout = Out(ResetOut)
+    assert resetout == ResetOut
+    assert resetin == ResetIn
+
+    resetin = Flip(ResetOut)
+    resetout = Flip(ResetIn)
+    assert resetout == ResetOut
+    assert resetin == ResetIn
+
+def test_reset_val():
+    b = Reset(name="a")
+    assert str(b) == "a"
+    assert isinstance(b, ResetType)
+    assert isinstance(b, Reset)
+    assert not b.isinput()
+    assert not b.isoutput()
     assert not b.isinout()
+
+def test_enable():
+    assert isinstance(Enable, EnableKind)
+    assert Enable == Enable
+    assert str(Enable) == 'Enable'
+
+def test_enable_flip():
+    EnableOut = Out(Enable)
+    assert isinstance(EnableOut, EnableKind)
+    assert str(EnableOut) == 'Out(Enable)'
+
+    EnableIn = In(Enable)
+    assert isinstance(EnableIn, EnableKind)
+    assert str(EnableIn) == 'In(Enable)'
+
+    enablein = In(EnableIn)
+    enableout = Out(EnableIn)
+    assert enableout == EnableOut
+    assert enablein == EnableIn
+
+    enablein = In(EnableOut)
+    enableout = Out(EnableOut)
+    assert enableout == EnableOut
+    assert enablein == EnableIn
+
+    enablein = Flip(EnableOut)
+    enableout = Flip(EnableIn)
+    assert enableout == EnableOut
+    assert enablein == EnableIn
+
+def test_enable_val():
+    b = Enable(name="a")
+    assert str(b) == "a"
+    assert isinstance(b, EnableType)
+    assert isinstance(b, Enable)
+    assert not b.isinput()
+    assert not b.isoutput()

--- a/tests/test_type/test_conversions.py
+++ b/tests/test_type/test_conversions.py
@@ -1,7 +1,11 @@
 import pytest
 from collections import OrderedDict
 from magma import \
-    bit, BitType, GND, VCC, \
+    GND, VCC, \
+    bit, BitType, \
+    clock, ClockType, \
+    reset, ResetType, \
+    enable, EnableType, \
     array, ArrayType, \
     bits, BitsType, \
     uint, UIntType, \
@@ -13,9 +17,52 @@ def test_bit():
     assert isinstance(bit(1), BitType)
     assert isinstance(bit(VCC), BitType)
     assert isinstance(bit(GND), BitType)
+    assert isinstance(bit(bit(0)), BitType)
+    assert isinstance(bit(clock(0)), BitType)
+    assert isinstance(bit(reset(0)), BitType)
+    assert isinstance(bit(enable(0)), BitType)
     assert isinstance(bit(bits(0,1)), BitType)
     assert isinstance(bit(uint(0,1)), BitType)
     assert isinstance(bit(sint(0,1)), BitType)
+
+def test_enable():
+    assert isinstance(enable(0), EnableType)
+    assert isinstance(enable(1), EnableType)
+    assert isinstance(enable(VCC), EnableType)
+    assert isinstance(enable(GND), EnableType)
+    assert isinstance(enable(bit(0)), EnableType)
+    assert isinstance(enable(clock(0)), EnableType)
+    assert isinstance(enable(reset(0)), EnableType)
+    assert isinstance(enable(enable(0)), EnableType)
+    assert isinstance(enable(bits(0,1)), EnableType)
+    assert isinstance(enable(uint(0,1)), EnableType)
+    assert isinstance(enable(sint(0,1)), EnableType)
+
+def test_reset():
+    assert isinstance(reset(0), ResetType)
+    assert isinstance(reset(1), ResetType)
+    assert isinstance(reset(VCC), ResetType)
+    assert isinstance(reset(GND), ResetType)
+    assert isinstance(reset(bit(0)), ResetType)
+    assert isinstance(reset(clock(0)), ResetType)
+    assert isinstance(reset(enable(0)), ResetType)
+    assert isinstance(reset(reset(0)), ResetType)
+    assert isinstance(reset(bits(0,1)), ResetType)
+    assert isinstance(reset(uint(0,1)), ResetType)
+    assert isinstance(reset(sint(0,1)), ResetType)
+
+def test_clock():
+    assert isinstance(clock(0), ClockType)
+    assert isinstance(clock(1), ClockType)
+    assert isinstance(clock(VCC), ClockType)
+    assert isinstance(clock(GND), ClockType)
+    assert isinstance(clock(bit(0)), ClockType)
+    assert isinstance(clock(clock(0)), ClockType)
+    assert isinstance(clock(reset(0)), ClockType)
+    assert isinstance(clock(enable(0)), ClockType)
+    assert isinstance(clock(bits(0,1)), ClockType)
+    assert isinstance(clock(uint(0,1)), ClockType)
+    assert isinstance(clock(sint(0,1)), ClockType)
 
 def test_array():
      assert isinstance(array(1,4), ArrayType)


### PR DESCRIPTION
I added new clock types Reset and Enable to clock.py.

@leonardt could you check primitives.py and coreir.py. We should update these modules to use the new types.

Going forward, let's go with reset and enable. We can add set and clear latter.