### PR TITLE
Always Pull The Latest CoreIR Without Using Version Numbers

### DIFF
--- a/.travis/install_coreir.sh
+++ b/.travis/install_coreir.sh
@@ -22,7 +22,7 @@ if [ "$TRAVIS_BRANCH" == "coreir-dev" ]; then
     export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/deps/lib:$LD_LIBRARY_PATH;
     pip install git+git://github.com/leonardt/pycoreir.git@dev;
 else
-    wget https://github.com/rdaly525/coreir/releases/download/v0.0.11/coreir.tar.gz;
+    curl -s -L https://github.com/rdaly525/coreir/releases/latest | grep "href.*coreir.tar.gz" | cut -d \" -f 2 | xargs -I {} wget https://github.com"{}"
     mkdir coreir_release;
     tar -xf coreir.tar.gz -C coreir_release --strip-components 1;
     export PATH=$TRAVIS_BUILD_DIR/coreir_release/bin:$PATH;

--- a/.travis/install_coreir.sh
+++ b/.travis/install_coreir.sh
@@ -22,6 +22,7 @@ if [ "$TRAVIS_BRANCH" == "coreir-dev" ]; then
     export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/deps/lib:$LD_LIBRARY_PATH;
     pip install git+git://github.com/leonardt/pycoreir.git@dev;
 else
+    # based on https://gist.github.com/steinwaywhw/a4cd19cda655b8249d908261a62687f8
     curl -s -L https://github.com/rdaly525/coreir/releases/latest | grep "href.*coreir.tar.gz" | cut -d \" -f 2 | xargs -I {} wget https://github.com"{}"
     mkdir coreir_release;
     tar -xf coreir.tar.gz -C coreir_release --strip-components 1;


### PR DESCRIPTION
It is annoying to have to update all my branches every time we increment the coreir version number. This fixes that. 

This pull request, unlike the last one, is actually based on coreir-dev rather than master.