### PR TITLE
Run uniquification before compiling circuit for coreir simulator

### DIFF
--- a/magma/simulator/coreir_simulator.py
+++ b/magma/simulator/coreir_simulator.py
@@ -11,6 +11,7 @@ from ..bitutils import int2seq
 from ..clock import ClockType
 from ..transforms import setup_clocks, flatten
 from ..circuit import CircuitType
+from ..uniquification import uniquification_pass, UniquificationMode
 
 import coreir
 
@@ -110,7 +111,15 @@ class CoreIRSimulator(CircuitSimulator):
 
         return triggered
 
-    def __init__(self, circuit, clock, coreir_filename=None, context=None, namespaces=["global"]):
+    def __init__(self, circuit, clock, coreir_filename=None, context=None,
+                 namespaces=["global"], opts={}):
+        uniquification_mode_str = opts.get("uniquify", "UNIQUIFY")
+        uniquification_mode = getattr(UniquificationMode,
+                                      uniquification_mode_str, None)
+        if uniquification_mode is None:
+            raise ValueError(f"Invalid uniquification mode "
+                             f"{uniquification_mode_str}")
+        uniquification_pass(circuit, uniquification_mode)
         self.watchpoints = []
         self.default_scope = Scope()
 


### PR DESCRIPTION
Fixes the test in #345.

Issue was: uniquification (cacheing circuits by name) is no longer done in the circuit metaclass, instead it is done as a uniquification pass before compiling. There was a code path for the coreir simulator that compiles a magma circuit through the coreir backend that was not through `m.compile` (the only place we added the uniquification hook).

This change adds the uniquification pass in the `__init__` method of the coreir simulator object, before it compiles the magma circuit to coreir.