### PR TITLE
Fixes issues in the new uniquification logic

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -187,7 +187,7 @@ class CoreIRBackend:
     def compile_instance(self, instance, module_definition):
         name = instance.__class__.coreir_name
         lib = self.libs[instance.coreir_lib]
-        logger.debug(instance.name, type(instance))
+        logger.debug(f"Compiling instance {(instance.name, type(instance))}")
         if instance.coreir_genargs is None:
             if hasattr(instance, "wrappedModule") and \
                instance.wrappedModule.context == self.context:
@@ -292,7 +292,7 @@ class CoreIRBackend:
         logger.debug(f"Compiling definition {definition}")
         if definition.name in self.modules:
             logger.debug(f"    {definition} already compiled, skipping")
-            return
+            return self.modules[definition.name]
         self.check_interface(definition)
         module_type = self.convert_interface_to_module_type(definition.interface)
         coreir_module = self.context.global_namespace.new_module(definition.coreir_name, module_type)
@@ -303,8 +303,8 @@ class CoreIRBackend:
         # If this module was imported from verilog, do not go through the
         # general module construction flow. Instead just attach the verilog
         # source as metadata and return the module.
-        if hasattr(definition, "verilogFile") and definition.verilogFile:
-            verilog_metadata = {"verilog_string": definition.verilogFile}
+        if hasattr(definition, "verilog") and definition.verilog:
+            verilog_metadata = {"verilog_string": definition.verilog}
             coreir_module.add_metadata("verilog", json.dumps(verilog_metadata))
             return coreir_module
 
@@ -350,8 +350,8 @@ class CoreIRBackend:
         elif value is VCC or value is GND:
             source = self.get_constant_instance(value, None, module_definition)
         else:
-            logger.debug(value, output_ports)
-            logger.debug(id(value), [id(key) for key in output_ports])
+            logger.debug((value, output_ports))
+            logger.debug((id(value), [id(key) for key in output_ports]))
             source = module_definition.select(output_ports[value])
         sink = module_definition.select(magma_port_to_coreir(port))
         module_definition.connect(source, sink)
@@ -413,6 +413,7 @@ class CoreIRBackend:
                 self.modules[key.name] = self.compile_declaration(key)
 
     def compile(self, defn_or_declaration):
+        logger.debug(f"Compiling: {defn_or_declaration.name}")
         if defn_or_declaration.is_definition:
             self.compile_dependencies(defn_or_declaration)
             # don't try to compile if already have definition

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -484,6 +484,12 @@ class DefineCircuitKind(CircuitKind):
         inst.stack = inspect.stack()
         cls.instances.append(inst)
 
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other):
+        return self.name == other.name
+
 
 # Register graphviz repr if running in IPython.
 # There's a bug in IPython which breaks visual reprs

--- a/magma/circuit_database.py
+++ b/magma/circuit_database.py
@@ -4,6 +4,8 @@ import uuid
 from .compile import compile
 import coreir
 from .logging import warning
+from .config import get_database_hash_backend
+from magma.backend.coreir_ import CoreIRBackend
 
 
 class CircuitDatabaseInterface(ABC):
@@ -35,12 +37,27 @@ class CircuitDatabase(CircuitDatabaseInterface):
         def hash(self, circuit):
             with tempfile.TemporaryDirectory() as tempdir:
                 try:
-                    compile(tempdir + "/circuit", circuit, output="coreir", context=coreir.Context())
-                    json_str = open(tempdir + "/circuit.json").read()
+                    backend = get_database_hash_backend()
+                    if backend == "coreir":
+                        if hasattr(circuit, "wrappedModule") and circuit.wrappedModule:
+                            circuit.wrappedModule.save_to_file(tempdir + "/circuit.json")
+                        else:
+                            compile(tempdir + "/circuit", circuit, output="coreir")
+                        # Mark graph as dirty so future JSON passes will run,
+                        # otherwise it will not register our changes via the
+                        # API
+                        CoreIRBackend().context.run_passes(["markdirty"])
+                        string = open(tempdir + "/circuit.json").read()
+                    elif backend == "verilog":
+                        compile(tempdir + "/circuit", circuit, backend)
+                        string = open(tempdir + "/circuit.v").read()
+                    else:
+                        raise NotImplementedError(backend)
                 except Exception as e:
-                    warning(f"Could not compile circuit: '{str(e)}'. Uniquifying anyway.")
-                    json_str = uuid.uuid4()
-            return hash(json_str)
+                    warning(f"Could not compile circuit {circuit}: '{str(e)}'. Uniquifying anyway.")
+                    raise e
+                    string = uuid.uuid4()
+            return hash(string)
 
         def add_circuit(self, circuit):
             hash_ = self.hash(circuit)

--- a/magma/config.py
+++ b/magma/config.py
@@ -1,9 +1,24 @@
 __COMPILE_DIR = 'normal'
 
+
 def set_compile_dir(target):
     global __COMPILE_DIR
     assert target in ['normal', 'callee_file_dir']
     __COMPILE_DIR = target
 
+
 def get_compile_dir():
     return __COMPILE_DIR
+
+
+__database_hash_backend = "coreir"
+
+
+def set_database_hash_backend(target):
+    global __database_hash_backend
+    assert target in ["verilog", "coreir"]
+    __database_hash_backend = target
+
+
+def get_database_hash_backend():
+    return __database_hash_backend

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -24,7 +24,6 @@ class TransformedCircuit:
         self.orig_to_new = {}
         self.circuit = DefineCircuit(orig_circuit.name + '_' + transform_name,
                                      *orig_circuit.interface.decl())
-        EndCircuit()
 
     def get_new_bit(self, orig_bit, scope):
         assert isinstance(scope, Scope), "Second argument to get_new_bit should be an instance of Scope"
@@ -220,8 +219,7 @@ def flatten(circuit):
             newbit = new_circuit.interface.ports[name]
             flattened_circuit.set_new_bit(origbit, Scope(), newbit)
 
-    for primitive in new_primitives:
-        new_circuit.place(primitive)
+    EndCircuit()  # For TransformedCircuit
 
     return flattened_circuit
 


### PR DESCRIPTION
Main change is to add new `__hash__` and `__eq__` methods for circuits.
Given the new uniquification naming scheme, we can assume that names are
unique and use them for hashing and equiality checks.

Another major change is to not use a new coreir context for compiling 

Updates the coreir backend to use proper syntax of logging.

Adds the ability to set the database backend (for mantle's verilog
target, it makes more sense to use the magma verilog backend, this
shouldn't affect most user code since the mantle verilog target isn't in
heavy use).

Update the transform logic to end the circuit definition at the end.
Before, it was calling EndCircuit right away (but then populating the
definition later) which was causing issues in the uniquification logic
(can't compile when EndCircuit was called because the definition wasn't
ready).