### PR TITLE
Add support for passing a dictionary to rename ports

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -373,7 +373,7 @@ def isdefinition(circuit):
     return getattr(circuit, "is_definition", False)
 
 def isprimitive(circuit):
-    return circuit.primitive
+    return getattr(circuit, "primitive", False)
 
 # a map from circuitDefinition names to circuit definition objects
 definitionCache = {}

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -92,7 +92,7 @@ class CircuitKind(type):
 
         # instance interface for this instance
         if hasattr(cls, 'IO'):
-            self.setinterface(cls.IO(inst=self))
+            self.setinterface(cls.IO(inst=self, renamed_ports=cls.renamed_ports))
 
         return self
 
@@ -338,7 +338,8 @@ def DeclareCircuit(name, *decl, **args):
         coreir_genargs=args.get('coreir_genargs', None),
         coreir_configargs=args.get('coreir_configargs', {}),
         verilog_name=args.get('verilog_name', name),
-        default_kwargs=args.get('default_kwargs', {})
+        default_kwargs=args.get('default_kwargs', {}),
+        renamed_ports=args.get('renamed_ports', {})
     )
     return CircuitKind( name, (CircuitType,), dct )
 
@@ -396,6 +397,7 @@ class DefineCircuitKind(CircuitKind):
             else:
                 dct['name'] = name
         name = dct['name']
+        dct["renamed_ports"] = dct.get("renamed_ports", {})
 
         self = CircuitKind.__new__(metacls, name, bases, dct)
 
@@ -425,7 +427,7 @@ class DefineCircuitKind(CircuitKind):
 
         if hasattr(self, 'IO'):
             # instantiate interface
-            self.interface = self.IO(defn=self)
+            self.interface = self.IO(defn=self, renamed_ports=dct["renamed_ports"])
             setports(self, self.interface.ports)
 
             # create circuit definition
@@ -497,7 +499,8 @@ def DefineCircuit(name, *decl, **args):
                coreir_lib     = args.get('coreir_lib', "global"),
                coreir_genargs = args.get('coreir_genargs', None),
                coreir_configargs = args.get('coreir_configargs', None),
-               default_kwargs = args.get('default_kwargs', {}))
+               default_kwargs = args.get('default_kwargs', {}),
+               renamed_ports = args.get('renamed_ports', {}))
 
     currentDefinition = DefineCircuitKind( name, (Circuit,), dct)
     return currentDefinition

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -172,7 +172,7 @@ class _Interface(Type):
 #  e.g. Interface('I0', In(Bit)(), 'I1', In(Bit)(), 'O', Out(Bit)())
 #
 class Interface(_Interface):
-    def __init__(self, decl, renamed_ports):
+    def __init__(self, decl, renamed_ports={}):
 
         directions, names, ports = parse(decl, renamed_ports)
 
@@ -204,7 +204,7 @@ class Interface(_Interface):
 #  interface = Interface()
 #
 class _DeclareInterface(_Interface):
-    def __init__(self, renamed_ports, inst=None, defn=None):
+    def __init__(self, renamed_ports={}, inst=None, defn=None):
 
         # parse the class Interface declaration
         directions, names, ports = parse(self.Decl, renamed_ports)

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -92,6 +92,13 @@ def get_primitives(outer_circuit, outer_scope):
 
     return (primitives, mapping)
 
+
+def get_renamed_port(circ, name):
+    for key, value in circ.renamed_ports.items():
+        if value == name:
+            return circ.interface.ports[key]
+    return circ.interface.ports[name]
+
 def get_new_source(source_qual, primitive_map, old_circuit, new_circuit):
     old_source = source_qual.bit
     scope = source_qual.scope
@@ -111,11 +118,11 @@ def get_new_source(source_qual, primitive_map, old_circuit, new_circuit):
         if not isprimitive(type(old_primitive)):
             raise MagmaTransformException("Failed to collapse bit to primitive. bit={} type={}".format(old_primitive, type(old_primitive)))
         new_primitive = primitive_map[QualifiedInstance(instance=old_primitive, scope=scope)]
-        newsource = new_primitive.interface.ports[bitref.name]
+        newsource = get_renamed_port(new_primitive, bitref.name)
     elif isinstance(bitref, DefnRef):
         defn = bitref.defn.name
         assert defn == old_circuit.name, f"Collapsed bit to circuit other than outermost, {defn} {old_circuit.name}"
-        newsource = new_circuit.interface.ports[bitref.name]
+        newsource = get_renamed_port(new_circuit, bitref.name)
     elif isinstance(old_source, ArrayType):
         # Must not be a whole array
         assert bitref.anon()


### PR DESCRIPTION
This implements a generalized solution for renaming circuit ports. The logic leverages the `origPortName` field introduced by @David-Durst. It exposes a parameter to circuit definitions/declarations that provide a dictionary of the form `{portName: origPortName}`. Then, when parsing the interface to construct the ports, it checks if the port name is in the mapping, and if so attaches the `origPortName` field.