### PR TITLE
Updating CoreIR Dependency to 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         # "pyverilog",
         "numpy",
         "graphviz",
-        "coreir>=0.30a0, <= 0.31a0",
+        "coreir>=1.0.0, <= 1.1.0",
         "bit_vector==0.39a0"
     ],
     python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "numpy",
         "graphviz",
         "coreir>=1.0.0, <= 1.1.0",
-        "bit_vector==0.39a0"
+        "bit_vector==0.42a0"
     ],
     python_requires='>=3.6',
     long_description=long_description,


### PR DESCRIPTION
The latest CoreIR in PyPI is 1.0.0 (https://pypi.org/project/coreir/#history - as of 2/8/19). The latest bit-vector is 0.42a0. Updates Magma to use those.