### PR TITLE
Adding Second VerifyConnectivity To Fix Aetherling Unit Tests

### DIFF
--- a/magma/simulator/coreir_simulator.py
+++ b/magma/simulator/coreir_simulator.py
@@ -135,7 +135,7 @@ class CoreIRSimulator(CircuitSimulator):
         self.ctx.enable_symbol_table()
         coreir_circuit = self.ctx.load_from_file(coreir_filename)
         self.ctx.run_passes(["rungenerators", "wireclocks-coreir", "verifyconnectivity --noclkrst",
-                             "flattentypes", "flatten", "deletedeadinstances"],
+                             "flattentypes", "flatten", "verifyconnectivity --noclkrst", "deletedeadinstances"],
                             namespaces=namespaces)
         self.simulator_state = coreir.SimulatorState(coreir_circuit)
 


### PR DESCRIPTION
@rdaly525 For some reason, removing the second verifyconnectivity pass causes https://github.com/David-Durst/aetherling/blob/6c4cf43d5cb0494229367b1441453eeb2c8cc3a3/tests/test_native_2d_line_buffer.py#L474-L482 to fail following with the following error. This is weird as the unconnected wire issue appears only the second time that the circuit runs through the simulator. It's weird because:

1. If everything is wired up correctly the first time, shouldn't the circuit be wired up correctly the second time?
2. Aren't the verifyconnectivity passes stateless? Shouldn't adding them not change the graph

```
Testing started at 3:14 PM ...
/Users/durst/anaconda/envs/aetherling/bin/python "/Users/durst/Library/Application Support/JetBrains/Toolbox/apps/PyCharm-P/ch-0/182.4505.26/PyCharm.app/Contents/helpers/pycharm/_jb_pytest_runner.py" --target test_native_2d_line_buffer.py::test_2D_bit_line_buffer_1_1_3_3_5_5_1_1_0_0 -- -s
Launching pytest with arguments -s test_native_2d_line_buffer.py::test_2D_bit_line_buffer_1_1_3_3_5_5_1_1_0_0 in /Users/durst/dev/W17-8/aetherling/tests

============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.4.2, py-1.5.2, pluggy-0.6.0
rootdir: /Users/durst/dev/W17-8/aetherling, inifile:
plugins: xdist-1.22.5, forked-0.2
collected 1 item
test_native_2d_line_buffer.py {'pixel_type': Bit, 'pixels_per_row_per_clock': 1, 'rows_of_pixels_per_clock': 1, 'window_cols': 3, 'window_rows': 3, 'image_cols': 5, 'image_rows': 5, 'stride_cols': 1, 'stride_rows': 1, 'origin_cols': 0, 'origin_rows': 0}
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=1
Numargs=1
Numargs=1
Numargs=2
Numargs=1
Numargs=1
Numargs=1
Numargs=1
Numargs=1
Numargs=1
Numargs=1
Numargs=1
Numargs=1
Found raddr
Found raddr
Starting topological sort
topo_order.size() = 120
numVertices(g)    = 120
{'pixel_type': Bit, 'pixels_per_row_per_clock': 1, 'rows_of_pixels_per_clock': 1, 'window_cols': 3, 'window_rows': 3, 'image_cols': 5, 'image_rows': 5, 'stride_cols': 1, 'stride_rows': 1, 'origin_cols': 0, 'origin_rows': 0}
Actual:  [[[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, True], [False, False, False], [False, False, False]]], [[[False, True, False], [False, False, False], [False, False, False]]], [[[True, False, None], [False, False, None], [False, False, None]]], [[[False, None, None], [False, None, None], [False, None, None]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, None], [False, False, None], [False, False, None]]], [[[False, None, None], [False, None, None], [False, None, None]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, None], [False, False, None], [False, False, None]]], [[[False, None, None], [False, None, None], [False, None, None]]], [[[False, False, False], [False, False, False], [None, None, None]]], [[[False, False, False], [False, False, False], [None, None, None]]], [[[False, False, False], [False, False, False], [None, None, None]]], [[[False, False, None], [False, False, None], [None, None, None]]], [[[False, None, None], [False, None, None], [None, None, None]]], [[[False, False, False], [None, None, None], [None, None, None]]], [[[False, False, False], [None, None, None], [None, None, None]]], [[[False, False, False], [None, None, None], [None, None, None]]], [[[False, False, None], [None, None, None], [None, None, None]]], [[[False, None, None], [None, None, None], [None, None, None]]]] 
Expected:  [[[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, True], [False, False, False], [False, False, False]]], [[[False, True, False], [False, False, False], [False, False, False]]], [[[True, False, None], [False, False, None], [False, False, None]]], [[[False, None, None], [False, None, None], [False, None, None]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, None], [False, False, None], [False, False, None]]], [[[False, None, None], [False, None, None], [False, None, None]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, False], [False, False, False], [False, False, False]]], [[[False, False, None], [False, False, None], [False, False, None]]], [[[False, None, None], [False, None, None], [False, None, None]]], [[[False, False, False], [False, False, False], [None, None, None]]], [[[False, False, False], [False, False, False], [None, None, None]]], [[[False, False, False], [False, False, False], [None, None, None]]], [[[False, False, None], [False, False, None], [None, None, None]]], [[[False, None, None], [False, None, None], [None, None, None]]], [[[False, False, False], [None, None, None], [None, None, None]]], [[[False, False, False], [None, None, None], [None, None, None]]], [[[False, False, False], [None, None, None], [None, None, None]]], [[[False, False, None], [None, None, None], [None, None, None]]], [[[False, None, None], [None, None, None], [None, None, None]]]] 
Numargs=1
Numargs=1
In Run Generators
Done running generators
Numargs=1
Numargs=2
  Def:
    Instances:
    Connections:
      self.in_data_0 <=> self.out

ERROR: {muxn}.self.in_sel[0] Is not connected
with params=(N:1, width:1)


I AM DYING!
Assertion failed: (0), function die, file context.cpp, line 112.

Process finished with exit code 134 (interrupted by signal 6: SIGABRT)
```