### PR TITLE
Fix coerir add_metadata calls

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -17,6 +17,7 @@ from .util import make_relative, get_codegen_debug_info
 from ..interface import InterfaceKind
 import inspect
 import copy
+import json
 
 from collections import defaultdict
 
@@ -246,8 +247,8 @@ class CoreIRBackend:
         coreir_module = self.context.global_namespace.new_module(declaration.coreir_name,
                                                                  module_type)
         if get_codegen_debug_info() and declaration.debug_info:
-            coreir_module.add_metadata("filename", make_relative(declaration.debug_info.filename))
-            coreir_module.add_metadata("lineno", str(declaration.debug_info.lineno))
+            coreir_module.add_metadata("filename", json.dumps(make_relative(declaration.debug_info.filename)))
+            coreir_module.add_metadata("lineno", json.dumps(str(declaration.debug_info.lineno)))
         return coreir_module
 
     def compile_definition_to_module_definition(self, definition, module_definition):
@@ -263,8 +264,8 @@ class CoreIRBackend:
             wireclock(definition, instance)
             coreir_instance = self.compile_instance(instance, module_definition)
             if get_codegen_debug_info() and instance.debug_info:
-                coreir_instance.add_metadata("filename", make_relative(instance.debug_info.filename))
-                coreir_instance.add_metadata("lineno", str(instance.debug_info.lineno))
+                coreir_instance.add_metadata("filename", json.dumps(make_relative(instance.debug_info.filename)))
+                coreir_instance.add_metadata("lineno", json.dumps(str(instance.debug_info.lineno)))
             for name, port in instance.interface.ports.items():
                 self.add_output_port(output_ports, port)
 
@@ -295,8 +296,8 @@ class CoreIRBackend:
         module_type = self.convert_interface_to_module_type(definition.interface)
         coreir_module = self.context.global_namespace.new_module(definition.coreir_name, module_type)
         if get_codegen_debug_info() and definition.debug_info:
-            coreir_module.add_metadata("filename", make_relative(definition.debug_info.filename))
-            coreir_module.add_metadata("lineno", str(definition.debug_info.lineno))
+            coreir_module.add_metadata("filename", json.dumps(make_relative(definition.debug_info.filename)))
+            coreir_module.add_metadata("lineno", json.dumps(str(definition.debug_info.lineno)))
         module_definition = coreir_module.new_definition()
         self.compile_definition_to_module_definition(definition, module_definition)
         coreir_module.definition = module_definition
@@ -345,8 +346,8 @@ class CoreIRBackend:
         sink = module_definition.select(magma_port_to_coreir(port))
         module_definition.connect(source, sink)
         if get_codegen_debug_info() and hasattr(port, "debug_info"):
-            module_definition.add_metadata(source, sink, "filename", make_relative(port.debug_info.filename))
-            module_definition.add_metadata(source, sink, "lineno", str(port.debug_info.lineno))
+            module_definition.add_metadata(source, sink, "filename", json.dumps(make_relative(port.debug_info.filename)))
+            module_definition.add_metadata(source, sink, "lineno", json.dumps(str(port.debug_info.lineno)))
 
 
     __unique_constant_id = -1


### PR DESCRIPTION
The new add_metadata API in CoreIR expects data parseable as json. We
now pass everything through json.dumps().