### PR TITLE
Repr hash

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -113,7 +113,6 @@ class CircuitKind(type):
         return f"{cls.__name__}{interface}"
 
     def __repr__(cls):
-
         name = cls.__name__
         args = str(cls.IO)
         if hasattr(cls,"instances"):
@@ -135,6 +134,9 @@ class CircuitKind(type):
             s = '{} = DeclareCircuit("{}", {})'.format(name, name, args)
 
         return s
+
+    def __hash__(cls):
+        return hash(repr(cls))
 
     def _repr_html_(cls):
         return circuit_to_html(cls)

--- a/tests/gold/uniquify_equal.json
+++ b/tests/gold/uniquify_equal.json
@@ -1,0 +1,36 @@
+{"top":"global.top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "foo":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"]
+        ]],
+        "connections":[
+          ["self.O","self.I"]
+        ]
+      },
+      "top":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "foo_inst0":{
+            "modref":"global.foo"
+          },
+          "foo_inst1":{
+            "modref":"global.foo"
+          }
+        },
+        "connections":[
+          ["self.I","foo_inst0.I"],
+          ["foo_inst1.I","foo_inst0.O"],
+          ["self.O","foo_inst1.O"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/gold/uniquify_unequal.json
+++ b/tests/gold/uniquify_unequal.json
@@ -1,0 +1,46 @@
+{"top":"global.top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "foo":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"]
+        ]],
+        "connections":[
+          ["self.O","self.I"]
+        ]
+      },
+      "foo_unq1":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["O",["Array",2,"Bit"]]
+        ]],
+        "connections":[
+          ["self.O","self.I"]
+        ]
+      },
+      "top":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "foo_inst0":{
+            "modref":"global.foo"
+          },
+          "foo_inst1":{
+            "modref":"global.foo_unq1"
+          }
+        },
+        "connections":[
+          ["self.I","foo_inst0.I"],
+          ["foo_inst1.I.0","foo_inst0.O"],
+          ["foo_inst1.I.1","foo_inst0.O"],
+          ["self.O","foo_inst1.O.0"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_uniquify.py
+++ b/tests/test_uniquify.py
@@ -1,4 +1,5 @@
 import magma as m
+from magma.testing import check_files_equal
 
 
 def test_verilog_field_uniquify():
@@ -11,3 +12,54 @@ def test_verilog_field_uniquify():
         assign C = A & B;\
     '''
     m.EndCircuit()
+
+def test_uniquify_equal():
+    foo = m.DefineCircuit("foo", "I", m.In(m.Bit), "O", m.Out(m.Bit))
+    m.wire(foo.I, foo.O)
+    m.EndCircuit()
+
+    bar = m.DefineCircuit("foo", "I", m.In(m.Bit), "O", m.Out(m.Bit))
+    m.wire(bar.I, bar.O)
+    m.EndCircuit()
+
+    top = m.DefineCircuit("top", "I", m.In(m.Bit), "O", m.Out(m.Bit))
+    curr = top.I
+    for circ in (foo, bar):
+        inst = circ()
+        m.wire(inst.I, curr)
+        curr = inst.O
+    m.wire(curr, top.O)
+    m.EndCircuit()
+
+    assert hash(foo) == hash(bar)
+
+    m.compile("build/uniquify_equal", top, output="coreir")
+    assert check_files_equal(__file__,
+                             "build/uniquify_equal.json",
+                             "gold/uniquify_equal.json")
+
+
+def test_uniquify_unequal():
+    foo = m.DefineCircuit("foo", "I", m.In(m.Bit), "O", m.Out(m.Bit))
+    m.wire(foo.I, foo.O)
+    m.EndCircuit()
+
+    bar = m.DefineCircuit("foo", "I", m.In(m.Bits(2)), "O", m.Out(m.Bits(2)))
+    m.wire(bar.I, bar.O)
+    m.EndCircuit()
+
+    top = m.DefineCircuit("top", "I", m.In(m.Bit), "O", m.Out(m.Bit))
+    foo_inst = foo()
+    m.wire(top.I, foo_inst.I)
+    bar_inst = bar()
+    m.wire(foo_inst.O, bar_inst.I[0])
+    m.wire(foo_inst.O, bar_inst.I[1])
+    m.wire(bar_inst.O[0], top.O)
+    m.EndCircuit()
+
+    assert hash(foo) != hash(bar)
+
+    m.compile("build/uniquify_unequal", top, output="coreir")
+    assert check_files_equal(__file__,
+                             "build/uniquify_unequal.json",
+                             "gold/uniquify_unequal.json")


### PR DESCRIPTION
Per discussions with @phanrahan, let's try to use the `repr` string for computing circuit hashes. This will naturally go into the uniquification pipeline. I think it's mostly robust. Since `__repr__` is a fairly simple function we can enhance or fix it as we notice issues.