### PR TITLE
Added Documentation (with small passes change) That I Wished For

### DIFF
--- a/doc/internals.md
+++ b/doc/internals.md
@@ -1,0 +1,72 @@
+Types of passes:
+1. Pass – parent, just takes an object __(I think it’s a circuit, with InstanceGraphPass it’s a circuit, unclear for others)__ and assigns it to the pass’s main
+2. InstancePass(Pass) – A pass that finds the paths to all the instances instances in a definition. This includes nested instances (instances which as used in the definitions of other instances).
+    1. __init__ - call’s Pass’s init, then creates an empty instances list – main here is a circuit definition
+    1. run/_run - BFS search of all instances, return a list of paths to all.
+        1. note: callable is meaningless here, since InstancePass never inherited and thus never callable
+3. DefinitionPass - A pass that creates a dictionary containing all the definitions used in a top-level circuit definition. It has the names of the definitions as keys and the definition objects as values. The top-level definition is included in the dictionary.
+    1. This is a recursive algorithm working on definitions.
+        1. It starts with the top level definition (self.main)
+        1. For the current iteration's definition, it gets all that definition's instances and recurs on the definition of each instance IF the instance comes from a definition and not a declaration.
+            1. Note: variable instancedefinition can contain either definitions or declarations. This is confusing
+        1. Add the current iteration's definition to the pass's dictionary of definitions. The self.definitions dictionary has the name of definitions as keys and the definition objects as values.
+            1. Note: if the pass is callable, it's called each time a new definition is added to the dictionary.
+    1. __is this really what this is doing? Why is this here? Neither DefinitionPass nor InstancePass are ever referenced___
+        1. not true. InstancePass never used, but definition pass subclassed a bunch, like BuildInstanceGraphPass.
+        2. subclasses of this use DefinitionPass._run to populate the definitions property of the Pass object
+    2. __even if this were to do something, shouldn't it need to be changed to call InstancePass to find nested instances?__
+        1. No. Since instances can't contain instances, only definitions can, this is not a problem.
+    2. __can an instance have a definition in it's instances list? If so, then isn't this pass broken?__ - no, according to circuit.py isdefinition, a circuit is a definition if it has instances. Since can't be both a definition and an instance, instances can't contain instances
+        1. definition.instances can only have instances. Instances are instances of either definitions or declarations. These are accessed by type(instance)
+    3. __And what does call do? Nothing has a `__call__` method__
+        1. The passes that subclass this have `__call__` methods
+4. BuildInstanceGraphPass
+    1. This has a graph which tracks which definitions are dependent on other definitions. Definitions as vertices and instances are directed edges. Each edge points from the definition that uses the instance to the instance's definition.
+        1. The graph is stored as a mapping where keys are definitions and values are lists of definitions that the key is dependent on
+    1. This inherits DefinitionPass's run, which calls BuildInstanceGraphPass's `__call__` method for each definition (and not for declarations)
+    1. The `__call__` hanldes on definition at a time. For each definition, this
+        1. Adds the definition to the graph if its not already in there
+        2. For each instance in the definition:
+            1. Add the instance's definition to the graph if its not already in the graph
+            1. Add an edge indicating dependency from the definition using the instance to the instance's definition
+5. InstanceGraphPass -
+    1. call BuildInstanceGraphPass to build a dependency graph of definitions for circuit definition passed in as main
+    1. set that list as value for self.tsortedgraph
+    1. If callable, which it isn't but subclasses might, will call self for each vertex in the sorted graph
+
+
+How Are Circuit Definitions And Instances Structured
+1. Each definition has a instances list, which is a list of instances in that are added to that definition
+2. Each of those instances may have a definition that is gotten by getting the instances type. This is because an instance's definition is the class it is an instance of. Getting the type of an instance gets the class its an instance of.
+
+Where Do Circuit Declarations, Definitions, and Instances Fit in the Type System? – see [magma/circuit.py](https://github.com/phanrahan/magma/blob/coreir-dev/magma/circuit.py)
+1. CircuitKind – instances of this are circuit declarations.
+    1. Declarations are like function declarations in C, Magma declarations declare the ports but do not show how to define the circuit. Declarations cannot contain instances. Declarations are used in use cases including wrappers for CoreIR C++ modules that provide definitions, or as an abstract interface for multiple definitions that are backend-dependent.
+    1. AnonymousCircuitType is an instance of this, __so what does that make instances of AnonymousCircuit? You can’t have instances of a circuit declaration without a definition, right?__
+    1. CircuitType is an instance of this, subclass of AnonymousCircuitType
+        1. a comment declares instances of CircuitType are instances placed in definitions
+    1. DeclareCircuit returns an instance of CircuitKind
+        1. __Where is this used differently from the result of DefineCircuit?__
+2. DefineCircuitKind – instances of this are circuit definitions. This is a subclass of a CircuitKind.
+    1. Defintions are like function definitions in C, they define how a circuit works in hardware, such as the instances of other circuit definitions used inside of the current circuit.
+    1. Instances of DefineCircuitKind (known as circuit definitions) get a place method, which allows placing circuit instances in the circuit definitions. Place is called by an instance when the instance is created
+        1. Since DefineCircuitKind is used as a metaclass, instances of the circuit definitions don’t get the place method
+    1. Circuit is an instance of DefineCircuitKind
+        1. CircuitType is Circuit’s parent class,
+        1. Circuit – has two functions
+            1. Instances of Circuit are circuit instances that are placed in circuit interfaces
+            2. Subclasses of circuit are CircuitDefinitions
+        1. __Why does Circuit exist? Why not just make CircuitType’s metaclass to be DefineCircuitkind?__
+    1. DefineCircuit returns an instance of DefineCircuitKind
+3. CircuitType – instances of this are circuit instances that have a declaration and not a definition.
+    1. When an instance of CircuitType is created, it’s `__init__` function calls the place of the current active definition, which is stored in the global currentDefinition function
+    1. This class (and subclasses of it) are circuit declarations.
+4. Circuit - instances of this are circuit instances that have a definition and not a declaration.
+    1. This class (and subclasses of it) are circuit definitions.
+
+How does compiling magma circuits (NOT INSTANCES) to coreir modules work?
+1. (optional) – call the compile function that is not part of the CoreIRBackend (CIRB) object. This creates a coreirbackend, calls compile on the coreirbackend with the circuit handed to it
+2. Compile for CIRB – builds an InstanceGraph using InstanceGraphPass (InstanceGraphPass class in magma.passes.passes)
+    1. InstanceGraphPass –
+        1. Super is just the pass `__init__`, this just assigns the main property (for storing the main circuit)
+        1. BuildInstanceGraphPass -

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -30,7 +30,7 @@ All types inherit from [Type in magma/t.py](https://github.com/phanrahan/magma/b
 1. Arrays of bits or other types
 1. Named tuples of other types
 
-Note that PyCoreIR also have python implementations of the CoreIR types below. Sometimes you may see these when working with CoreIR objects underlying Magma.
+Note that PyCoreIR also has Python implementations of the CoreIR types below. Sometimes you may see these when working with CoreIR objects underlying Magma.
 
 ### Circuits
 1. CircuitDeclaration - declarations state that a circuit exists and has certain input and ouput wires, but not what the circuit does.
@@ -81,7 +81,7 @@ CoreIR has two type systems:
 1. Instances – a circuit in hardware
     1. Note: in IR, an instance is just a pointer back to a module so that at compilation time, CoreIR knows what to build. This is like LLVM where a call node references a function.
 
-### How To Create And Test A Circuit In Magma?
+### How To Create And Test A Circuit In CoreIR?
 1. Get a namespace to put the generator in. Aetherling shows how to [make a new namespace](https://github.com/rdaly525/coreir/blob/master/src/libs/aetherlinglib.cpp#L19) and [access it for creating things in it](https://github.com/rdaly525/coreir/blob/master/src/libs/aetherlinglib/aeZip2.h#L10).
 1. Create a params object. See [Aetherling's Zip2 params object](https://github.com/rdaly525/coreir/blob/master/src/libs/aetherlinglib/aeZip2.h#L18) for an example of how to create one.
 1. Create a typegen. See [Aetherling's Zip2 typegen object](https://github.com/rdaly525/coreir/blob/master/src/libs/aetherlinglib/aeZip2.h#L25) for an example.

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,0 +1,95 @@
+# The Projects
+The projects in order of dependency (with most abstract at top) are:
+1. Mantle - libraries of useful circuits built in Magma
+1. Magma - A Python API for creating circuits
+1. PyCoreIR - A set of Python bindings for converting Magma into CoreIR
+1. CoreIR - A C++ library for manipulating the CoreIR hardware IR (like LLVM for hardware)
+
+__NOTE: Where does loam fit in here?__
+
+CoreIR can be compiled to verilog to target a diverse array of hardware.
+
+# How Do I Install All These Things?
+[See the instructions from this project dependent on all of them](https://github.com/David-Durst/aetherling#installation)
+
+# Core Concepts:
+Magma and CoreIR have somewhat similar ways of constructing circuits. There are circuits and types for the values produced and consumed by circuits.
+
+Roughly, the mapping between concepts for circuits in the two platforms is:
+1. DeclareCircuit() function that produces a CircuitDeclaration == Generator Declaration + TypeGen
+    1. Note; a difference here is that Magma circuit definitions do not require separate declarations, while CoreIR generators do require generator declarations and TypeGens.
+1. DefineCircuit() function like DefineUpsample() that produces CircuitDefinitions == Generator
+1. CircuitDefinition == Module
+1. Instance == Instance
+
+## Magma
+
+### Types
+All types inherit from [Type in magma/t.py](https://github.com/phanrahan/magma/blob/master/magma/t.py#L9). Possible types are:
+1. Bits (with direction for whether this bit produces or consumes data)
+1. Arrays of bits or other types
+1. Named tuples of other types
+
+Note that PyCoreIR also have python implementations of the CoreIR types below. Sometimes you may see these when working with CoreIR objects underlying Magma.
+
+### Circuits
+1. CircuitDeclaration - declarations state that a circuit exists and has certain input and ouput wires, but not what the circuit does.
+    1. Declarations are like function declarations in C, Magma declarations declare the ports but do not show how to define the circuit.
+    1. Declarations cannot contain instances. Declarations are used in use cases including wrappers for CoreIR C++ modules that provide definitions, or as an abstract interface for multiple definitions that are backend-dependent.
+    1. Declarations are instances of the CircuitKind class in magma/circuit.py
+1. CircuitDefinition -  definitions contain all the properties of declarations as well as an implementation of the circuit to process the input and produce output.
+    1. Defintions are like function definitions in C, they define how a circuit works in hardware, such as the instances of other circuit definitions used inside of the current circuit.
+    1. Definitions are instances of the DefineCircuitKind class in magma/circuit.py
+1. Instances - these are instances of CircuitDefinitions or CircuitDeclarations. You combine multiple instances to implement another circuit definition.
+
+### How To Create And Test A Circuit In Magma?
+1. Create a module
+1. Implement the module's definition using instances of other modules, like muxes and adders. There are two main ways to do this:
+    1. [Aetherling's upsample](https://github.com/David-Durst/aetherling/blob/master/aetherling/modules/upsample.py#L14) shows how to create a circuit definition using a function that creates an instance of a class which inherits from the Circuit class. The returned class is a CircuitDefinition. Calling the CircuitDefinition creates an instance. When DefineUpsampleParallel() is called, an UpsampleParallel circuit definition is returned. Calling that definition creates an instance. The [UpsampleParallel()](https://github.com/David-Durst/aetherling/blob/master/aetherling/modules/upsample.py#L32) function is a shortcut that creates an UpsampleParallel circuit definition, creates an instance of it, and returns only the instance for use in another circuit definition.
+        1. Note: The canonical approach when creating a circuit defintion is to create both DefineCircuit() and Circuit() functions (like DefineUpsampleParallel() and UpsampleParallel()) where DefineCircuit() returns a circuit definition and Circuit() calls DefineCircuit() and then returns an instance. This makes it easy to use the circuit in other circuits.
+        1. The DefineCircuit() function must always have the @cache_definition annotation to ensure that there is only one instance of each circuit definition with identical parameters. You only want one definition because it is a constructor for producing instances, and there should only be one constructor.
+        1. The class must always have two fields:
+            1. name - The name of the CircuitDefinition in the magma type system
+            1. IO - the input and output ports on the circuit. This is a list that alternates between strings, which are port names, and types, which are the types of the ports. The types should be subclasses of the Type class in magma/t.py.
+    1. [Mantle's counter](https://github.com/phanrahan/mantle/blob/master/mantle/common/counter.py#L25) shows how to create a CircuitDefinition using the DefineCircuit() function call. This is an older circuit that provides more flexibility but is more verbose. It is recommended that users do not use it unless necessary.
+1. [Aetherling's upsample tests](https://github.com/David-Durst/aetherling/blob/master/tests/test_up.py#L16) show how to take a circuit definition and simulate it using the CoreIR simulator.
+
+## CoreIR
+
+### Types
+CoreIR has two type systems:
+1. Value Types - These are types of inputs to generators. The full list can be seen [here](https://github.com/rdaly525/coreir/blob/master/include/coreir/ir/valuetype.h) if the below list is out of date:
+    1. Bool
+    1. Int
+    1. BitVector
+    1. String
+    1. CoreIRType - a generator can be parameterized by a CoreIR type, which can be used to set the type of the inputs of the modules produced by the generator.
+    1. Module - a generator can accept a CoreIR module as input.
+1. CoreIR Types - These are types of inputs and outputs to circuits. The full list can be seen [here](https://github.com/rdaly525/coreir/blob/master/include/coreir/ir/types.h) if the below list is out of date:
+    1. Bit/BitIn/BitInOut - Bit is for outputs. BitIn is for inputs. BitInOut is for ports that do both. InOuts are typically not used.
+    1. Arrays of CoreIR types
+    1. Records (aka named tuples) of CoreIR types
+    1. NamedTypes that alias other CoreIR types, like aliasing a bit for a CE port.
+
+### Circuits
+1. Param - an object that defines the parameters to a generator.
+    1.
+1. TypeGen - an object that defines the types of the modules produced by generators. Multiple generators can have the same typegen.
+1. Generator Declarations - a declaration of a generator's name, parameters, and typegen.
+1. Generators – functions that produces a module. Parameters to generators should define the structure of the circuit, such as number of inputs or types of variables operated on.
+1. Modules - functions that produce instances. Parameters to modules should not change the structure of the circuit. Rather, they should set things like the constant amount that a counter increments by each clock cycle.
+1. Instances – a circuit in hardware
+    1. Note: in IR, an instance is just a pointer back to a module so that at compilation time, CoreIR knows what to build. This is like LLVM where a call node references a function.
+
+### How To Create And Test A Circuit In Magma?
+1. Get a namespace to put the generator in. Aetherling shows how to [make a new namespace](https://github.com/rdaly525/coreir/blob/master/src/libs/aetherlinglib.cpp#L19) and [access it for creating things in it](https://github.com/rdaly525/coreir/blob/master/src/libs/aetherlinglib/aeZip2.h#L10).
+1. Create a params object. See [Aetherling's Zip2 params object](https://github.com/rdaly525/coreir/blob/master/src/libs/aetherlinglib/aeZip2.h#L18) for an example of how to create one.
+1. Create a typegen. See [Aetherling's Zip2 typegen object](https://github.com/rdaly525/coreir/blob/master/src/libs/aetherlinglib/aeZip2.h#L25) for an example.
+    1. Note that the record returned by the anonymous function is the type of the modules produced by the generators that use this typegen.
+1. Create a generator declaration. See [Aetherling's Zip2 generator](https://github.com/rdaly525/coreir/blob/master/src/libs/aetherlinglib/aeZip2.h#L46) for an example.
+1. Add a unit test that just verifies the generator can instantiate modules. This is a basic test that doesn't guarantee correctness. Do this by creating a .cpp file in the tests/unit folder and following [simple.cpp's example](https://github.com/rdaly525/coreir/blob/master/tests/unit/simple.cpp#L6)
+1. Add a simulator test that creates a module using instances derived from the generator. This is a complex test that should guarantee correctness. Do this by creating a .cpp file in the tests/simulator folder and following [aetherlingHelpersSim.cpp's example](https://github.com/rdaly525/coreir/blob/master/tests/simulator/aetherlingHelpersSim.cpp).
+
+
+
+

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -91,5 +91,7 @@ CoreIR has two type systems:
 1. Add a simulator test that creates a module using instances derived from the generator. This is a complex test that should guarantee correctness. Do this by creating a .cpp file in the tests/simulator folder and following [aetherlingHelpersSim.cpp's example](https://github.com/rdaly525/coreir/blob/master/tests/simulator/aetherlingHelpersSim.cpp).
 
 
-
+## How To Interface Between CoreIR and Magma
+1. To access CoreIR generators from Magma, use either DefineCircuitFromGeneratorWrapper() or CircuitInstanceFromGeneratorWrapper()
+1. To export Magma circuit definitions to CoreIR, use GetCoreIRModule() to get a PyCoreIR module and then call save_to_file("circuitName.json") on that PyCoreIR module to export a CoreIR module as a json file. The json file can be compiled to Verilog using the [CoreIR CLI with the -i flag documented here](https://github.com/rdaly525/coreir/blob/master/doc/StandaloneCoireIR.md#options).
 

--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -1,5 +1,5 @@
 from magma.backend.coreir_ import CoreIRBackend
-from magma.circuit import Circuit
+from magma.circuit import DefineCircuitKind
 from magma import cache_definition
 
 @cache_definition
@@ -21,7 +21,7 @@ def CircuitInstanceFromGeneratorWrapper(cirb: CoreIRBackend, namespace: str, gen
     return DefineCircuitFromGeneratorWrapper(cirb, namespace, generator,
                                              dependentNamespaces, genargs)(**modargs)
 
-def GetCoreIRModule(cirb: CoreIRBackend, circuit: Circuit):
+def GetCoreIRModule(cirb: CoreIRBackend, circuit: DefineCircuitKind):
     """
     Get the CoreIR module corresponding to the Magma circuit or circuit instance
 

--- a/magma/passes/passes.py
+++ b/magma/passes/passes.py
@@ -23,13 +23,13 @@ class InstancePass(Pass):
 
     def _run(self, definition, path):
         for instance in definition.instances:
-            instancedefinition = type(instance)
+            defintionOrDeclarationOfInstance = type(instance)
             instpath = path + (instance, )
             self.instances.append(instpath)
             if callable(self):
                 self(instpath)
-            if isdefinition(instancedefinition):
-                self._run( instancedefinition, instpath )
+            if isdefinition(defintionOrDeclarationOfInstance):
+                self._run( defintionOrDeclarationOfInstance, instpath )
     
     def run(self):
          self._run(self.main, tuple())
@@ -43,9 +43,9 @@ class DefinitionPass(Pass):
 
     def _run(self, definition):
         for instance in definition.instances:
-            instancedefinition = type(instance)
-            if isdefinition(instancedefinition):
-                self._run( instancedefinition )
+            defintionOrDeclarationOfInstance = type(instance)
+            if isdefinition(defintionOrDeclarationOfInstance):
+                self._run( defintionOrDeclarationOfInstance )
 
         # call each definition only once
         name = definition.__name__


### PR DESCRIPTION
The passes change cleans up a name that is misleading. 

Please don't merge this until we've gone over the documentation more. I expect:
1. @leonardt and @phanrahan to review internals.md and the Magma section of overview.md
1. @rdaly525 to review the CoreIR section of overview.md
1. I will fill out internals.md more to cover more of Magma's backend/coreir_.py