### PR TITLE
Make instances a property on a CircuitType

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -423,14 +423,14 @@ class DefineCircuitKind(CircuitKind):
     #
     def place(cls, inst):
         if not inst.name:
-            inst.name = 'inst' + str(len(cls.instances))
+            inst.name = 'inst' + str(len(cls._instances))
             # osnr's suggested name
             #inst.name = 'inst' + str(len(cls.instances)) + '_' + inst.__class__.name
             #print('naming circuit instance', inst.name)
         #print('placing', inst, 'in', cls)
         inst.defn = cls
         inst.stack = inspect.stack()
-        cls.instances.append(inst)
+        cls._instances.append(inst)
 
 
 # Register graphviz repr if running in IPython.

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -392,7 +392,7 @@ class DefineCircuitKind(CircuitKind):
 
         self.firrtl = None
 
-        self.instances = []
+        self._instances = []
         self._is_definition = dct.get('is_definition', False)
         self.is_instance = False
 
@@ -413,6 +413,10 @@ class DefineCircuitKind(CircuitKind):
     @property
     def is_definition(self):
         return self._is_definition or self.verilog or self.verilogFile
+
+    @property
+    def instances(self):
+        return self._instances
 
     #
     # place a circuit instance in this definition

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -423,14 +423,14 @@ class DefineCircuitKind(CircuitKind):
     #
     def place(cls, inst):
         if not inst.name:
-            inst.name = 'inst' + str(len(cls._instances))
+            inst.name = 'inst' + str(len(cls.instances))
             # osnr's suggested name
             #inst.name = 'inst' + str(len(cls.instances)) + '_' + inst.__class__.name
             #print('naming circuit instance', inst.name)
         #print('placing', inst, 'in', cls)
         inst.defn = cls
         inst.stack = inspect.stack()
-        cls._instances.append(inst)
+        cls.instances.append(inst)
 
 
 # Register graphviz repr if running in IPython.


### PR DESCRIPTION
This prevents instances from inheriting the `instances` field as a class attribute
```python
>>> from mantle.coreir.arith import DefineAdd
>>> Add8 = DefineAdd(8)
>>> Add8.instances
[inst0 = coreir_add8()]
>>> add = Add8()
>>> add.instances
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Add8' object has no attribute 'instances'
>>> type(add).instances
[inst0 = coreir_add8()]
```

The previous (undesired) behavior was
```python

>>> from mantle.coreir.arith import DefineAdd
>>> Add8 = DefineAdd(8)
>>> add = Add8()
>>> add.instances
[inst0 = coreir_add8()]
>>> type(add).instances
[inst0 = coreir_add8()]
```