### PR TITLE
Support multi-directional tuples in coreir backend

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -266,27 +266,21 @@ class CoreIRBackend:
 
         for instance in definition.instances:
             for name, port in instance.interface.ports.items():
-                if port.isinput():
-                    self.connect(module_definition, port, port.value(),
-                                 output_ports)
+                self.connect_input(module_definition, port, output_ports)
 
         for port in definition.interface.ports.values():
-            self.connect_input(definition, module_definition, port,
+            self.connect_input(module_definition, port,
                                output_ports)
 
-    def connect_input(self, definition, module_definition, port,
+    def connect_input(self, module_definition, port,
                       output_ports):
         if not port.isinput():
             if isinstance(port, TupleType):
                 for elem in port:
-                    self.connect_input(definition, module_definition, elem,
+                    self.connect_input(module_definition, elem,
                                        output_ports)
             return
-        output = port.value()
-        if not output:
-            error(repr(definition))
-            raise Exception(f"Output {port} of {definition.name} not connected.".format(port))
-        self.connect(module_definition, port, output, output_ports)
+        self.connect(module_definition, port, port.value(), output_ports)
 
     def compile_definition(self, definition):
         logger.debug(f"Compiling definition {definition}")

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -119,7 +119,7 @@ class CoreIRBackend:
                     return f"_{k}"
                 return k
             _type = self.context.Record({
-                to_string(k): self.get_type(t, is_input) for (k, t) in
+                to_string(k): self.get_type(t, t.isinput()) for (k, t) in
                 zip(port.Ks, port.Ts)
             })
         elif is_input:
@@ -178,7 +178,8 @@ class CoreIRBackend:
     def convert_interface_to_module_type(self, interface):
         args = OrderedDict()
         for name, port in interface.ports.items():
-            if not port.isinput() and not port.isoutput():
+            if not port.isinput() and not port.isoutput() and \
+                    not isinstance(port, TupleType):
                 raise NotImplementedError()
             args[name] = self.get_type(port, port.isinput())
         return self.context.Record(args)
@@ -218,11 +219,12 @@ class CoreIRBackend:
                     generator, gen_args, config_args)
 
     def add_output_port(self, output_ports, port):
-        output_ports[port] = magma_port_to_coreir(port)
-        if isinstance(port, ArrayType):
-            for element in port:
-                self.add_output_port(output_ports, element)
-        elif isinstance(port, TupleType):
+        if port.isoutput():
+            output_ports[port] = magma_port_to_coreir(port)
+            if isinstance(port, ArrayType):
+                for element in port:
+                    self.add_output_port(output_ports, element)
+        if isinstance(port, TupleType):
             for element in port:
                 self.add_output_port(output_ports, element)
 
@@ -250,8 +252,7 @@ class CoreIRBackend:
         output_ports = {}
         for name, port in definition.interface.ports.items():
             logger.debug(name, port, port.isoutput())
-            if port.isoutput():
-                self.add_output_port(output_ports, port)
+            self.add_output_port(output_ports, port)
 
         for instance in definition.instances:
             wiredefaultclock(definition, instance)
@@ -261,19 +262,31 @@ class CoreIRBackend:
                 coreir_instance.add_metadata("filename", make_relative(instance.filename))
                 coreir_instance.add_metadata("lineno", str(instance.lineno))
             for name, port in instance.interface.ports.items():
-                if port.isoutput():
-                    self.add_output_port(output_ports, port)
+                self.add_output_port(output_ports, port)
 
         for instance in definition.instances:
             for name, port in instance.interface.ports.items():
                 if port.isinput():
-                    self.connect(module_definition, port, port.value(), output_ports)
-        for input in definition.interface.inputs(include_clocks=True):
-            output = input.value()
-            if not output:
-                error(repr(definition))
-                raise Exception(f"Output {input} of {definition.name} not connected.".format(input))
-            self.connect(module_definition, input, output, output_ports)
+                    self.connect(module_definition, port, port.value(),
+                                 output_ports)
+
+        for port in definition.interface.ports.values():
+            self.connect_input(definition, module_definition, port,
+                               output_ports)
+
+    def connect_input(self, definition, module_definition, port,
+                      output_ports):
+        if not port.isinput():
+            if isinstance(port, TupleType):
+                for elem in port:
+                    self.connect_input(definition, module_definition, elem,
+                                       output_ports)
+            return
+        output = port.value()
+        if not output:
+            error(repr(definition))
+            raise Exception(f"Output {port} of {definition.name} not connected.".format(port))
+        self.connect(module_definition, port, output, output_ports)
 
     def compile_definition(self, definition):
         logger.debug(f"Compiling definition {definition}")

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -88,8 +88,11 @@ class TupleType(Type):
         #    print('Wiring error: Tuple elements must have the same type')
         #    return
 
-        for k in range(len(i)):
-            i[k].wire(o[k], debug_info)
+        for i_elem, o_elem in zip(i, o):
+            if o_elem.isinput():
+                o_elem.wire(i_elem, debug_info)
+            else:
+                i_elem.wire(o_elem, debug_info)
 
     def driven(self):
         for t in self.ts:

--- a/tests/test_coreir/gold/test_multi_direction_tuple.json
+++ b/tests/test_coreir/gold/test_multi_direction_tuple.json
@@ -1,0 +1,16 @@
+{"top":"global.Foo",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Foo":{
+        "type":["Record",[
+          ["ifc",["Record",[["I","BitIn"],["O","Bit"]]]]
+        ]],
+        "connections":[
+          ["self.ifc.O","self.ifc.I"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/gold/test_multi_direction_tuple_instance.json
+++ b/tests/test_coreir/gold/test_multi_direction_tuple_instance.json
@@ -1,0 +1,30 @@
+{"top":"global.bar",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Foo":{
+        "type":["Record",[
+          ["ifc",["Record",[["I","BitIn"],["O","Bit"]]]]
+        ]],
+        "connections":[
+          ["self.ifc.O","self.ifc.I"]
+        ]
+      },
+      "bar":{
+        "type":["Record",[
+          ["ifc",["Record",[["I","BitIn"],["O","Bit"]]]]
+        ]],
+        "instances":{
+          "inst0":{
+            "modref":"global.Foo"
+          }
+        },
+        "connections":[
+          ["self.ifc.I","inst0.ifc.I"],
+          ["self.ifc.O","inst0.ifc.O"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/gold/test_nesting.json
+++ b/tests/test_coreir/gold/test_nesting.json
@@ -1,0 +1,40 @@
+{"top":"global.bar",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Foo":{
+        "type":["Record",[
+          ["ifc",["Record",[["I","BitIn"],["O","Bit"]]]]
+        ]],
+        "connections":[
+          ["self.ifc.O","self.ifc.I"]
+        ]
+      },
+      "bar":{
+        "type":["Record",[
+          ["I",["Record",[["x",["Record",[["a","BitIn"],["b","BitIn"]]]],["y",["Record",[["a","Bit"],["b","Bit"]]]],["z",["Record",[["a","BitIn"],["b","Bit"]]]]]]]
+        ]],
+        "instances":{
+          "inst0":{
+            "modref":"global.Foo"
+          },
+          "inst1":{
+            "modref":"global.Foo"
+          },
+          "inst2":{
+            "modref":"global.Foo"
+          }
+        },
+        "connections":[
+          ["self.I.x.a","inst0.ifc.I"],
+          ["self.I.y.a","inst0.ifc.O"],
+          ["self.I.x.b","inst1.ifc.I"],
+          ["self.I.y.b","inst1.ifc.O"],
+          ["self.I.z.a","inst2.ifc.I"],
+          ["self.I.z.b","inst2.ifc.O"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/test_coreir_tuple.py
+++ b/tests/test_coreir/test_coreir_tuple.py
@@ -33,5 +33,17 @@ def test_multi_direction_tuple_instance():
     assert check_files_equal(__file__, f"build/test_multi_direction_tuple_instance.json",
                              f"gold/test_multi_direction_tuple_instance.json")
 
+
+def test_multi_direction_tuple_instance_bulk():
+    bar = m.DefineCircuit("bar", "ifc", m.Tuple(I=m.In(m.Bit), O=m.Out(m.Bit)))
+    foo_inst = def_foo()()
+    m.wire(bar.ifc, foo_inst.ifc)
+    m.EndCircuit()
+
+    m.compile("build/test_multi_direction_tuple_instance_bulk", bar, output="coreir")
+    # NOTE: Should be the same as previous test, so we use that as a check
+    assert check_files_equal(__file__, f"build/test_multi_direction_tuple_instance_bulk.json",
+                             f"gold/test_multi_direction_tuple_instance.json")
+
 if __name__ == "__main__":
     test_multi_direction_tuple()

--- a/tests/test_coreir/test_coreir_tuple.py
+++ b/tests/test_coreir/test_coreir_tuple.py
@@ -45,5 +45,24 @@ def test_multi_direction_tuple_instance_bulk():
     assert check_files_equal(__file__, f"build/test_multi_direction_tuple_instance_bulk.json",
                              f"gold/test_multi_direction_tuple_instance.json")
 
+def test_nesting():
+    bar = m.DefineCircuit("bar", "I", m.Tuple(x=m.In(m.Tuple(a=m.Bit, b=m.Bit)),
+                                              y=m.Out(m.Tuple(a=m.Bit, b=m.Bit)),
+                                              z=m.Tuple(a=m.In(m.Bit), b=m.Out(m.Bit))))
+    foo = def_foo()
+    foo_inst0 = foo()
+    foo_inst1 = foo()
+    foo_inst2 = foo()
+    m.wire(foo_inst0.ifc.I, bar.I.x.a)
+    m.wire(foo_inst0.ifc.O, bar.I.y.a)
+    m.wire(foo_inst1.ifc.I, bar.I.x.b)
+    m.wire(foo_inst1.ifc.O, bar.I.y.b)
+    m.wire(foo_inst2.ifc.I, bar.I.z.a)
+    m.wire(foo_inst2.ifc.O, bar.I.z.b)
+    m.EndCircuit()
+    m.compile("build/test_nesting", bar, output="coreir")
+    assert check_files_equal(__file__, f"build/test_nesting.json",
+                             f"gold/test_nesting.json")
+
 if __name__ == "__main__":
     test_multi_direction_tuple()

--- a/tests/test_coreir/test_coreir_tuple.py
+++ b/tests/test_coreir/test_coreir_tuple.py
@@ -2,11 +2,15 @@ import magma as m
 from magma.testing import check_files_equal
 
 
-def test_multi_direction_tuple():
+def def_foo():
     foo = m.DefineCircuit("Foo", "ifc", m.Tuple(I=m.In(m.Bit), O=m.Out(m.Bit)))
     m.wire(foo.ifc.I, foo.ifc.O)
     m.EndCircuit()
+    return foo
 
+
+def test_multi_direction_tuple():
+    foo = def_foo()
     m.compile("build/test_multi_direction_tuple", foo, output="coreir")
     assert check_files_equal(__file__, f"build/test_multi_direction_tuple.json",
                              f"gold/test_multi_direction_tuple.json")
@@ -16,6 +20,18 @@ def test_multi_direction_tuple():
 
     assert [T.isinput() for T in foo.IO.ports["ifc"].Ts] == \
            [True, False]
+
+
+def test_multi_direction_tuple_instance():
+    bar = m.DefineCircuit("bar", "ifc", m.Tuple(I=m.In(m.Bit), O=m.Out(m.Bit)))
+    foo_inst = def_foo()()
+    m.wire(bar.ifc.I, foo_inst.ifc.I)
+    m.wire(bar.ifc.O, foo_inst.ifc.O)
+    m.EndCircuit()
+
+    m.compile("build/test_multi_direction_tuple_instance", bar, output="coreir")
+    assert check_files_equal(__file__, f"build/test_multi_direction_tuple_instance.json",
+                             f"gold/test_multi_direction_tuple_instance.json")
 
 if __name__ == "__main__":
     test_multi_direction_tuple()

--- a/tests/test_coreir/test_coreir_tuple.py
+++ b/tests/test_coreir/test_coreir_tuple.py
@@ -1,0 +1,21 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_multi_direction_tuple():
+    foo = m.DefineCircuit("Foo", "ifc", m.Tuple(I=m.In(m.Bit), O=m.Out(m.Bit)))
+    m.wire(foo.ifc.I, foo.ifc.O)
+    m.EndCircuit()
+
+    m.compile("build/test_multi_direction_tuple", foo, output="coreir")
+    assert check_files_equal(__file__, f"build/test_multi_direction_tuple.json",
+                             f"gold/test_multi_direction_tuple.json")
+
+    assert [T.isinput() for T in foo.interface.ports["ifc"].Ts] == \
+           [False, True]
+
+    assert [T.isinput() for T in foo.IO.ports["ifc"].Ts] == \
+           [True, False]
+
+if __name__ == "__main__":
+    test_multi_direction_tuple()


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/241

@rsetaluri check out the test in tests/test_coreir/test_coreir_tuple.py which checks compiling and also inspecting the interface/IO, the output files are
* tests/test_coreir/gold/test_multi_direction_tuple.json
* tests/test_coreir/build/test_multi_direction_tuple_instance.json (checks that instances with these multi directional tuples works as well, not just in the definition signature)

The issue was that the `parse` code in Interface was not properly flipping the tuple type. It assumes that the top level type is either an input or an output, and flips it for definitions. I changed the code to just use the `.flip()` method, which works for tuples with multi directional elements.

I also had to update the coreir backend to properly handle IO ports that may not be inputs or outputs at the top level.
