### PR TITLE
Emit verilog with coreir backend when using coreir output with coreir mantle target

### DIFF
--- a/magma/compile.py
+++ b/magma/compile.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import inspect
 import subprocess
@@ -89,9 +90,13 @@ def __compile_to_coreir(main, file_name, opts):
 def compile(basename, main, output='verilog', **kwargs):
     opts = kwargs.copy()
 
+    mantle_imported = "mantle" in sys.modules
+
     # Rather than having separate logic for 'coreir-verilog' mode, we defer to
     # 'coreir' mode with the 'output_verilog' option set to True.
-    if output == 'coreir-verilog' or (output == "verilog" and m.mantle_target == "coreir"):
+    if output == 'coreir-verilog' or \
+            (output == "verilog" and m.mantle_target == "coreir" and
+             mantle_imported):
         opts["output_verilog"] = True
         output = "coreir"
 

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -7,6 +7,7 @@ from .backend import verilog, blif, firrtl, dot
 from .config import get_compile_dir
 from .logging import error
 from .circuit import isdefinition
+import magma as m
 
 __all__ = ['compile']
 
@@ -90,7 +91,7 @@ def compile(basename, main, output='verilog', **kwargs):
 
     # Rather than having separate logic for 'coreir-verilog' mode, we defer to
     # 'coreir' mode with the 'output_verilog' option set to True.
-    if output == 'coreir-verilog':
+    if output == 'coreir-verilog' or (output == "verilog" and m.mantle_target == "coreir"):
         opts["output_verilog"] = True
         output = "coreir"
 

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -90,13 +90,16 @@ def __compile_to_coreir(main, file_name, opts):
 def compile(basename, main, output='verilog', **kwargs):
     opts = kwargs.copy()
 
+    # If the output is verilog and mantle has been imported and we're using the
+    # coreir mantle target, use coreir to generate verilog by setting the output
+    # to coreir-verilog
     mantle_imported = "mantle" in sys.modules
+    if output == "verilog" and m.mantle_target == "coreir" and mantle_imported:
+        output == 'coreir-verilog'
 
     # Rather than having separate logic for 'coreir-verilog' mode, we defer to
     # 'coreir' mode with the 'output_verilog' option set to True.
-    if output == 'coreir-verilog' or \
-            (output == "verilog" and m.mantle_target == "coreir" and
-             mantle_imported):
+    if output == 'coreir-verilog':
         opts["output_verilog"] = True
         output = "coreir"
 

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -8,6 +8,7 @@ from .backend import verilog, blif, firrtl, dot
 from .config import get_compile_dir
 from .logging import error
 from .circuit import isdefinition
+from .logging import info
 import magma as m
 
 __all__ = ['compile']
@@ -95,7 +96,10 @@ def compile(basename, main, output='verilog', **kwargs):
     # to coreir-verilog
     mantle_imported = "mantle" in sys.modules
     if output == "verilog" and m.mantle_target == "coreir" and mantle_imported:
-        output == 'coreir-verilog'
+        info("`m.compile` called with `output == verilog` and `m.mantle_target"
+             " == \"coreir\" and mantle has been imported, using coreir to"
+             " generate verilog (setting output to \"coreir-verilog\").`")
+        output = 'coreir-verilog'
 
     # Rather than having separate logic for 'coreir-verilog' mode, we defer to
     # 'coreir' mode with the 'output_verilog' option set to True.

--- a/magma/logging.py
+++ b/magma/logging.py
@@ -31,7 +31,7 @@ handler.setFormatter(colorlog.ColoredFormatter(
 log.addHandler(handler)
 
 
-level = os.getenv("MAGMA_LOG_LEVEL", None)
+level = os.getenv("MAGMA_LOG_LEVEL", "INFO")
 if level in ["DEBUG", "WARN", "INFO"]:
     log.setLevel(getattr(logging, level))
 elif level is not None:

--- a/tests/gold/test_coreir_compile_verilog.v
+++ b/tests/gold/test_coreir_compile_verilog.v
@@ -1,0 +1,23 @@
+//Module: And2 defined externally
+
+
+module main (
+  input [1:0] I,
+  output  O
+);
+  //Wire declarations for instance 'inst0' (Module And2)
+  wire  inst0__I0;
+  wire  inst0__I1;
+  wire  inst0__O;
+  And2 inst0(
+    .I0(inst0__I0),
+    .I1(inst0__I1),
+    .O(inst0__O)
+  );
+
+  //All the connections
+  assign inst0__I0 = I[0];
+  assign inst0__I1 = I[1];
+  assign O = inst0__O;
+
+endmodule //main

--- a/tests/test_compile_coreir_verilog.py
+++ b/tests/test_compile_coreir_verilog.py
@@ -5,7 +5,7 @@ import magma as m
 m.set_mantle_target("coreir")
 
 
-def test():
+def test(caplog):
     And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                             "O", m.Out(m.Bit))
 
@@ -23,3 +23,4 @@ def test():
     del sys.modules['mantle']
     assert check_files_equal(__file__, "build/test_coreir_compile_verilog.v",
                              "gold/test_coreir_compile_verilog.v")
+    assert caplog.records[0].msg == "`m.compile` called with `output == verilog` and `m.mantle_target == \"coreir\" and mantle has been imported, using coreir to generate verilog (setting output to \"coreir-verilog\").`"

--- a/tests/test_compile_coreir_verilog.py
+++ b/tests/test_compile_coreir_verilog.py
@@ -1,0 +1,22 @@
+import os
+from magma.testing.utils import check_files_equal
+import magma as m
+m.set_mantle_target("coreir")
+
+
+def test():
+    And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
+                            "O", m.Out(m.Bit))
+
+    main = m.DefineCircuit("main", "I", m.In(m.Bits(2)), "O", m.Out(m.Bit))
+
+    and2 = And2()
+
+    m.wire(main.I[0], and2.I0)
+    m.wire(main.I[1], and2.I1)
+    m.wire(and2.O, main.O)
+
+    m.EndCircuit()
+    m.compile("build/test_coreir_compile_verilog", main)
+    assert check_files_equal(__file__, "build/test_coreir_compile_verilog.v",
+                             "gold/test_coreir_compile_verilog.v")

--- a/tests/test_compile_coreir_verilog.py
+++ b/tests/test_compile_coreir_verilog.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from magma.testing.utils import check_files_equal
 import magma as m
@@ -17,6 +18,8 @@ def test():
     m.wire(and2.O, main.O)
 
     m.EndCircuit()
+    sys.modules['mantle'] = True  # Mock mantle import
     m.compile("build/test_coreir_compile_verilog", main)
+    del sys.modules['mantle']
     assert check_files_equal(__file__, "build/test_coreir_compile_verilog.v",
                              "gold/test_coreir_compile_verilog.v")


### PR DESCRIPTION
This avoids unexpected behavior when trying to compile with the default output (verilog) and the default mantle target (coreir). If the user requests verilog when the mantle target is coreir, it will now use coreir to output verilog