### PR TITLE
Add check for clock type in CoreIR compilation

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -210,6 +210,8 @@ class CoreIRBackend:
             for name, value in type(instance).coreir_genargs.items():
                 if isinstance(value, AsyncResetKind):
                     value = self.context.named_types["coreir", "arst"]
+                elif isinstance(value, ClockKind):
+                    value = self.context.named_types["coreir", "clk"]
                 gen_args[name] = value
             gen_args = self.context.new_values(gen_args)
             return module_definition.add_generator_instance(instance.name,

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -2,8 +2,8 @@ import pytest
 import tempfile
 from magma import In, Out, Flip, \
     Clock, ClockType, ClockKind, \
-    Reset, ResetType, ResetKind, reset \
-    Enable, EnableType, EnableKind, enable \
+    Reset, ResetType, ResetKind, reset, \
+    Enable, EnableType, EnableKind, enable, \
     AsyncReset, AsyncResetType, AsyncResetKind, \
     DeclareCircuit, DefineCircuit, EndCircuit, \
     Bit, bit, wire, compile

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -2,8 +2,8 @@ import pytest
 import tempfile
 from magma import In, Out, Flip, \
     Clock, ClockType, ClockKind, \
-    Reset, ResetType, ResetKind, \
-    Enable, EnableType, EnableKind, \
+    Reset, ResetType, ResetKind, reset \
+    Enable, EnableType, EnableKind, enable \
     AsyncReset, AsyncResetType, AsyncResetKind, \
     DeclareCircuit, DefineCircuit, EndCircuit, \
     Bit, bit, wire, compile
@@ -152,5 +152,25 @@ def test_coreir_wrap(T):
         compile(filename, top, output="coreir")
         got = open(f"{filename}.json").read()
     expected_filename = f"tests/test_type/test_coreir_wrap_golden_{T}.json"
+    expected = open(expected_filename).read()
+    assert got == expected
+
+
+@pytest.mark.parametrize("T,t", [(Reset, reset), (Enable, enable)])
+def test_const_wire(T, t):
+    foo = DefineCircuit("foo", "I", In(T))
+    EndCircuit()
+
+    top = DefineCircuit("top", "O", Out(Bit))
+    foo_inst = foo()
+    wire(t(0), foo_inst.I)
+    wire(bit(0), top.O)
+    EndCircuit()
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        filename = f"{tempdir}/top"
+        compile(filename, top, output="coreir")
+        got = open(f"{filename}.json").read()
+    expected_filename = f"tests/test_type/test_const_wire_golden.json"
     expected = open(expected_filename).read()
     assert got == expected

--- a/tests/test_type/test_const_wire_golden.json
+++ b/tests/test_type/test_const_wire_golden.json
@@ -1,0 +1,31 @@
+{"top":"global.top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "foo":{
+        "type":["Record",[
+          ["I","BitIn"]
+        ]]
+      },
+      "top":{
+        "type":["Record",[
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "bit_const_0_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",false]}
+          },
+          "inst0":{
+            "modref":"global.foo"
+          }
+        },
+        "connections":[
+          ["inst0.I","bit_const_0_None.out"],
+          ["self.O","bit_const_0_None.out"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_type/test_coreir_wrap_golden.json
+++ b/tests/test_type/test_coreir_wrap_golden.json
@@ -1,0 +1,35 @@
+{"top":"global.top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "foo":{
+        "type":["Record",[
+          ["r",["Named","coreir.arstIn"]]
+        ]]
+      },
+      "top":{
+        "type":["Record",[
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "bit_const_0_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",false]}
+          },
+          "inst0":{
+            "modref":"global.foo"
+          },
+          "inst1":{
+            "genref":"coreir.wrap",
+            "genargs":{"type":["CoreIRType",["Named","coreir.arst"]]}
+          }
+        },
+        "connections":[
+          ["inst1.in","bit_const_0_None.out"],
+          ["self.O","bit_const_0_None.out"],
+          ["inst1.out","inst0.r"]
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_type/test_coreir_wrap_golden_AsyncReset.json
+++ b/tests/test_type/test_coreir_wrap_golden_AsyncReset.json
@@ -1,0 +1,36 @@
+{"top":"global.top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "foo":{
+        "type":["Record",[
+          ["r",["Named","coreir.arstIn"]]
+        ]]
+      },
+      "top":{
+        "type":["Record",[
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "bit_const_0_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",false]}
+          },
+          "inst0":{
+            "modref":"global.foo"
+          },
+          "inst1":{
+            "genref":"coreir.wrap",
+            "genargs":{"type":["CoreIRType",["Named","coreir.arst"]]}
+          }
+        },
+        "connections":[
+          ["inst1.in","bit_const_0_None.out"],
+          ["self.O","bit_const_0_None.out"],
+          ["inst1.out","inst0.r"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_type/test_coreir_wrap_golden_Clock.json
+++ b/tests/test_type/test_coreir_wrap_golden_Clock.json
@@ -1,0 +1,36 @@
+{"top":"global.top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "foo":{
+        "type":["Record",[
+          ["r",["Named","coreir.clkIn"]]
+        ]]
+      },
+      "top":{
+        "type":["Record",[
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "bit_const_0_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",false]}
+          },
+          "inst0":{
+            "modref":"global.foo"
+          },
+          "inst1":{
+            "genref":"coreir.wrap",
+            "genargs":{"type":["CoreIRType",["Named","coreir.clk"]]}
+          }
+        },
+        "connections":[
+          ["inst1.in","bit_const_0_None.out"],
+          ["self.O","bit_const_0_None.out"],
+          ["inst1.out","inst0.r"]
+        ]
+      }
+    }
+  }
+}
+}


### PR DESCRIPTION
Similar to what we do for AysncReset types, we make a special case to be
able to wire constants to clocks.