### PR TITLE
Escape dir name when splitting files

### DIFF
--- a/magma/compile.py
+++ b/magma/compile.py
@@ -77,7 +77,7 @@ def __compile_to_coreir(main, file_name, opts):
         cmd = f"coreir {lib_arg} -i {file_name}.json"
         if opts.get("split", ""):
             split = opts["split"]
-            cmd += f" -o {split}/*.v -s"
+            cmd += f" -o \"{split}/*.v\" -s"
         else:
             cmd += f" -o {file_name}.v"
         subprocess.run(cmd, shell=True)


### PR DESCRIPTION
This fixes an issue, where if the directory where split files should go
already exists and contains verilog files, then those are picked up in
bash glob, rather than passing the string `"<dir>/*.v"` directly. Now,
when issuing the CoreIR command we escape this string.