### PR TITLE
Initial implementation of CircuitGenerator

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -499,15 +499,25 @@ GeneratorArguments = namedtuple('GeneratorArguments', ['args', 'kwargs'])
 class CircuitGenerator(object):
     @lru_cache(maxsize=None)
     def __new__(type_, *args, **kwargs):
+        # Create an instance of the generator
         inst = object.__new__(type_)
+
+        # Build a list of stringified parameters of the form "param=value"
         params = list(signature(inst.generate).parameters.keys())
         cached_args = []
         for value, param in zip(args, params):
             cached_args.append("{}={}".format(param, value))
         for key in sorted(kwargs):
             cached_args.append("{}={}".format(key, kwargs[key]))
-        inst.cached_name = "{}({})".format(inst.name, ", ".join(cached_args))
+
+        # Cached name is base_name + stringified parameters joined by commas
+        inst.cached_name = "{}({})".format(inst.base_name,
+                                           ", ".join(cached_args))
+
+        # Generate the defintion
         definition = inst.generate(*args, **kwargs)
+
+        # Store generator arguments and reference to original generator
         definition._generator_arguments = GeneratorArguments(args, kwargs)
         definition._generator = type_
         return definition

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -508,5 +508,6 @@ class CircuitGenerator:
             cached_args.append("{}={}".format(key, value))
         inst.cached_name = "{}({})".format(inst.name, ", ".join(cached_args))
         definition = inst.generate(*args, **kwargs)
-        definition.__generator_arguments = GeneratorArguments(args, kwargs)
+        definition._generator_arguments = GeneratorArguments(args, kwargs)
+        definition._generator = type_
         return definition

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -493,6 +493,9 @@ def hstr(init, nbits):
     return format
 
 
+GeneratorArguments = namedtuple('GeneratorArguments', ['args', 'kwargs'])
+
+
 class CircuitGenerator:
     @lru_cache(maxsize=None)
     def __new__(type_, *args, **kwargs):
@@ -505,4 +508,5 @@ class CircuitGenerator:
             cached_args.append("{}={}".format(key, value))
         inst.cached_name = "{}({})".format(inst.name, ", ".join(cached_args))
         definition = inst.generate(*args, **kwargs)
+        definition.__generator_arguments = GeneratorArguments(args, kwargs)
         return definition

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -496,7 +496,7 @@ def hstr(init, nbits):
 GeneratorArguments = namedtuple('GeneratorArguments', ['args', 'kwargs'])
 
 
-class CircuitGenerator:
+class CircuitGenerator(object):
     @lru_cache(maxsize=None)
     def __new__(type_, *args, **kwargs):
         inst = object.__new__(type_)

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -504,8 +504,8 @@ class CircuitGenerator:
         cached_args = []
         for value, param in zip(args, params):
             cached_args.append("{}={}".format(param, value))
-        for key, value in kwargs.items():
-            cached_args.append("{}={}".format(key, value))
+        for key in sorted(kwargs):
+            cached_args.append("{}={}".format(key, kwargs[key]))
         inst.cached_name = "{}({})".format(inst.name, ", ".join(cached_args))
         definition = inst.generate(*args, **kwargs)
         definition._generator_arguments = GeneratorArguments(args, kwargs)

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -497,14 +497,12 @@ class CircuitGenerator:
     @lru_cache(maxsize=None)
     def __new__(type_, *args, **kwargs):
         inst = object.__new__(type_)
-        definition = inst.generate(*args, **kwargs)
-        return definition
-
-    def cached_name(self, *args, **kwargs):
-        params = list(signature(self.generate).parameters.keys())
+        params = list(signature(inst.generate).parameters.keys())
         cached_args = []
         for value, param in zip(args, params):
             cached_args.append("{}={}".format(param, value))
-        if kwargs:
-            raise NotImplementedError()
-        return "{}({})".format(self.name, ", ".join(cached_args))
+        for key, value in kwargs.items():
+            cached_args.append("{}={}".format(key, value))
+        inst.cached_name = "{}({})".format(inst.name, ", ".join(cached_args))
+        definition = inst.generate(*args, **kwargs)
+        return definition

--- a/tests/test_circuit/gold/test_add8cin.json
+++ b/tests/test_circuit/gold/test_add8cin.json
@@ -1,0 +1,28 @@
+{"top":"global.Add(n=8, cin=True, cout=False)",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Add(n=8, cin=True, cout=False)":{
+        "type":["Record",{
+          "I0":["Array",8,"BitIn"],
+          "I1":["Array",8,"BitIn"],
+          "CIN":"BitIn",
+          "O":["Array",8,"Bit"]
+        }],
+        "instances":{
+          "inst0":{
+            "genref":"coreir.add",
+            "genargs":{"has_cin":true, "has_cout":false, "width":8}
+          }
+        },
+        "connections":[
+          ["self.O","inst0.out"],
+          ["self.I1","inst0.in1"],
+          ["self.I0","inst0.in0"],
+          ["self.CIN","inst0.cin"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_circuit/test_circuit_generator.py
+++ b/tests/test_circuit/test_circuit_generator.py
@@ -3,7 +3,7 @@ from magma.testing import check_files_equal
 
 
 class DefineCoreirAdd(CircuitGenerator):
-    name = "coreir_add"
+    base_name = "coreir_add"
     def generate(self, N, has_cout=False, has_cin=False):
         T = Bits(N)
         IO = ['in0', In(T), 'in1', In(T), 'out', Out(T)]
@@ -23,7 +23,7 @@ class DefineCoreirAdd(CircuitGenerator):
 
 
 class DefineAdd(CircuitGenerator):
-    name = "Add"
+    base_name = "Add"
     def generate(self, n, cin=False, cout=False):
         width = n
         T = Bits(width)

--- a/tests/test_circuit/test_circuit_generator.py
+++ b/tests/test_circuit/test_circuit_generator.py
@@ -1,0 +1,54 @@
+from magma import *
+from magma.testing import check_files_equal
+
+
+@cache_definition
+def DefineCoreirAdd(N, has_cout=False, has_cin=False):
+    T = Bits(N)
+    IO = ['in0', In(T), 'in1', In(T), 'out', Out(T)]
+    gen_args = {"width": N}
+    if has_cout:
+        IO += ['cout', Out(Bit)]
+        gen_args['has_cout'] = True
+    if has_cin:
+        IO += ['cin', In(Bit)]
+        gen_args['has_cin'] = True
+    name = "add"
+    return DeclareCircuit("coreir_{}{}".format(name, N), *IO,
+                      stateful=False,
+                      verilog_name="coreir_" + name,
+                      coreir_name=name,
+                      coreir_lib = "coreir",
+                      coreir_genargs=gen_args)
+
+
+class DefineAdd(CircuitGenerator):
+    name = "Add"
+    def generate(self, n, cin=False, cout=False):
+        width = n
+        T = Bits(width)
+        IO = ["I0", In(T), "I1", In(T)]
+        if cin:
+            IO += ["CIN", In(Bit)]
+        IO += ["O", Out(T)]
+        if cout:
+            IO += ["COUT", Out(Bit)]
+
+        circ = DefineCircuit(self.cached_name(n, cin, cout), *IO)
+
+        add = DefineCoreirAdd(width, has_cout=cout, has_cin=cin)()
+        wire(circ.I0, add.in0)
+        wire(circ.I1, add.in1)
+        wire(circ.O, add.out)
+        if cout:
+            wire(circ.COUT, add.cout)
+        if cin:
+            wire(circ.CIN, add.cin)
+        EndDefine()
+        return circ
+
+def test_add_generator():
+    compile("build/test_add8cin", DefineAdd(8, cin=True, cout=False),
+            output="coreir")
+    assert check_files_equal(__file__,
+            "build/test_add8cin.json", "gold/test_add8cin.json")

--- a/tests/test_circuit/test_circuit_generator.py
+++ b/tests/test_circuit/test_circuit_generator.py
@@ -48,7 +48,10 @@ class DefineAdd(CircuitGenerator):
         return circ
 
 def test_add_generator():
-    compile("build/test_add8cin", DefineAdd(8, cin=True, cout=False),
-            output="coreir")
+    Add8cin = DefineAdd(8, cin=True, cout=False)
+    assert Add8cin._generator_arguments.args == (8,)
+    assert Add8cin._generator_arguments.kwargs == {"cin": True, "cout": False}
+    assert Add8cin._generator == DefineAdd
+    compile("build/test_add8cin", Add8cin, output="coreir")
     assert check_files_equal(__file__,
             "build/test_add8cin.json", "gold/test_add8cin.json")

--- a/tests/test_circuit/test_circuit_generator.py
+++ b/tests/test_circuit/test_circuit_generator.py
@@ -2,24 +2,24 @@ from magma import *
 from magma.testing import check_files_equal
 
 
-@cache_definition
-def DefineCoreirAdd(N, has_cout=False, has_cin=False):
-    T = Bits(N)
-    IO = ['in0', In(T), 'in1', In(T), 'out', Out(T)]
-    gen_args = {"width": N}
-    if has_cout:
-        IO += ['cout', Out(Bit)]
-        gen_args['has_cout'] = True
-    if has_cin:
-        IO += ['cin', In(Bit)]
-        gen_args['has_cin'] = True
-    name = "add"
-    return DeclareCircuit("coreir_{}{}".format(name, N), *IO,
-                      stateful=False,
-                      verilog_name="coreir_" + name,
-                      coreir_name=name,
-                      coreir_lib = "coreir",
-                      coreir_genargs=gen_args)
+class DefineCoreirAdd(CircuitGenerator):
+    name = "coreir_add"
+    def generate(self, N, has_cout=False, has_cin=False):
+        T = Bits(N)
+        IO = ['in0', In(T), 'in1', In(T), 'out', Out(T)]
+        gen_args = {"width": N}
+        if has_cout:
+            IO += ['cout', Out(Bit)]
+            gen_args['has_cout'] = True
+        if has_cin:
+            IO += ['cin', In(Bit)]
+            gen_args['has_cin'] = True
+        return DeclareCircuit(self.cached_name, *IO,
+                          stateful=False,
+                          verilog_name="coreir_add",
+                          coreir_name="add",
+                          coreir_lib = "coreir",
+                          coreir_genargs=gen_args)
 
 
 class DefineAdd(CircuitGenerator):
@@ -34,7 +34,7 @@ class DefineAdd(CircuitGenerator):
         if cout:
             IO += ["COUT", Out(Bit)]
 
-        circ = DefineCircuit(self.cached_name(n, cin, cout), *IO)
+        circ = DefineCircuit(self.cached_name, *IO)
 
         add = DefineCoreirAdd(width, has_cout=cout, has_cin=cin)()
         wire(circ.I0, add.in0)


### PR DESCRIPTION
Here's a first crack at a notion of a CircuitGenerator.
See `tests/test_circuit/test_circuit_generator.py` for example usage.

The basic pattern is to define a subclass of `CircuitGenerator` with:
* a class field `name` that is the prefix of the generated circuit's name.
* a method `definition` that creates a circuit definition. This definition can use `self.cached_name` to get a unique version of `name` based on the current arguments to the `definition` method.

For the example:
```python
class DefineAdd(CircuitGenerator):
    name = "Add"
    def generate(self, n, cin=False, cout=False):
        ...
```

`self.cached_name == "Add(n=8, cin=True, cout=False)"`

Thoughts?