### PR TITLE
fixing adder int2seq and simulator issues

### DIFF
--- a/notebooks/icestick/adder.ipynb
+++ b/notebooks/icestick/adder.ipynb
@@ -596,7 +596,7 @@
     }
    ],
    "source": [
-    "from magma.python_simulator import testvectors\n",
+    "from magma.simulator.python_simulator import testvectors\n",
     "\n",
     "tests = testvectors(Adder4) \n",
     "print(\" a  b  ci o  co\")\n",
@@ -694,10 +694,10 @@
     "\n",
     "main = icestick.main()\n",
     "adder4 = Adder4()\n",
-    "m.wire(int2seq(3, 4), adder4.a)\n",
-    "m.wire(int2seq(4, 4), adder4.b)\n",
+    "m.wire(m.bits(3, 4), adder4.a)\n",
+    "m.wire(m.bits(4, 4), adder4.b)\n",
     "m.wire(0, adder4.cin)\n",
-    "m.wire(adder4.out, [main.D1, main.D2, main.D3, main.D4])\n",
+    "m.wire(adder4.out, m.bits([main.D1, main.D2, main.D3, main.D4]))\n",
     "m.compile(\"build/ice_adder\", main)"
    ]
   },
@@ -714,7 +714,7 @@
       "cdone: high\n",
       "reset..\n",
       "cdone: low\n",
-      "flash ID: 0x20 0xBA 0x16 0x10 0x00 0x00 0x23 0x51 0x73 0x10 0x23 0x00 0x35 0x00 0x35 0x06 0x06 0x15 0x43 0xB6\n",
+      "flash ID: 0x20 0xBA 0x16 0x10 0x00 0x00 0x23 0x51 0x73 0x10 0x22 0x00 0x20 0x00 0x23 0x06 0x06 0x15 0xC9 0x77\n",
       "file size: 32220\n",
       "erase 64kB sector at 0x000000..\n",
       "programming..\n",
@@ -752,7 +752,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I fixed 2 issues with the adder icestick example:

1. I removed int2seq following the guidance of https://github.com/phanrahan/magma/issues/132
2. I'm importing python_simulator from the right location. It probably was moved at some point since this example was written.