### PR TITLE
Making Simulator Call Right Passes And Fix GetCoreIRModule Function

### DIFF
--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -27,4 +27,4 @@ def GetCoreIRModule(cirb: CoreIRBackend, circuit: Circuit):
     if (hasattr(circuit, "wrappedModule")):
         return circuit.wrappedModule
     else:
-        return cirb.compile_definition(circuit)
+        return cirb.compile(circuit)[circuit.name]

--- a/magma/simulator/coreir_simulator.py
+++ b/magma/simulator/coreir_simulator.py
@@ -109,7 +109,7 @@ class CoreIRSimulator(CircuitSimulator):
 
         return triggered
 
-    def __init__(self, circuit, clock, coreir_filename=None, context=None):
+    def __init__(self, circuit, clock, coreir_filename=None, context=None, namespaces=["global"]):
         self.watchpoints = []
 
         need_cleanup = False
@@ -132,7 +132,9 @@ class CoreIRSimulator(CircuitSimulator):
         self.ctx.get_lib("commonlib")
         self.ctx.enable_symbol_table()
         coreir_circuit = self.ctx.load_from_file(coreir_filename)
-        self.ctx.run_passes(["rungenerators", "flattentypes", "flatten", "verifyconnectivity-onlyinputs"])
+        self.ctx.run_passes(["rungenerators", "flattentypes", "flatten",
+                             "verifyconnectivity-noclkrst", "deletedeadinstances"],
+                            namespaces=namespaces)
         self.simulator_state = coreir.SimulatorState(coreir_circuit)
 
         if need_cleanup:


### PR DESCRIPTION
1. The simulator was only calling a subset of the passes necessary for Aetherling. The main additions are:
    a. Making verifyconnectivity cover a large set of ports
    b. Deleting the term instances that are added for passing verifyconnectivity but shouldn't be in the end circuit. This is done with the deletedeadinstances pass.
    c. Adding the ability to run over other namespaces.
2. GetCoreIRModule wasn't calling the right function when passed a circuit that isn't just a wrapper for a CoreIR module. I hadn't tested this functionality before. This works now.