### PR TITLE
Add basic primitives test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ ENV/
 tests/build
 
 .DS_Store
+
+tests/test_coreir/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 sudo: true  # Needed for coreir-dev branch building coreir from source (installing g++-4.9 through apt)
 
 before_install:
+    - sudo apt-get -qq update
+    - sudo apt-get install verilator
     - source .travis/install_coreir.sh
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 
 install:
     - pip install -r requirements.txt
-    - pip install pytest-cov
+    - pip install pytest-cov delegator.py
     - pip install -e .
 
 script:

--- a/magma/testing/verilator.py
+++ b/magma/testing/verilator.py
@@ -48,7 +48,7 @@ int main(int argc, char **argv, char **env) {{
         if port.isoutput():
             source += '''\
         top->{name} = test[{i}];
-        std::cout << "{name}=" << test[{i}] << " ";
+        printf("{name} = 0x%x ", test[{i}]);
 '''.format(name=name,i=i)
         i += 1
 
@@ -61,9 +61,9 @@ int main(int argc, char **argv, char **env) {{
     for name, port in circuit.interface.ports.items():
         if port.isinput():
             source += '''\
-        std::cout << "Expected {name} = " << test[{i}] << std::endl;
+        printf("Expected {name} = 0x%x\\n", test[{i}]);
         // For some reason top->port doesn't show up in cout, printf works though
-        printf("Actual {name}   = %x\\n", top->{name});
+        printf("Actual {name}   = 0x%x\\n", top->{name});
         assert(top->{name} == test[{i}]);
 '''.format(name=name,i=i)
         i += 1

--- a/tests/test_coreir/test_primitives.py
+++ b/tests/test_coreir/test_primitives.py
@@ -5,6 +5,7 @@ import magma.testing.verilator
 import delegator
 import inspect
 import os
+from random import randint
 
 unary_primitives = [
     ("not", operator.invert),
@@ -19,7 +20,7 @@ binary_primitives = [
     ("sub", operator.sub),
     ("mul", operator.mul),
     ("shl", operator.lshift),
-    ("lshr", operator.rshift),
+    # ("lshr", operator.rshift),
 ]
 
 comparison_primitives = [
@@ -47,15 +48,27 @@ def pytest_generate_tests(metafunc):
     if 'input1' in metafunc.fixturenames:
         metafunc.parametrize("input1", range(16))
 
-def complete(func, n, width):
+def complete(func, n, width, signed=False):
     max = 1 << width
     tests = []
     for i in range(n):
         for j in range(n):
-            test = [BitVector(i, width), BitVector(j, width)]
+            test = [BitVector(i, width, signed), BitVector(j, width, signed)]
             result = func(*test)
             test.append(result)
             tests.append(test)
+    return tests
+
+def random(func, n, width, signed=False):
+    max = 1 << width
+    tests = []
+    for i in range(n):
+        x = randint(0, max)
+        y = randint(0, max)
+        test = [BitVector(x, width, signed), BitVector(y, width, signed)]
+        result = func(*test)
+        test.append(result)
+        tests.append(test)
     return tests
 
 def test_binary_primitive(binary_primitive, width):
@@ -82,7 +95,43 @@ def test_binary_primitive(binary_primitive, width):
     build_dir = os.path.join(file_path, 'build')
     result = delegator.run(f"coreir -i {primitive_name}.json -o {primitive_name}.v", cwd=build_dir)
     assert not result.return_code, result.out + "\n" + result.err
-    tests = complete(primitive_op, 4, 16)
+    if width == 4:
+        tests = complete(primitive_op, 16, width)
+    else:
+        assert width == 16
+        tests = random(primitive_op, 512, width)
+    m.testing.verilator.compile(f"build/sim_{primitive_name}.cpp", circ, tests)
+    m.testing.verilator.run_verilator_test(f"{primitive_name}",
+            f"sim_{primitive_name}", f"{primitive_name}_wrapper")
+
+def test_comparison_primitive(comparison_primitive, width):
+
+    primitive_name, primitive_op, signed = comparison_primitive
+    prim = m.DeclareCircuit(f"primitive_name",
+            "in0", m.In(m.Array(width, m.Bit)),
+            "in1", m.In(m.Array(width, m.Bit)),
+            "out",  m.Out(m.Bit),
+            coreir_lib="coreir", coreir_name=primitive_name, coreir_genargs={"width": width})
+    circ = m.DefineCircuit(f"{primitive_name}_wrapper",
+            "I0", m.In(m.Array(width, m.Bit)),
+            "I1", m.In(m.Array(width, m.Bit)),
+            "O",  m.Out(m.Bit))
+    inst = prim()
+    m.wire(circ.I0, inst.in0)
+    m.wire(circ.I1, inst.in1)
+    m.wire(circ.O, inst.out)
+    m.EndDefine()
+    m.compile(f"build/{primitive_name}", circ, output="coreir")
+
+    file_path = os.path.dirname(__file__)
+    build_dir = os.path.join(file_path, 'build')
+    result = delegator.run(f"coreir -i {primitive_name}.json -o {primitive_name}.v", cwd=build_dir)
+    assert not result.return_code, result.out + "\n" + result.err
+    if width == 4:
+        tests = complete(primitive_op, 16, width, signed)
+    else:
+        assert width == 16
+        tests = random(primitive_op, 512, width, signed)
     m.testing.verilator.compile(f"build/sim_{primitive_name}.cpp", circ, tests)
     m.testing.verilator.run_verilator_test(f"{primitive_name}",
             f"sim_{primitive_name}", f"{primitive_name}_wrapper")

--- a/tests/test_coreir/test_primitives.py
+++ b/tests/test_coreir/test_primitives.py
@@ -20,7 +20,7 @@ binary_primitives = [
     ("sub", operator.sub),
     ("mul", operator.mul),
     ("shl", operator.lshift),
-    # ("lshr", operator.rshift),
+    ("lshr", operator.rshift),
 ]
 
 comparison_primitives = [

--- a/tests/test_coreir/test_primitives.py
+++ b/tests/test_coreir/test_primitives.py
@@ -1,0 +1,88 @@
+from bit_vector import BitVector
+import operator
+import magma as m
+import magma.testing.verilator
+import delegator
+import inspect
+import os
+
+unary_primitives = [
+    ("not", operator.invert),
+    # ("neg", operator.neg),
+]
+
+binary_primitives = [
+    ("and", operator.and_),
+    ("or", operator.or_),
+    ("xor", operator.xor),
+    ("add", operator.add),
+    ("sub", operator.sub),
+    ("mul", operator.mul),
+    ("shl", operator.lshift),
+    ("lshr", operator.rshift),
+]
+
+comparison_primitives = [
+    ("slt", operator.lt, True),
+    ("sle", operator.le, True),
+    ("sgt", operator.gt, True),
+    ("sge", operator.ge, True),
+    ("ult", operator.lt, False),
+    ("ule", operator.le, False),
+    ("ugt", operator.gt, False),
+    ("uge", operator.ge, False),
+]
+
+def pytest_generate_tests(metafunc):
+    if 'binary_primitive' in metafunc.fixturenames:
+        metafunc.parametrize("binary_primitive", binary_primitives)
+    if 'unary_primitive' in metafunc.fixturenames:
+        metafunc.parametrize("unary_primitive", unary_primitives)
+    if 'comparison_primitive' in metafunc.fixturenames:
+        metafunc.parametrize("comparison_primitive", comparison_primitives)
+    if 'width' in metafunc.fixturenames:
+        metafunc.parametrize("width", [4])
+    if 'input0' in metafunc.fixturenames:
+        metafunc.parametrize("input0", range(16))
+    if 'input1' in metafunc.fixturenames:
+        metafunc.parametrize("input1", range(16))
+
+def complete(func, n, width):
+    max = 1 << width
+    tests = []
+    for i in range(n):
+        for j in range(n):
+            test = [BitVector(i, width), BitVector(j, width)]
+            result = func(*test)
+            test.append(result)
+            tests.append(test)
+    return tests
+
+def test_binary_primitive(binary_primitive, width):
+
+    primitive_name, primitive_op = binary_primitive
+    prim = m.DeclareCircuit(f"primitive_name",
+            "in0", m.In(m.Array(width, m.Bit)),
+            "in1", m.In(m.Array(width, m.Bit)),
+            "out",  m.Out(m.Array(width, m.Bit)),
+            coreir_lib="coreir", coreir_name=primitive_name, coreir_genargs={"width": width})
+    circ = m.DefineCircuit(f"{primitive_name}_wrapper",
+            "I0", m.In(m.Array(width, m.Bit)),
+            "I1", m.In(m.Array(width, m.Bit)),
+            "O",  m.Out(m.Array(width, m.Bit))
+            )
+    inst = prim()
+    m.wire(circ.I0, inst.in0)
+    m.wire(circ.I1, inst.in1)
+    m.wire(circ.O, inst.out)
+    m.EndDefine()
+    m.compile(f"build/{primitive_name}", circ, output="coreir")
+
+    file_path = os.path.dirname(__file__)
+    build_dir = os.path.join(file_path, 'build')
+    result = delegator.run(f"coreir -i {primitive_name}.json -o {primitive_name}.v", cwd=build_dir)
+    assert not result.return_code, result.out + "\n" + result.err
+    tests = complete(primitive_op, 4, 16)
+    m.testing.verilator.compile(f"build/sim_{primitive_name}.cpp", circ, tests)
+    m.testing.verilator.run_verilator_test(f"{primitive_name}",
+            f"sim_{primitive_name}", f"{primitive_name}_wrapper")

--- a/tests/test_coreir/test_primitives.py
+++ b/tests/test_coreir/test_primitives.py
@@ -41,7 +41,7 @@ def pytest_generate_tests(metafunc):
     if 'comparison_primitive' in metafunc.fixturenames:
         metafunc.parametrize("comparison_primitive", comparison_primitives)
     if 'width' in metafunc.fixturenames:
-        metafunc.parametrize("width", [4])
+        metafunc.parametrize("width", [16])
     if 'input0' in metafunc.fixturenames:
         metafunc.parametrize("input0", range(16))
     if 'input1' in metafunc.fixturenames:


### PR DESCRIPTION
@dillonhuff @rdaly525 Here's a first sampling of tests for the coreir primitives through the verilog backend with verilator. So far just some of the binary primitives.

Currently `shl` and `sub` fail for me with the following outputs

For `sub`:
```
===== Test Iteration 0 =====
Inputs:
I0 = 0x0 I1 = 0x0
Expected O = 0x0
Actual O   = 0x0
===== Test Iteration 1 =====
Inputs:
I0 = 0x0 I1 = 0x1
Expected O = 0xffff
Actual O   = 0xf
--------------------------------------------- Captured stderr call ---------------------------------------------
Assertion failed: (top->O == test[2]), function main, file ../sim_sub.cpp, line 43.
```

For `shl`:
```
===== Test Iteration 0 =====
Inputs:
I0 = 0x0 I1 = 0x0
Expected O = 0x0
Actual O   = 0x0
===== Test Iteration 1 =====
Inputs:
I0 = 0x0 I1 = 0x1
Expected O = 0x0
Actual O   = 0x0
===== Test Iteration 2 =====
Inputs:
I0 = 0x0 I1 = 0x2
Expected O = 0x0
Actual O   = 0x0
===== Test Iteration 3 =====
Inputs:
I0 = 0x0 I1 = 0x3
Expected O = 0x0
Actual O   = 0x0
===== Test Iteration 4 =====
Inputs:
I0 = 0x1 I1 = 0x0
Expected O = 0x1
Actual O   = 0x1
===== Test Iteration 5 =====
Inputs:
I0 = 0x1 I1 = 0x1
Expected O = 0x2
Actual O   = 0x2
===== Test Iteration 6 =====
Inputs:
I0 = 0x1 I1 = 0x2
Expected O = 0x4
Actual O   = 0x4
===== Test Iteration 7 =====
Inputs:
I0 = 0x1 I1 = 0x3
Expected O = 0x8
Actual O   = 0x8
===== Test Iteration 8 =====
Inputs:
I0 = 0x2 I1 = 0x0
Expected O = 0x2
Actual O   = 0x2
===== Test Iteration 9 =====
Inputs:
I0 = 0x2 I1 = 0x1
Expected O = 0x4
Actual O   = 0x4
===== Test Iteration 10 =====
Inputs:
I0 = 0x2 I1 = 0x2
Expected O = 0x8
Actual O   = 0x8
===== Test Iteration 11 =====
Inputs:
I0 = 0x2 I1 = 0x3
Expected O = 0x10
Actual O   = 0x0
--------------------------------------------- Captured stderr call ---------------------------------------------
Assertion failed: (top->O == test[2]), function main, file ../sim_shl.cpp, line 43.
```

To reproduce:
* `cd magma`
* `git checkout test-coreir-prims`
* `pytest tests/test_coreir/test_primitives.py`