### PR TITLE
Support Tuple return value in Verilog backend

### DIFF
--- a/magma/ref.py
+++ b/magma/ref.py
@@ -77,7 +77,7 @@ class TupleRef(Ref):
        return self.qualifiedname()
 
    def qualifiedname(self, sep='.'):
-       return self.tuple.name.qualifiedname(sep=sep) + '.' + str(self.index)
+       return self.tuple.name.qualifiedname(sep=sep) + sep + str(self.index)
 
    def anon(self):
        return self.tuple.name.anon()

--- a/tests/gold/return_magma_named_tuple.v
+++ b/tests/gold/return_magma_named_tuple.v
@@ -1,0 +1,5 @@
+module return_magma_named_tuple (input [1:0] I, output  O_x, output  O_y);
+assign O_x = I[0];
+assign O_y = I[1];
+endmodule
+

--- a/tests/gold/return_magma_tuple.v
+++ b/tests/gold/return_magma_tuple.v
@@ -1,0 +1,5 @@
+module return_magma_tuple (input [1:0] I, output  O_0, output  O_1);
+assign O_0 = I[0];
+assign O_1 = I[1];
+endmodule
+

--- a/tests/gold/simple_circuit_1.v
+++ b/tests/gold/simple_circuit_1.v
@@ -1,0 +1,18 @@
+module eq (input  I0, input  I1, output  O);
+assign O = 1'b0;
+endmodule
+
+module logic (input  a, output  O0);
+wire  eq_inst0_O;
+wire  Mux2_inst0_O;
+eq eq_inst0 (.I0(a), .I1(1'b0), .O(eq_inst0_O));
+Mux2 Mux2_inst0 (.I0(1'b0), .I1(1'b1), .S(eq_inst0_O), .O(Mux2_inst0_O));
+assign O0 = Mux2_inst0_O;
+endmodule
+
+module Foo (input  a, output  c);
+wire  logic_inst0_O0;
+logic logic_inst0 (.a(a), .O0(logic_inst0_O0));
+assign c = logic_inst0_O0;
+endmodule
+

--- a/tests/test_circuit/gold/test_anon_value_Tuple(x=Bit,y=Bit).v
+++ b/tests/test_circuit/gold/test_anon_value_Tuple(x=Bit,y=Bit).v
@@ -1,0 +1,12 @@
+module main (input  I0_x, input  I0_y, input  I1_x, input  I1_y, output  O_x, output  O_y);
+wire  And2_inst0_I0_x;
+wire  And2_inst0_I0_y;
+wire  And2_inst0_I1_x;
+wire  And2_inst0_I1_y;
+wire  And2_inst0_O_x;
+wire  And2_inst0_O_y;
+And2 And2_inst0 (.I0_x(I0_x), .I0_y(I0_y), .I1_x(I1_x), .I1_y(I1_y), .O_x(And2_inst0_O_x), .O_y(And2_inst0_O_y));
+assign O_x = And2_inst0_O_x;
+assign O_y = And2_inst0_O_y;
+endmodule
+

--- a/tests/test_circuit/test_define.py
+++ b/tests/test_circuit/test_define.py
@@ -146,8 +146,6 @@ def test_2d_array_error(caplog):
                          [("verilog", "v"), ("coreir", "json")])
 @pytest.mark.parametrize("T",[m.Bit, m.Bits(2), m.Array(2, m.Bit), m.Tuple(x=m.Bit, y=m.Bit)])
 def test_anon_value(target, suffix, T):
-    if isinstance(T, m.TupleKind) and target == "verilog":
-        pytest.skip("Tuple not supported by verilog")
     And2 = m.DeclareCircuit('And2', "I0", m.In(T), "I1", m.In(T),
                             "O", m.Out(T))
 

--- a/tests/test_circuit_def.py
+++ b/tests/test_circuit_def.py
@@ -142,10 +142,6 @@ def test_return_py_tuple(target):
 
 
 def test_return_magma_tuple(target):
-    if target == "verilog":
-        # TODO: Tuples not supported in verilog backend
-        pytest.skip()
-
     @m.circuit.combinational
     def return_magma_tuple(I: m.Bits(2)) -> m.Tuple(m.Bit, m.Bit):
         return m.tuple_([I[0], I[1]])
@@ -154,10 +150,6 @@ def test_return_magma_tuple(target):
 
 
 def test_return_magma_named_tuple(target):
-    if target == "verilog":
-        # TODO: Tuples not supported in verilog backend
-        pytest.skip()
-
     @m.circuit.combinational
     def return_magma_named_tuple(I: m.Bits(2)) -> m.Tuple(x=m.Bit, y=m.Bit):
         return m.namedtuple(x=I[0], y=I[1])
@@ -166,10 +158,6 @@ def test_return_magma_named_tuple(target):
 
 
 def test_simple_circuit_1(target):
-    if target == "verilog":
-        # TODO: Tuples not supported in verilog backend
-        pytest.skip()
-
     EQ = m.DefineCircuit("eq", "I0", m.In(m.Bit), "I1", m.In(m.Bit), "O",
                          m.Out(m.Bit))
     m.wire(0, EQ.O)
@@ -223,10 +211,10 @@ def test_warnings(caplog):
             m.wire(c, io.c)
 
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_circuit_def.py:209: Assigning to value twice inside `if` block, taking the last value (first value is ignored)
+\033[1mtests/test_circuit_def.py:197: Assigning to value twice inside `if` block, taking the last value (first value is ignored)
             c = m.bit(1)
 
-\033[1mtests/test_circuit_def.py:209: Assigning to value twice inside `else` block, taking the last value (first value is ignored)
+\033[1mtests/test_circuit_def.py:197: Assigning to value twice inside `else` block, taking the last value (first value is ignored)
             c = m.bit(1)
 """
 
@@ -252,7 +240,7 @@ def test_not_implemented(caplog):
         pass
 
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_circuit_def.py:245: NOT IMPLEMENTED: Assigning to a variable once in `else` block (not in then block)
+\033[1mtests/test_circuit_def.py:233: NOT IMPLEMENTED: Assigning to a variable once in `else` block (not in then block)
                 c = m.bit(1)
 """
 

--- a/tests/test_verilog/.gitignore
+++ b/tests/test_verilog/.gitignore
@@ -1,1 +1,2 @@
 parsetab.py
+build


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.6.7, pytest-4.0.2, py-1.7.0, pluggy-0.8.0
rootdir: magma, inifile:
collected 237 items

tests/test_circuit_def.py ........................                       [ 10%]
tests/test_compile_errors.py sss                                         [ 11%]
tests/test_flatten.py .                                                  [ 11%]
tests/test_operators.py .............                                    [ 17%]
tests/test_circuit/test_circuit_generator.py .                           [ 17%]
tests/test_circuit/test_define.py ................                       [ 24%]
tests/test_circuit/test_inspect.py ..                                    [ 25%]
tests/test_circuit/test_is_definition.py ..                              [ 26%]
tests/test_coreir/test_compile_coreir_verilog.py .                       [ 26%]
tests/test_coreir/test_coreir.py ....                                    [ 28%]
tests/test_coreir/test_coreir_compile.py .                               [ 28%]
tests/test_coreir/test_coreir_tuple.py .....                             [ 30%]
tests/test_coreir/test_linking.py .                                      [ 31%]
tests/test_dot/test_dot.py .                                             [ 31%]
tests/test_higher/test_braid.py ..                                       [ 32%]
tests/test_higher/test_curry.py ..                                       [ 33%]
tests/test_higher/test_flat.py ..                                        [ 34%]
tests/test_higher/test_fork.py .                                         [ 34%]
tests/test_higher/test_join.py .                                         [ 35%]
tests/test_interface/test_interface.py .                                 [ 35%]
tests/test_io/test_inout1.py .                                           [ 35%]
tests/test_io/test_inout2.py .                                           [ 36%]
tests/test_io/test_out1.py .                                             [ 36%]
tests/test_io/test_out2.py .                                             [ 37%]
tests/test_ir/test_declaretest.py .                                      [ 37%]
tests/test_ir/test_ir.py .                                               [ 37%]
tests/test_meta/test_class.py .                                          [ 38%]
tests/test_meta/test_creg.py .                                           [ 38%]
tests/test_simulator/test_counter.py .                                   [ 39%]
tests/test_simulator/test_error.py .                                     [ 39%]
tests/test_simulator/test_ff.py .                                        [ 40%]
tests/test_simulator/test_logic.py .                                     [ 40%]
tests/test_simulator/test_mdb.py .                                       [ 40%]
tests/test_simulator/test_nested.py ..                                   [ 41%]
tests/test_simulator/test_tuple.py .                                     [ 42%]
tests/test_simulator/test_values.py .....                                [ 44%]
tests/test_ssa/test_ssa.py .....                                         [ 46%]
tests/test_type/test_anon.py .                                           [ 46%]
tests/test_type/test_array.py .......                                    [ 49%]
tests/test_type/test_bit.py .........                                    [ 53%]
tests/test_type/test_bits.py ....                                        [ 55%]
tests/test_type/test_clock.py .............                              [ 60%]
tests/test_type/test_conversions.py .........................            [ 71%]
tests/test_type/test_enum.py ..                                          [ 72%]
tests/test_type/test_new_types.py ..                                     [ 72%]
tests/test_type/test_sint.py ....                                        [ 74%]
tests/test_type/test_tuple.py .....                                      [ 76%]
tests/test_type/test_type_errors.py .....                                [ 78%]
tests/test_type/test_uint.py ....                                        [ 80%]
tests/test_verilog/test_from_file.py ....                                [ 82%]
tests/test_verilog/test_simple.py .........                              [ 86%]
tests/test_wire/test_arg.py ......                                       [ 88%]
tests/test_wire/test_call.py ..                                          [ 89%]
tests/test_wire/test_compose.py .                                        [ 89%]
tests/test_wire/test_const.py ...........                                [ 94%]
tests/test_wire/test_errors.py ........                                  [ 97%]
tests/test_wire/test_flip.py .                                           [ 98%]
tests/test_wire/test_named.py ....                                       [100%]

==================== 234 passed, 3 skipped in 2.74 seconds =====================
```