### PR TITLE
Improve isdefinition(circuit) logic

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -344,9 +344,7 @@ def popDefinition():
 #  A circuit is a definition if it has instances
 def isdefinition(circuit):
     'Return whether a circuit is a module definition'
-    return circuit.is_definition or \
-           getattr(circuit, "verilogFile", None) is not None or \
-           getattr(circuit, "verilog", None) is not None
+    return circuit.is_definition
 
 def isprimitive(circuit):
     return circuit.primitive
@@ -384,7 +382,7 @@ class DefineCircuitKind(CircuitKind):
         self.firrtl = None
 
         self.instances = []
-        self.is_definition = dct.get('is_definition', False)
+        self._is_definition = dct.get('is_definition', False)
 
         if hasattr(self, 'IO'):
             # instantiate interface
@@ -395,10 +393,14 @@ class DefineCircuitKind(CircuitKind):
             if hasattr(self, 'definition'):
                  pushDefinition(self)
                  self.definition()
-                 self.is_definition = True
+                 self._is_definition = True
                  EndCircuit()
 
         return self
+
+    @property
+    def is_definition(self):
+        return self._is_definition or self.verilog or self.verilogFile
 
     #
     # place a circuit instance in this definition

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -306,6 +306,7 @@ class CircuitType(AnonymousCircuitType):
 def DeclareCircuit(name, *decl, **args):
     dct = dict(
         IO=decl,
+        is_definition=False,
         primitive=args.get('primitive', True),
         stateful=args.get('stateful', False),
         simulate=args.get('simulate'),
@@ -343,7 +344,7 @@ def popDefinition():
 #  A circuit is a definition if it has instances
 def isdefinition(circuit):
     'Return whether a circuit is a module definition'
-    return hasattr(circuit, "instances") or \
+    return circuit.is_definition or \
            getattr(circuit, "verilogFile", None) is not None or \
            getattr(circuit, "verilog", None) is not None
 
@@ -383,6 +384,7 @@ class DefineCircuitKind(CircuitKind):
         self.firrtl = None
 
         self.instances = []
+        self.is_definition = dct.get('is_definition', False)
 
         if hasattr(self, 'IO'):
             # instantiate interface
@@ -393,6 +395,7 @@ class DefineCircuitKind(CircuitKind):
             if hasattr(self, 'definition'):
                  pushDefinition(self)
                  self.definition()
+                 self.is_definition = True
                  EndCircuit()
 
         return self
@@ -438,6 +441,7 @@ def DefineCircuit(name, *decl, **args):
         currentDefinitionStack.append(currentDefinition)
 
     dct = dict(IO             = decl,
+               is_definition  = True,
                primitive      = args.get('primitive', False),
                stateful       = args.get('stateful', False),
                simulate       = args.get('simulate'),

--- a/tests/test_circuit/test_is_definition.py
+++ b/tests/test_circuit/test_is_definition.py
@@ -1,0 +1,29 @@
+from magma import *
+from magma.circuit import isdefinition
+
+
+def test_is_definition():
+    class IsDefinition(Circuit):
+        name = "this_is_definition"
+        IO = ["I", In(Bit), "O", Out(Bit)]
+        @classmethod
+        def definition(cls):
+            wire(cls.I, cls.O)
+
+    assert isdefinition(IsDefinition), "Should be a definition"
+
+    circ = DefineCircuit('another_definition', 'I', In(Bit), 'O', Out(Bit))
+    wire(circ.I, circ.O)
+    EndDefine()
+    assert isdefinition(circ), "Should be a definition"
+
+
+def test_is_not_definition():
+    class IsDefinition(Circuit):
+        name = "this_is_not_definition"
+        IO = ["I", In(Bit), "O", Out(Bit)]
+
+    assert not isdefinition(IsDefinition), "Should not be a definition"
+
+    circ = DeclareCircuit('another_not_definition', 'I', In(Bit), 'O', Out(Bit))
+    assert not isdefinition(circ), "Should not be a definition"


### PR DESCRIPTION
`DefineCircuit` sets `_is_definition` to `True`
`DeclareCircuit` sets `_is_definition` to `False`

When subclassing `Circuit`, `_is_definition` is equal to whether the subclass defines `definition`.

The `is_definition` property uses `_is_definition` but also checks whether `verilog` or `verilogFile` is populated.