### PR TITLE
Preserve origPortRename After Qualifying Direction

### DIFF
--- a/magma/interface.py
+++ b/magma/interface.py
@@ -220,11 +220,11 @@ class _DeclareInterface(_Interface):
             elif defn: ref = DefnRef(defn, name)
             else:      ref = AnonRef(name)
 
-            port = port.qualify(direction)
+            qualified_port = port.qualify(direction)
             if hasattr(port, "origPortName"):
                 ref.name = port.origPortName
 
-            args[name] = port(name=ref)
+            args[name] = qualified_port(name=ref)
 
         self.ports = args
 


### PR DESCRIPTION
This fixes my port renaming between Magma and CoreIR. In some cases, the port returned from port.qualify has the origPortName property stripped from it. This prevents the following line from doing the name mapping (`ref.name = port.origPortName`). Rather than requiring all qualifies to preserve this property, I'm removing the variable name reuse. 

The fact that qualify doesn't preserve all properties shouldn't be a problem as origPortName is made in only one place (https://github.com/phanrahan/magma/blob/master/magma/backend/coreir_.py#L146-L150) and used only here. Therefore, the ports should never be modified in between those two places. Any thoughts on how to guarantee that more strongly?
