### PR TITLE
Change dot backend to try and use the names instances were declared with

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -18,7 +18,6 @@ from .tuple import TupleType
 from .bit import VCC, GND
 from .debug import get_callee_frame_info
 from .logging import warning
-from .backend.dot import to_html
 
 __all__  = ['AnonymousCircuitType']
 __all__ += ['AnonymousCircuit']
@@ -37,6 +36,10 @@ __all__ += ['circuit_generator']
 
 circuit_type_method = namedtuple('circuit_type_method', ['name', 'definition'])
 
+def circuit_to_html(cls):
+    # Avoid circular dependency so dot backend can use passes
+    from .backend.dot import to_html
+    return to_html(cls)
 
 # create an attribute for each port
 def setports(self, ports):
@@ -115,7 +118,7 @@ class CircuitKind(type):
         return s
 
     def _repr_html_(cls):
-        return to_html(cls)
+        return circuit_to_html(cls)
 
     def find(cls, defn):
         name = cls.__name__
@@ -172,7 +175,7 @@ class AnonymousCircuitType(object):
         #    ', '.join(args), self.filename, self.lineno)
 
     def _repr_html_(self):
-        return to_html(self)
+        return circuit_to_html(self)
 
     def __getitem__(self, key):
         return self.interface[key]
@@ -423,8 +426,8 @@ class DefineCircuitKind(CircuitKind):
 try:
     ip = get_ipython()
     html_formatter = ip.display_formatter.formatters['text/html']
-    html_formatter.for_type(DefineCircuitKind, to_html)
-    html_formatter.for_type(CircuitKind, to_html)
+    html_formatter.for_type(DefineCircuitKind, circuit_to_html)
+    html_formatter.for_type(CircuitKind, circuit_to_html)
 except NameError:
     # Not running in IPython right now?
     pass

--- a/magma/passes/debug_name.py
+++ b/magma/passes/debug_name.py
@@ -14,6 +14,9 @@ class InstDecl:
 class DebugNamePass(DefinitionPass):
     def __call__(self, definition):
         for inst in definition.instances:
+            if hasattr(inst, 'decl'):
+                # Skip if this pass has already been run (partially or not)
+                continue
             stack = inst.stack
             inst.decl = None
             for frame_info in stack:

--- a/magma/passes/debug_name.py
+++ b/magma/passes/debug_name.py
@@ -20,8 +20,8 @@ class DebugNamePass(DefinitionPass):
             stack = inst.stack
             inst.decl = None
             for frame_info in stack:
-                local_vars = frame_info.frame.f_locals.items()
+                local_vars = frame_info[0].f_locals.items()
                 for name, var in local_vars:
                     if var is inst:
-                        inst.decl = InstDecl(name, frame_info.lineno, frame_info.frame.f_code.co_filename)
+                        inst.decl = InstDecl(name, frame_info[2], frame_info[0].f_code.co_filename)
                         break


### PR DESCRIPTION
I tested this with the pico40 processor, and it makes some circuits a bit easier to understand. Unfortunately some circuits (especially mantle ones), wind up with a bunch of LUT4's with names like "self" since they are never assigned directly to a variable, so the DebugName pass can't really find a meaningful name.

This changes the dot backend to print nodes with varname (magma name), for example: mycounter (inst0) 