### PR TITLE
Adding flag so defineCircuitFromGeneratorWrapper can run the generators

### DIFF
--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -16,15 +16,16 @@ def DefineModuleWrapper(cirb: CoreIRBackend, coreirModule, uniqueName):
 
 def DefineCircuitFromGeneratorWrapper(cirb: CoreIRBackend, namespace: str, generator: str,
                                       uniqueName: str, dependentNamespaces: list = [],
-                                      genargs: dict = {}):
+                                      genargs: dict = {}, runGenerators = True):
     if uniqueName in definitionCache:
         return definitionCache[uniqueName]
     moduleToWrap = cirb.context.import_generator(namespace,generator)(**genargs)
-    # cirb.context.run_passes(["rungenerators"], [namespace] + dependentNamespaces)
+    if runGenerators:
+        cirb.context.run_passes(["rungenerators"], [namespace] + dependentNamespaces)
     return DefineModuleWrapper(cirb, moduleToWrap, uniqueName)
 
 def CircuitInstanceFromGeneratorWrapper(cirb: CoreIRBackend, namespace: str, generator: str,
-                                        dependentNamespaces: list, uniqueName: str,
+                                        uniqueName: str, dependentNamespaces: list,
                                         genargs: dict = {}, modargs: dict = {}):
     return DefineCircuitFromGeneratorWrapper(cirb, namespace, generator,
                                              uniqueName, dependentNamespaces,
@@ -59,7 +60,7 @@ def DeclareCoreIRGenerator(lib : str, name : str, typegen = None, backend = None
         def Define(**kwargs):
             kwargs_str = "_".join(f"{key}_{value}" for key, value in kwargs.items())
             unique_name = f"{lib}_{name}_{kwargs_str}"
-            return DefineCircuitFromGeneratorWrapper(backend, lib, name, unique_name, genargs=kwargs)
+            return DefineCircuitFromGeneratorWrapper(backend, lib, name, unique_name, genargs=kwargs, runGenerators=False)
         return Define
 
 def coreir_typegen(fn):


### PR DESCRIPTION
This allows both usages of the function. Aetherling has significant dependencies on it running the passes. This seems like a reasonable solution a solution.