### PR TITLE
Basic support for port type in module body

### DIFF
--- a/tests/test_verilog/simple.v
+++ b/tests/test_verilog/simple.v
@@ -1,0 +1,3 @@
+module top(a);
+    input a;
+endmodule

--- a/tests/test_verilog/test_simple.py
+++ b/tests/test_verilog/test_simple.py
@@ -1,0 +1,15 @@
+from magma import DeclareFromVerilog
+import inspect
+import os
+import magma as m
+
+def test_simple():
+    file_path = os.path.dirname(__file__)
+    file_name = os.path.join(file_path, "simple.v")
+    with open(file_name, 'r') as f:
+        s = f.read()
+
+    v = DeclareFromVerilog(s)
+    top = v[0]
+    assert top.name == "top"
+    assert repr(top.IO) == "Interface(a, In(Bit))"


### PR DESCRIPTION
Adds minimal support for Verilog modules that declare the port type in the body of the definition

Example:
```
module top(a);
    input a;
endmodule
```