### PR TITLE
Circuit generators

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,11 +3,5 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def magma_test():
-    """
-    Clear the circuit cache before running, allows name reuse across tests
-    without collisions
-    """
-    import magma.circuit
-    magma.circuit.__magma_clear_circuit_cache()
     import magma.config
     magma.config.set_compile_dir('callee_file_dir')

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -14,7 +14,7 @@ except ImportError:
     from backports.functools_lru_cache import lru_cache
 import operator
 from collections import namedtuple
-from .interface import InterfaceKind, DeclareInterface
+from .interface import *
 from .wire import *
 from .t import Flip
 from .array import ArrayType
@@ -359,8 +359,13 @@ class DefineCircuitKind(CircuitKind):
     def __new__(metacls, name, bases, dct):
 
         if 'name' not in dct:
+            # Check if we are a subclass of something other than Circuit
             for base in bases:
-                if base.__name__ is not "Circuit":
+                if base is not Circuit:
+                    if not issubclass(base, Circuit):
+                        raise Exception("Must subclass from Circuit or a "
+                                "subclass of Circuit. {}".format(base))
+                    # If so, we will inherit the name of the first parent
                     dct['name'] = base.name
                     break
             else:

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -179,7 +179,7 @@ class AnonymousCircuitType(object):
 
     # wire a list of outputs to the circuit's inputs
     def wireoutputs(self, outputs, debug_info):
-        nputs = self.interface.inputs()
+        inputs = self.interface.inputs()
         ni = len(inputs)
         no = len(outputs)
         if ni != no:

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -4,10 +4,6 @@ import inspect
 from functools import wraps
 if sys.version_info > (3, 0):
     from functools import reduce
-if sys.version_info < (3, 3):
-    from funcsigs import signature
-else:
-    from inspect import signature
 try:
     from functools import lru_cache
 except ImportError:

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -179,7 +179,7 @@ class AnonymousCircuitType(object):
 
     # wire a list of outputs to the circuit's inputs
     def wireoutputs(self, outputs, debug_info):
-        inputs = self.interface.inputs()
+        nputs = self.interface.inputs()
         ni = len(inputs)
         no = len(outputs)
         if ni != no:

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -1,11 +1,20 @@
 import sys
 import six
 import inspect
+from functools import wraps
 if sys.version_info > (3, 0):
     from functools import reduce
+if sys.version_info < (3, 3):
+    from funcsigs import signature
+else:
+    from inspect import signature
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 import operator
 from collections import namedtuple
-from .interface import *
+from .interface import InterfaceKind, DeclareInterface
 from .wire import *
 from .t import Flip
 from .array import ArrayType
@@ -26,6 +35,8 @@ __all__ += ['DefineCircuit', 'EndDefine', 'EndCircuit']
 __all__ += ['isdefinition']
 __all__ += ['isprimitive']
 __all__ += ['CopyInstance']
+__all__ += ['circuit_type_method']
+__all__ += ['circuit_generator']
 
 
 circuit_type_method = namedtuple('circuit_type_method', ['name', 'definition'])
@@ -49,7 +60,7 @@ class CircuitKind(type):
 
         # override circuit class name
         if 'name' not in dct:
-             dct['name'] = name
+            dct['name'] = name
         name = dct['name']
 
         if 'primitive' not in dct:
@@ -62,7 +73,7 @@ class CircuitKind(type):
             setattr(cls, method.name, method.definition)
 
         # create interface for this circuit class
-        if hasattr(cls, 'IO'):
+        if hasattr(cls, 'IO') and not isinstance(cls.IO, InterfaceKind):
             # turn IO attribite into an Interface
             cls.IO = DeclareInterface(*cls.IO)
 
@@ -343,30 +354,20 @@ def isdefinition(circuit):
 def isprimitive(circuit):
     return circuit.primitive
 
-Cache = {}
-
-def __magma_clear_circuit_cache():
-    """
-    Used in testing to clear Cache to prevent name conflicts from different
-    tests
-    """
-    Cache.clear()
 
 class DefineCircuitKind(CircuitKind):
     def __new__(metacls, name, bases, dct):
 
-        # override name if present in dict
         if 'name' not in dct:
-             dct['name'] = name
+            for base in bases:
+                if base.__name__ is not "Circuit":
+                    dct['name'] = base.name
+                    break
+            else:
+                dct['name'] = name
         name = dct['name']
 
-        # circuit definition are cached
-        if name in Cache:
-            #warn('Warning: Circuit {} already defined'.format(name))
-            return Cache[name]
-
         self = CircuitKind.__new__(metacls, name, bases, dct)
-        Cache[name] = self
 
         self.verilog = None
         self.verilogFile = None
@@ -484,3 +485,14 @@ def hstr(init, nbits):
     return format
 
 
+GeneratorArguments = namedtuple('GeneratorArguments', ['args', 'kwargs'])
+
+
+def circuit_generator(func):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        result = func(*args, **kwargs)
+        # Store arguments to generate the circuit
+        result._generator_arguments = GeneratorArguments(args, kwargs)
+        return result
+    return wrapped

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -490,6 +490,7 @@ GeneratorArguments = namedtuple('GeneratorArguments', ['args', 'kwargs'])
 
 
 def circuit_generator(func):
+    @lru_cache(maxsize=None)
     @wraps(func)
     def wrapped(*args, **kwargs):
         result = func(*args, **kwargs)

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -1,8 +1,11 @@
 import os
 import inspect
 
+from .passes import DefinitionPass
 from .backend import verilog, blif, firrtl, dot
 from .config import get_compile_dir
+from .logging import error
+from .circuit import isdefinition
 
 __all__ = ['compile']
 
@@ -12,7 +15,47 @@ def write_file(file_name, extension, code):
         file.write(code)
 
 
+class MultipleDefinitionException(Exception):
+    pass
+
+
+class CheckDefinitionUniquenessPass(DefinitionPass):
+    def __init__(self, main):
+        super(CheckDefinitionUniquenessPass, self).__init__(main)
+        self.seen = {}
+
+    def __call__(self, definition):
+        if definition.name not in self.seen:
+            self.seen[definition.name] = []
+        self.seen[definition.name].append(definition)
+
+    def _run(self, definition):
+        for instance in definition.instances:
+            instancedefinition = type(instance)
+            if isdefinition(instancedefinition):
+                self._run( instancedefinition )
+
+        self(definition)
+
+    def run(self):
+        super(CheckDefinitionUniquenessPass, self).run()
+        duplicated = []
+        print(self.seen)
+        for name, definitions in self.seen.items():
+            if len(definitions) > 1:
+                duplicated.append((name, definitions))
+                error("Found multiple definitions for {}".format(name))
+
+        if len(duplicated):
+            raise MultipleDefinitionException()
+
+
+def check_definitions_are_unique(circuit):
+    CheckDefinitionUniquenessPass(circuit).run()
+
+
 def compile(basename, main, output='verilog', origin=None, include_coreir=False):
+    check_definitions_are_unique(main)
     if get_compile_dir() == 'callee_file_dir':
         (_, filename, _, _, _, _) = inspect.getouterframes(inspect.currentframe())[1]
         file_path = os.path.dirname(filename)

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -26,8 +26,8 @@ class CheckDefinitionUniquenessPass(DefinitionPass):
 
     def __call__(self, definition):
         if definition.name not in self.seen:
-            self.seen[definition.name] = []
-        self.seen[definition.name].append(definition)
+            self.seen[definition.name] = set()
+        self.seen[definition.name].add(definition)
 
     def _run(self, definition):
         for instance in definition.instances:

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -11,13 +11,14 @@ from .compatibility import IntegerTypes, StringTypes
 
 __all__  = ['DeclareInterface']
 __all__ += ['Interface']
+__all__ += ['InterfaceKind']
 
 # flatten a list of lists
 def flatten(l):
     return sum(l, [])
 
 #
-# parse argument declaration of the form 
+# parse argument declaration of the form
 #
 #  (name0, type0, name1, type1, ..., namen, typen)
 #
@@ -79,7 +80,7 @@ class _Interface(Type):
 
     def __len__(self):
         return len(self.ports.keys())
-                
+
     def __getitem__(self, key):
         if isinstance(key,slice):
             return array([self[i] for i in range(*key.indices(len(self)))])
@@ -107,7 +108,7 @@ class _Interface(Type):
     def args(self):
         return flatten( [[name, port] for name, port in self.ports.items()] )
 
-    # return all the arguments as name, flip(port) 
+    # return all the arguments as name, flip(port)
     #   same as the declaration
     def decl(self):
         return flatten( [[name, type(port).flip()] \
@@ -135,7 +136,7 @@ class _Interface(Type):
     # return all the clock argument names
     def clockargnames(self):
         return [name for name, port in self.ports.items() \
-                    if isinstance(port, ClockTypes) ] 
+                    if isinstance(port, ClockTypes) ]
 #                                or name in ['SET'] ]
 
 

--- a/tests/test_circuit/gold/test_add8cin.json
+++ b/tests/test_circuit/gold/test_add8cin.json
@@ -1,0 +1,47 @@
+{"top":"global.test",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Add8_cin":{
+        "type":["Record",{
+          "I0":["Array",8,"BitIn"],
+          "I1":["Array",8,"BitIn"],
+          "O":["Array",8,"Bit"],
+          "CIN":"BitIn"
+        }],
+        "instances":{
+          "inst0":{
+            "genref":"coreir.add",
+            "genargs":{"has_cin":true, "has_cout":false, "width":8}
+          }
+        },
+        "connections":[
+          ["self.O","inst0.out"],
+          ["self.I1","inst0.in1"],
+          ["self.I0","inst0.in0"],
+          ["self.CIN","inst0.cin"]
+        ]
+      },
+      "test":{
+        "type":["Record",{
+          "I0":["Array",8,"BitIn"],
+          "I1":["Array",8,"BitIn"],
+          "CIN":"BitIn",
+          "O":["Array",8,"Bit"]
+        }],
+        "instances":{
+          "inst0":{
+            "modref":"global.Add8_cin"
+          }
+        },
+        "connections":[
+          ["self.O","inst0.O"],
+          ["self.I1","inst0.I1"],
+          ["self.I0","inst0.I0"],
+          ["self.CIN","inst0.CIN"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_circuit/test_circuit_generator.py
+++ b/tests/test_circuit/test_circuit_generator.py
@@ -1,0 +1,67 @@
+from magma import *
+from magma.testing import check_files_equal
+from collections import namedtuple
+
+
+@circuit_generator
+def DefineAdd(N, has_cout=False, has_cin=False):
+    T = Bits(N)
+    IO_ = ['I0', In(T), 'I1', In(T), 'O', Out(T)]
+    name_ = "Add{}".format(N)
+    if has_cout:
+        IO_ += ['COUT', Out(Bit)]
+        name_ += "_cout"
+    if has_cin:
+        IO_ += ['CIN', In(Bit)]
+        name_ += "_cin"
+    class Add(Circuit):
+        # Underscores because there's some weird scoping issue here with Python
+        # when trying to capture name and IO
+        name = name_
+        IO = IO_
+    return Add
+
+# Mock importing DefineAdd from external module using a namedtuple
+primitives = namedtuple('primitives', ['DefineAdd'])(DefineAdd)
+
+
+@circuit_generator
+def DefineAdd(N, has_cout=False, has_cin=False):
+    class Add(primitives.DefineAdd(N, has_cout, has_cin)):
+        @classmethod
+        def definition(add):
+            T = Bits(N)
+            coreir_io = ['in0', In(T), 'in1', In(T), 'out', Out(T)]
+            coreir_genargs = {"width": N, "has_cout": has_cout, "has_cin": has_cin}
+            if has_cout:
+                coreir_io += ['cout', Out(Bit)]
+            if has_cin:
+                coreir_io += ['cin', In(Bit)]
+            CoreirAdd = DeclareCircuit("coreir_" + add.name, *coreir_io,
+                    coreir_name="add", coreir_lib="coreir",
+                    coreir_genargs=coreir_genargs)
+            coreir_add = CoreirAdd()
+            wire(add.I0, coreir_add.in0)
+            wire(add.I1, coreir_add.in1)
+            wire(coreir_add.out, add.O)
+            if has_cout:
+                wire(coreir_add.cout, add.COUT)
+            if has_cin:
+                wire(coreir_add.cin, add.CIN)
+    return Add
+
+
+def test_add_generator():
+    Add8cin = DefineAdd(8, has_cin=True, has_cout=False)
+    assert Add8cin._generator_arguments.args == (8,)
+    assert Add8cin._generator_arguments.kwargs == {"has_cin": True, "has_cout": False}
+    test_circuit = DefineCircuit("test", "I0", In(Bits(8)), "I1", In(Bits(8)),
+            "CIN", In(Bit), "O", Out(Bits(8)))
+    adder = Add8cin()
+    wire(test_circuit, adder)
+    wire(test_circuit.O, adder.O)
+    EndDefine()
+    print(repr(test_circuit))
+    compile("build/test_add8cin", test_circuit, output="coreir")
+    assert check_files_equal(__file__,
+            "build/test_add8cin.json", "gold/test_add8cin.json")

--- a/tests/test_compile_errors.py
+++ b/tests/test_compile_errors.py
@@ -1,0 +1,56 @@
+from magma import *
+from magma.compile import MultipleDefinitionException
+
+
+def test_multiple_definitions():
+    class Circ1(Circuit):
+        name = "same"
+        IO = ['I', In(Bit), 'O', Out(Bit)]
+
+        @classmethod
+        def definition(io):
+            wire(io.I, io.O)
+
+    class Circ2(Circuit):
+        name = "same"
+        IO = ['I', In(Bit), 'O', Out(Bit)]
+
+        @classmethod
+        def definition(io):
+            wire(io.I, io.O)
+
+    test = DefineCircuit('test', 'I', In(Bit), 'O1', Out(Bit), 'O2', Out(Bit))
+    circ1 = Circ1()
+    wire(test.I, circ1.I)
+    wire(test.O1, circ1.O)
+    circ2 = Circ2()
+    wire(test.I, circ2.I)
+    wire(test.O2, circ2.O)
+    EndDefine()
+    try:
+        compile('shouldnotmatter', test)
+        assert False, "Should throw MultipleDefinitionException"
+    except MultipleDefinitionException:
+        pass
+
+
+def test_same_definitions():
+    class Circ1(Circuit):
+        name = "same"
+        IO = ['I', In(Bit), 'O', Out(Bit)]
+
+        @classmethod
+        def definition(io):
+            wire(io.I, io.O)
+    test = DefineCircuit('test', 'I', In(Bit), 'O1', Out(Bit), 'O2', Out(Bit))
+    circ1 = Circ1()
+    wire(test.I, circ1.I)
+    wire(test.O1, circ1.O)
+    circ2 = Circ1()
+    wire(test.I, circ2.I)
+    wire(test.O2, circ2.O)
+    EndDefine()
+    try:
+        compile("build/test_same_definition", test)
+    except MultipleDefinitionException:
+        assert False, "Should not throw MultipleDefinitionException"

--- a/tests/test_ir/test_declaretest.py
+++ b/tests/test_ir/test_declaretest.py
@@ -2,10 +2,7 @@ from magma import *
 from magma.testing import check_files_equal
 
 def test():
-    # Clear the circuit cache from any other test cases
-    import magma.circuit
-    magma.circuit.__magma_clear_circuit_cache()
-    And2 = DeclareCircuit('And2', "I0", In(Bit), "I1", In(Bit), "O", Out(Bit)) 
+    And2 = DeclareCircuit('And2', "I0", In(Bit), "I1", In(Bit), "O", Out(Bit))
 
     main = DefineCircuit("main", "I0", In(Bit), "I1", In(Bit), "O", Out(Bit))
     inst0 = And2()


### PR DESCRIPTION
* Removes cacheing logic in DefineCircuitKind. Adds in a pass that checks for multiple definitions with the same name in the `compile` command. Comes with two tests in `tests/test_compile_errors.py`.
* Adds `@circuit_generator` decorator that stores generator arguments in the returned `Circuit` class.
* Patches `DefineCircuitKind`'s naming logic to inherit the `name` from a parent class if the parent is not `Circuit`. This allows you to inherit the name from a generator declaration.

See `tests/test_circuit/test_circuit_generator.py` for an example of using generators with inheritance.