### PR TITLE
Change enum implementation to return a type

### DIFF
--- a/magma/enum.py
+++ b/magma/enum.py
@@ -1,2 +1,8 @@
-class Enum:
-    pass
+import magma as m
+
+def Enum(**kwargs):
+    num_bits = max((len(kwargs) - 1).bit_length(), 1)
+    type_ = m.Bits(num_bits)
+    for key, value in kwargs.items():
+        setattr(type_, key, value)
+    return type_

--- a/magma/enum.py
+++ b/magma/enum.py
@@ -1,7 +1,8 @@
 import magma as m
 
 def Enum(**kwargs):
-    num_bits = max((len(kwargs) - 1).bit_length(), 1)
+    max_value = max(value for value in kwargs.values())
+    num_bits = max(max_value.bit_length(), 1)
     type_ = m.Bits(num_bits)
     for key, value in kwargs.items():
         setattr(type_, key, value)

--- a/tests/test_type/gold/test_enum.v
+++ b/tests/test_type/gold/test_enum.v
@@ -1,0 +1,25 @@
+
+
+module coreir_const #(parameter value=1, parameter width=1) (
+  output [width-1:0] out
+);
+  assign out = value;
+
+endmodule //coreir_const
+
+module enum_test (
+  input [1:0] I,
+  output [1:0] O_0,
+  output [1:0] O_1
+);
+  //Wire declarations for instance 'const_0_2' (Module coreir_const)
+  wire [1:0] const_0_2__out;
+  coreir_const #(.value(2'b00),.width(2)) const_0_2(
+    .out(const_0_2__out)
+  );
+
+  //All the connections
+  assign O_1[1:0] = const_0_2__out[1:0];
+  assign O_0[1:0] = I[1:0];
+
+endmodule //enum_test

--- a/tests/test_type/gold/test_enum_max_value.v
+++ b/tests/test_type/gold/test_enum_max_value.v
@@ -1,0 +1,25 @@
+
+
+module coreir_const #(parameter value=1, parameter width=1) (
+  output [width-1:0] out
+);
+  assign out = value;
+
+endmodule //coreir_const
+
+module enum_test_max_value (
+  input [2:0] I,
+  output [2:0] O_0,
+  output [2:0] O_1
+);
+  //Wire declarations for instance 'const_4_3' (Module coreir_const)
+  wire [2:0] const_4_3__out;
+  coreir_const #(.value(3'b100),.width(3)) const_4_3(
+    .out(const_4_3__out)
+  );
+
+  //All the connections
+  assign O_1[2:0] = const_4_3__out[2:0];
+  assign O_0[2:0] = I[2:0];
+
+endmodule //enum_test_max_value

--- a/tests/test_type/test_enum.py
+++ b/tests/test_type/test_enum.py
@@ -1,0 +1,16 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_enum():
+    State = m.Enum(
+        zero=0,
+        one=1,
+        two=2
+    )
+    circuit = m.DefineCircuit('enum_test', "I", m.In(State), "O", m.Out(m.Array(2, State)))
+    m.wire(circuit.I, circuit.O[0])
+    m.wire(State.zero, circuit.O[1])
+    m.EndDefine()
+    m.compile("build/test_enum", circuit, output="coreir-verilog")
+    check_files_equal(__file__, "build/test_enum.v", "gold/test_enum.v")

--- a/tests/test_type/test_enum.py
+++ b/tests/test_type/test_enum.py
@@ -13,4 +13,18 @@ def test_enum():
     m.wire(State.zero, circuit.O[1])
     m.EndDefine()
     m.compile("build/test_enum", circuit, output="coreir-verilog")
-    check_files_equal(__file__, "build/test_enum.v", "gold/test_enum.v")
+    assert check_files_equal(__file__, "build/test_enum.v", "gold/test_enum.v")
+
+
+def test_enum_max_value():
+    State = m.Enum(
+        zero=0,
+        one=1,
+        four=4
+    )
+    circuit = m.DefineCircuit('enum_test_max_value', "I", m.In(State), "O", m.Out(m.Array(2, State)))
+    m.wire(circuit.I, circuit.O[0])
+    m.wire(State.four, circuit.O[1])
+    m.EndDefine()
+    m.compile("build/test_enum_max_value", circuit, output="coreir-verilog")
+    assert check_files_equal(__file__, "build/test_enum_max_value.v", "gold/test_enum_max_value.v")


### PR DESCRIPTION
This constructs a type (of type Bits) for an enum. It determines the width based on the max value of the enum values (passed as kwargs).

It also sets the enum names on the constructed Bits object so the user can reference them.