### PR TITLE
Fix issue with list of port declarations

### DIFF
--- a/magma/fromverilog.py
+++ b/magma/fromverilog.py
@@ -94,14 +94,18 @@ def ParseVerilogModule(node, type_map):
     if ports:
         assert not args, "Can we have mixed declared and undeclared types in a Verilog module?"
         for port in ports:
+            found = False
             for child in node.children():
                 if isinstance(child, Decl):
-                    first_child = child.children()[0]
-                    if isinstance(first_child, (parser.Input, parser.Output, parser.Inout)) and \
-                            first_child.name == port:
-                        args.append(first_child.name)
-                        args.append(get_type(first_child, type_map))
-                        break
+                    for sub_child in child.children():
+                        if isinstance(sub_child, (parser.Input, parser.Output, parser.Inout)) and \
+                                sub_child.name == port:
+                            args.append(sub_child.name)
+                            args.append(get_type(sub_child, type_map))
+                            found = True
+                            break
+                if found:
+                    break
             else:
                 raise Exception(f"Could not find type declaration for port {port}")
 

--- a/tests/test_verilog/decl_list.v
+++ b/tests/test_verilog/decl_list.v
@@ -1,0 +1,15 @@
+module memory_core(clk_in, clk_en, reset, config_addr, config_data,
+     config_read, config_write, config_en, config_en_sram,
+     config_en_linebuf, data_in, data_out, wen_in, ren_in, valid_out,
+     chain_in, chain_out, chain_wen_in, chain_valid_out, almost_full,
+     almost_empty, addr_in, read_data, read_data_sram,
+     read_data_linebuf, flush);
+  input clk_in, clk_en, reset, config_read, config_write, config_en,
+       config_en_linebuf, wen_in, ren_in, chain_wen_in, flush;
+  input [31:0] config_addr, config_data;
+  input [3:0] config_en_sram;
+  input [15:0] data_in, chain_in, addr_in;
+  output [15:0] data_out, chain_out;
+  output valid_out, chain_valid_out, almost_full, almost_empty;
+  output [31:0] read_data, read_data_sram, read_data_linebuf;
+endmodule

--- a/tests/test_verilog/test_from_file.py
+++ b/tests/test_verilog/test_from_file.py
@@ -59,3 +59,15 @@ def test_coreir_compilation():
 
     assert m.testing.check_files_equal(
         __file__, "build/test_rxmod_top.json", "gold/test_rxmod_top.json")
+
+
+def test_decl_list():
+    file_path = os.path.dirname(__file__)
+    type_map = {"clk_in"    : m.In(m.Clock),
+                "reset"     : m.In(m.AsyncReset),
+                "config_en" : m.In(m.Enable),
+                "clk_en"    : m.In(m.Enable)}
+    memory_core = m.DefineFromVerilogFile(
+        os.path.join(file_path, "decl_list.v"), target_modules=["memory_core"],
+        type_map=type_map)[0]
+    assert str(memory_core) == "memory_core(clk_in: In(Clock), clk_en: In(Enable), reset: In(AsyncReset), config_addr: In(Bits(32)), config_data: In(Bits(32)), config_read: In(Bit), config_write: In(Bit), config_en: In(Enable), config_en_sram: In(Bits(4)), config_en_linebuf: In(Bit), data_in: In(Bits(16)), data_out: Out(Bits(16)), wen_in: In(Bit), ren_in: In(Bit), valid_out: Out(Bit), chain_in: In(Bits(16)), chain_out: Out(Bits(16)), chain_wen_in: In(Bit), chain_valid_out: Out(Bit), almost_full: Out(Bit), almost_empty: Out(Bit), addr_in: In(Bits(16)), read_data: Out(Bits(32)), read_data_sram: Out(Bits(32)), read_data_linebuf: Out(Bits(32)), flush: In(Bit))"


### PR DESCRIPTION
This is a hotfix for an issue with importing verilog that uses a list of declarations of the following format
```
input clk_in, clk_en, reset, config_read, config_write, config_en,
       config_en_linebuf, wen_in, ren_in, chain_wen_in, flush;
```

In the old code, we were assuming that a declaration of the form `input <port_name>` only had one port, but in Verilog it's possible to list the ports as shown above. This patch updates the behavior to traverse all the children of the declaration AST node (part of the logic used for getting the types of ports listed in the module declaration). 