### PR TITLE
Coreir linking minimal example

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,3 +9,4 @@ def magma_test():
     magma.config.set_compile_dir('callee_file_dir')
     magma_clear_circuit_cache()
     clear_cachedFunctions()
+    magma.backend.coreir_.__reset_context()

--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -42,3 +42,5 @@ from .compile import *
 #from .tests import *
 
 #print('import magma')
+
+from .frontend.coreir_ import DeclareCoreIRGenerator, coreir_typegen

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -41,10 +41,13 @@ def magma_port_to_coreir(port):
 
     return select.replace("[", ".").replace("]", "")
 
+
+magma_coreir_context = coreir.Context()  # Singleton context meant to be used with coreir/magma code
+
 class CoreIRBackend:
     def __init__(self, context=None):
         if context is None:
-            context = coreir.Context()
+            context = magma_coreir_context
         self.context = context
         self.libs = keydefaultdict(self.context.get_lib)
         self.__constant_cache = {}

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -43,6 +43,13 @@ def magma_port_to_coreir(port):
 
 
 magma_coreir_context = coreir.Context()  # Singleton context meant to be used with coreir/magma code
+def __reset_context():
+    """
+    Testing hook so every test has a fresh context
+    """
+    global magma_coreir_context
+    magma_coreir_context = coreir.Context()
+
 
 class CoreIRBackend:
     def __init__(self, context=None):

--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -48,10 +48,15 @@ def GetCoreIRModule(cirb: CoreIRBackend, circuit: DefineCircuitKind):
             circuitNotInstance = circuit
         return cirb.compile(circuitNotInstance)[circuitNotInstance.name]
 
-def DeclareCoreIRGenerator(lib : str, name : str, typegen):
-    def Define(**kwargs):
-        return DefineCircuitFromGeneratorWrapper(CoreIRBackend(), lib, name, genargs=kwargs)
-    return Define
+def DeclareCoreIRGenerator(lib : str, name : str, typegen = None):
+    if typegen is not None:
+        # This is for generators which we don't have access to
+        raise NotImplementedError()
+    else:
+        # Assume the generator is available, create a wrapped circuit
+        def Define(**kwargs):
+            return DefineCircuitFromGeneratorWrapper(CoreIRBackend(), lib, name, genargs=kwargs)
+        return Define
 
 def coreir_typegen(fn):
     def wrapped(*args, **kwargs):

--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -15,7 +15,7 @@ def DefineModuleWrapper(cirb: CoreIRBackend, coreirModule, uniqueName):
     return ModuleWrapper
 
 def DefineCircuitFromGeneratorWrapper(cirb: CoreIRBackend, namespace: str, generator: str,
-                                      dependentNamespaces: list, uniqueName: str,
+                                      dependentNamespaces: list = [], uniqueName: str,
                                       genargs: dict = {}):
     if uniqueName in definitionCache:
         return definitionCache[uniqueName]
@@ -47,3 +47,13 @@ def GetCoreIRModule(cirb: CoreIRBackend, circuit: DefineCircuitKind):
         else:
             circuitNotInstance = circuit
         return cirb.compile(circuitNotInstance)[circuitNotInstance.name]
+
+def DeclareCoreIRGenerator(lib : str, name : str, typegen):
+    def Define(**kwargs):
+        return DefineCircuitFromGeneratorWrapper(CoreIRBackend(), lib, name, genargs=kwargs)
+    return Define
+
+def coreir_typegen(fn):
+    def wrapped(*args, **kwargs):
+        return None
+    return wrapped

--- a/tests/test_coreir/gold/linker_test0.json
+++ b/tests/test_coreir/gold/linker_test0.json
@@ -15,9 +15,9 @@
           }
         },
         "connections":[
-          ["inst0.in0","self.I0"],
-          ["inst0.in1","self.I1"],
-          ["inst0.out","self.O"]
+          ["self.I0","inst0.in0"],
+          ["self.I1","inst0.in1"],
+          ["self.O","inst0.out"]
         ]
       }
     }

--- a/tests/test_coreir/gold/linker_test0.json
+++ b/tests/test_coreir/gold/linker_test0.json
@@ -1,0 +1,26 @@
+{"top":"global.LinkerTest0",
+"namespaces":{
+  "global":{
+    "modules":{
+      "LinkerTest0":{
+        "type":["Record",[
+          ["I0",["Array",16,"BitIn"]],
+          ["I1",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "inst0":{
+            "genref":"commonlib.smax",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["inst0.in0","self.I0"],
+          ["inst0.in1","self.I1"],
+          ["inst0.out","self.O"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/test_linking.py
+++ b/tests/test_coreir/test_linking.py
@@ -1,3 +1,4 @@
+import os
 import magma as m
 import coreir
 
@@ -33,6 +34,8 @@ def test_declare_generator():
             m.wire(self.I1, smax.in1)
             m.wire(self.O, smax.out)
 
-    m.compile("build/linker_test", LinkerTest, output="coreir")
-    with open("build/linker_test.json", "r") as actual:
-        print(actual.read())
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    m.compile(os.path.join(dir_path, "build/linker_test0"), LinkerTest, output="coreir")
+    with open(os.path.join(dir_path, "build/linker_test0.json"), "r") as actual:
+        with open(os.path.join(dir_path, "gold/linker_test0.json"), "r") as expected:
+            assert actual.read() == expected.read()

--- a/tests/test_coreir/test_linking.py
+++ b/tests/test_coreir/test_linking.py
@@ -1,6 +1,5 @@
 import os
 import magma as m
-import coreir
 
 # def smax_type_gen(context, values):
 #     width = values['width'].value

--- a/tests/test_coreir/test_linking.py
+++ b/tests/test_coreir/test_linking.py
@@ -1,0 +1,38 @@
+import magma as m
+import coreir
+
+# def smax_type_gen(context, values):
+#     width = values['width'].value
+#     return context.Record({
+#         "in0": context.Array(width, context.BitIn()),
+#         "in1": context.Array(width, context.BitIn()),
+#         "out": context.Array(width, context.Bit())
+#     })
+
+@m.coreir_typegen
+def smax_type_gen(width : int):
+    return Tuple(
+        in0 = m.Array(width, m.In(m.Bit)),
+        in1 = m.Array(width, m.In(m.BitIn)),
+        out = m.Array(width, m.In(m.Bit))
+    )
+
+
+def test_declare_generator():
+    DefineSmax = m.DeclareCoreIRGenerator(lib="commonlib", name="smax", typegen=smax_type_gen)
+    width = 16
+
+    class LinkerTest(m.Circuit):
+        name = "LinkerTest0"
+        IO = ["I0", m.In(m.Bits(width)), "I1", m.In(m.Bits(width)), "O", m.Out(m.Bits(width))]
+        @classmethod
+        def definition(self):
+            Smax = DefineSmax(width=width)
+            smax = Smax()
+            m.wire(self.I0, smax.in0)
+            m.wire(self.I1, smax.in1)
+            m.wire(self.O, smax.out)
+
+    m.compile("build/linker_test", LinkerTest, output="coreir")
+    with open("build/linker_test.json", "r") as actual:
+        print(actual.read())


### PR DESCRIPTION
Summary of changes:
* coreir backend uses a default context for all instances of backends. This change should still work with any existing code that uses their own coreir backend objects that they pass around, but moves us towards a singleton coreir context for all of magma
* adds a hook to refresh the context, used for testing where each test should have a fresh coreir context (so no state is shared across tests), similar to our hook to clear the circuit cache for testing
* adds `DeclareCoreIRGenerator(lib : str, name : str, typegen = None)` which generates a `Define*(...)` function that acts like a normal python/magma generator. It uses `DefineCircuitFromGeneratorWrapper` by passing through `kwargs`.
* Adds stubs for `coreir_typegen` which will enable linking in generators which we don't currently have access to (so we can't run them to get the generated module and create a wrapper)

This travis push build will fail since it's not being run on the coreir-dev branch, but hopefully the PR build will pass since it will build on the coreir-dev branch