### PR TITLE
Keep original name for keyword argument

### DIFF
--- a/magma/ssa/ssa.py
+++ b/magma/ssa/ssa.py
@@ -39,8 +39,8 @@ class SSAVisitor(ast.NodeTransformer):
     def visit_FunctionDef(self, node):
         for a in node.args.args:
             self.args.add(a.arg)
-            self.last_name[a.arg] = f"{a.arg}_0"
-            a.arg = f"{a.arg}_0"
+            self.last_name[a.arg] = f"{a.arg}"
+            a.arg = f"{a.arg}"
         node.body = flatten([self.visit(s) for s in node.body])
         return node
 

--- a/magma/ssa/ssa.py
+++ b/magma/ssa/ssa.py
@@ -28,8 +28,11 @@ class SSAVisitor(ast.NodeTransformer):
         self.return_values = []
 
     def write_name(self, var):
-        self.var_counter[var] += 1
-        self.last_name[var] = f"{var}_{self.var_counter[var]}"
+        while True:
+            self.var_counter[var] += 1
+            self.last_name[var] = f"{var}_{self.var_counter[var]}"
+            if self.last_name[var] not in self.args:
+                break
 
     def visit_Assign(self, node):
         node.value = self.visit(node.value)

--- a/tests/test_ssa/test_ssa.py
+++ b/tests/test_ssa/test_ssa.py
@@ -13,10 +13,10 @@ def test_basic():
         return x
 
     assert inspect.getsource(basic_if) == """\
-def basic_if(I_0: m.Bits(2), S_0: m.Bit) ->m.Bit:
-    x_0 = I_0[0]
-    x_1 = I_0[1]
-    x_2 = phi([x_1, x_0], S_0)
+def basic_if(I: m.Bits(2), S: m.Bit) ->m.Bit:
+    x_0 = I[0]
+    x_1 = I[1]
+    x_2 = phi([x_1, x_0], S)
     __magma_ssa_return_value_0 = x_2
     O = __magma_ssa_return_value_0
     return O
@@ -34,11 +34,11 @@ def test_wat():
         return x
 
     assert inspect.getsource(basic_if) == """\
-def basic_if(I_0: m.Bit, S_0: m.Bit) ->m.Bit:
-    x_0 = I_0
+def basic_if(I: m.Bit, S: m.Bit) ->m.Bit:
+    x_0 = I
     x_1 = x_0
     x_2 = x_0
-    x_3 = phi([x_2, x_1], S_0)
+    x_3 = phi([x_2, x_1], S)
     __magma_ssa_return_value_0 = x_3
     O = __magma_ssa_return_value_0
     return O
@@ -54,10 +54,10 @@ def test_default():
         return x
 
     assert inspect.getsource(default) == """\
-def default(I_0: m.Bits(2), S_0: m.Bit) ->m.Bit:
-    x_0 = I_0[1]
-    x_1 = I_0[0]
-    x_2 = phi([x_0, x_1], S_0)
+def default(I: m.Bits(2), S: m.Bit) ->m.Bit:
+    x_0 = I[1]
+    x_1 = I[0]
+    x_2 = phi([x_0, x_1], S)
     __magma_ssa_return_value_0 = x_2
     O = __magma_ssa_return_value_0
     return O
@@ -80,18 +80,19 @@ def test_nested():
         return x
 
     assert inspect.getsource(nested) == """\
-def nested(I_0: m.Bits(4), S_0: m.Bits(2)) ->m.Bit:
-    x_0 = I_0[0]
-    x_1 = I_0[1]
-    x_2 = phi([x_1, x_0], S_0[1])
-    x_3 = I_0[2]
-    x_4 = I_0[3]
-    x_5 = phi([x_4, x_3], S_0[1])
-    x_6 = phi([x_5, x_2], S_0[0])
+def nested(I: m.Bits(4), S: m.Bits(2)) ->m.Bit:
+    x_0 = I[0]
+    x_1 = I[1]
+    x_2 = phi([x_1, x_0], S[1])
+    x_3 = I[2]
+    x_4 = I[3]
+    x_5 = phi([x_4, x_3], S[1])
+    x_6 = phi([x_5, x_2], S[0])
     __magma_ssa_return_value_0 = x_6
     O = __magma_ssa_return_value_0
     return O
 """
+
 
 def test_weird():
     @ssa
@@ -102,11 +103,30 @@ def test_weird():
         return x
 
     assert inspect.getsource(default) == """\
-def default(I_0: m.Bits(2), x_0_0: m.Bit) ->m.Bit:
-    x_0 = I_0[1]
-    x_1 = I_0[0]
-    x_2 = phi([x_0, x_1], x_0_0)
-    __magma_ssa_return_value_0 = x_2
+def default(I: m.Bits(2), x_0: m.Bit) ->m.Bit:
+    x_1 = I[1]
+    x_2 = I[0]
+    x_3 = phi([x_1, x_2], x_0)
+    __magma_ssa_return_value_0 = x_3
+    O = __magma_ssa_return_value_0
+    return O
+"""
+
+
+def test_skip():
+    @ssa
+    def default(x_0: m.Bit, x_1: m.Bit, x_3: m.Bit) -> m.Bit:
+        x = x_1
+        if x_0:
+            x = x_0
+        return x
+
+    assert inspect.getsource(default) == """\
+def default(x_0: m.Bit, x_1: m.Bit, x_3: m.Bit) ->m.Bit:
+    x_2 = x_1
+    x_4 = x_0
+    x_5 = phi([x_2, x_4], x_0)
+    __magma_ssa_return_value_0 = x_5
     O = __magma_ssa_return_value_0
     return O
 """

--- a/tests/test_syntax/gold/basic_function_call.json
+++ b/tests/test_syntax/gold/basic_function_call.json
@@ -4,18 +4,18 @@
     "modules":{
       "basic_func":{
         "type":["Record",[
-          ["I_0",["Array",2,"BitIn"]],
-          ["S_0","BitIn"],
+          ["I",["Array",2,"BitIn"]],
+          ["S","BitIn"],
           ["O","Bit"]
         ]],
         "connections":[
-          ["self.O","self.I_0.1"]
+          ["self.O","self.I.1"]
         ]
       },
       "basic_function_call":{
         "type":["Record",[
-          ["I_0",["Array",2,"BitIn"]],
-          ["S_0","BitIn"],
+          ["I",["Array",2,"BitIn"]],
+          ["S","BitIn"],
           ["O","Bit"]
         ]],
         "instances":{
@@ -24,9 +24,9 @@
           }
         },
         "connections":[
-          ["self.I_0","basic_func_inst0.I_0"],
+          ["self.I","basic_func_inst0.I"],
           ["self.O","basic_func_inst0.O"],
-          ["self.S_0","basic_func_inst0.S_0"]
+          ["self.S","basic_func_inst0.S"]
         ]
       }
     }

--- a/tests/test_syntax/gold/basic_function_call.v
+++ b/tests/test_syntax/gold/basic_function_call.v
@@ -1,10 +1,10 @@
-module basic_func (input [1:0] I_0, input  S_0, output  O);
-assign O = I_0[1];
+module basic_func (input [1:0] I, input  S, output  O);
+assign O = I[1];
 endmodule
 
-module basic_function_call (input [1:0] I_0, input  S_0, output  O);
+module basic_function_call (input [1:0] I, input  S, output  O);
 wire  basic_func_inst0_O;
-basic_func basic_func_inst0 (.I_0(I_0), .S_0(S_0), .O(basic_func_inst0_O));
+basic_func basic_func_inst0 (.I(I), .S(S), .O(basic_func_inst0_O));
 assign O = basic_func_inst0_O;
 endmodule
 

--- a/tests/test_syntax/gold/if_statement_basic.json
+++ b/tests/test_syntax/gold/if_statement_basic.json
@@ -4,12 +4,12 @@
     "modules":{
       "basic_if":{
         "type":["Record",[
-          ["I_0",["Array",2,"BitIn"]],
-          ["S_0","BitIn"],
+          ["I",["Array",2,"BitIn"]],
+          ["S","BitIn"],
           ["O","Bit"]
         ]],
         "connections":[
-          ["self.O","self.I_0.1"]
+          ["self.O","self.I.1"]
         ]
       }
     }

--- a/tests/test_syntax/gold/if_statement_basic.v
+++ b/tests/test_syntax/gold/if_statement_basic.v
@@ -1,4 +1,4 @@
-module basic_if (input [1:0] I_0, input  S_0, output  O);
-assign O = I_0[1];
+module basic_if (input [1:0] I, input  S, output  O);
+assign O = I[1];
 endmodule
 

--- a/tests/test_syntax/gold/if_statement_nested.json
+++ b/tests/test_syntax/gold/if_statement_nested.json
@@ -4,12 +4,12 @@
     "modules":{
       "if_statement_nested":{
         "type":["Record",[
-          ["I_0",["Array",4,"BitIn"]],
-          ["S_0",["Array",2,"BitIn"]],
+          ["I",["Array",4,"BitIn"]],
+          ["S",["Array",2,"BitIn"]],
           ["O","Bit"]
         ]],
         "connections":[
-          ["self.O","self.I_0.3"]
+          ["self.O","self.I.3"]
         ]
       }
     }

--- a/tests/test_syntax/gold/if_statement_nested.v
+++ b/tests/test_syntax/gold/if_statement_nested.v
@@ -1,4 +1,4 @@
-module if_statement_nested (input [3:0] I_0, input [1:0] S_0, output  O);
-assign O = I_0[3];
+module if_statement_nested (input [3:0] I, input [1:0] S, output  O);
+assign O = I[3];
 endmodule
 

--- a/tests/test_syntax/gold/multiple_assign.json
+++ b/tests/test_syntax/gold/multiple_assign.json
@@ -14,7 +14,7 @@
         },
         "connections":[
           ["self.c","logic_inst0.O0"],
-          ["self.a","logic_inst0.a_0"]
+          ["self.a","logic_inst0.a"]
         ]
       },
       "Mux2":{
@@ -43,7 +43,7 @@
       },
       "logic":{
         "type":["Record",[
-          ["a_0","BitIn"],
+          ["a","BitIn"],
           ["O0","Bit"]
         ]],
         "instances":{
@@ -68,7 +68,7 @@
           ["self.O0","Mux2_inst0.O"],
           ["eq_inst0.O","Mux2_inst0.S"],
           ["eq_inst0.I1","bit_const_0_None.out"],
-          ["self.a_0","eq_inst0.I0"]
+          ["self.a","eq_inst0.I0"]
         ]
       }
     }

--- a/tests/test_syntax/gold/multiple_assign.v
+++ b/tests/test_syntax/gold/multiple_assign.v
@@ -2,17 +2,17 @@ module eq (input  I0, input  I1, output  O);
 assign O = 1'b0;
 endmodule
 
-module logic (input  a_0, output  O0);
+module logic (input  a, output  O0);
 wire  eq_inst0_O;
 wire  Mux2_inst0_O;
-eq eq_inst0 (.I0(a_0), .I1(1'b0), .O(eq_inst0_O));
+eq eq_inst0 (.I0(a), .I1(1'b0), .O(eq_inst0_O));
 Mux2 Mux2_inst0 (.I0(1'b1), .I1(1'b0), .S(eq_inst0_O), .O(Mux2_inst0_O));
 assign O0 = Mux2_inst0_O;
 endmodule
 
 module Foo (input  a, output  c);
 wire  logic_inst0_O0;
-logic logic_inst0 (.a_0(a), .O0(logic_inst0_O0));
+logic logic_inst0 (.a(a), .O0(logic_inst0_O0));
 assign c = logic_inst0_O0;
 endmodule
 

--- a/tests/test_syntax/gold/optional_assignment.json
+++ b/tests/test_syntax/gold/optional_assignment.json
@@ -16,7 +16,7 @@
         "connections":[
           ["self.c","logic_inst0.O0"],
           ["self.d","logic_inst0.O1"],
-          ["self.a","logic_inst0.a_0"]
+          ["self.a","logic_inst0.a"]
         ]
       },
       "Mux2":{
@@ -45,7 +45,7 @@
       },
       "logic":{
         "type":["Record",[
-          ["a_0","BitIn"],
+          ["a","BitIn"],
           ["O0","Bit"],
           ["O1","Bit"]
         ]],
@@ -82,8 +82,8 @@
           ["eq_inst1.O","Mux2_inst1.S"],
           ["eq_inst0.I1","bit_const_0_None.out"],
           ["eq_inst1.I1","bit_const_0_None.out"],
-          ["self.a_0","eq_inst0.I0"],
-          ["self.a_0","eq_inst1.I0"]
+          ["self.a","eq_inst0.I0"],
+          ["self.a","eq_inst1.I0"]
         ]
       }
     }

--- a/tests/test_syntax/gold/optional_assignment.v
+++ b/tests/test_syntax/gold/optional_assignment.v
@@ -2,14 +2,14 @@ module eq (input  I0, input  I1, output  O);
 assign O = 1'b0;
 endmodule
 
-module logic (input  a_0, output  O0, output  O1);
+module logic (input  a, output  O0, output  O1);
 wire  eq_inst0_O;
 wire  Mux2_inst0_O;
 wire  eq_inst1_O;
 wire  Mux2_inst1_O;
-eq eq_inst0 (.I0(a_0), .I1(1'b0), .O(eq_inst0_O));
+eq eq_inst0 (.I0(a), .I1(1'b0), .O(eq_inst0_O));
 Mux2 Mux2_inst0 (.I0(1'b1), .I1(1'b1), .S(eq_inst0_O), .O(Mux2_inst0_O));
-eq eq_inst1 (.I0(a_0), .I1(1'b0), .O(eq_inst1_O));
+eq eq_inst1 (.I0(a), .I1(1'b0), .O(eq_inst1_O));
 Mux2 Mux2_inst1 (.I0(1'b0), .I1(1'b1), .S(eq_inst1_O), .O(Mux2_inst1_O));
 assign O0 = Mux2_inst1_O;
 assign O1 = Mux2_inst0_O;
@@ -18,7 +18,7 @@ endmodule
 module Foo (input  a, output  c, output  d);
 wire  logic_inst0_O0;
 wire  logic_inst0_O1;
-logic logic_inst0 (.a_0(a), .O0(logic_inst0_O0), .O1(logic_inst0_O1));
+logic logic_inst0 (.a(a), .O0(logic_inst0_O0), .O1(logic_inst0_O1));
 assign c = logic_inst0_O0;
 assign d = logic_inst0_O1;
 endmodule

--- a/tests/test_syntax/gold/return_magma_named_tuple.json
+++ b/tests/test_syntax/gold/return_magma_named_tuple.json
@@ -4,12 +4,12 @@
     "modules":{
       "return_magma_named_tuple":{
         "type":["Record",[
-          ["I_0",["Array",2,"BitIn"]],
+          ["I",["Array",2,"BitIn"]],
           ["O",["Record",[["x","Bit"],["y","Bit"]]]]
         ]],
         "connections":[
-          ["self.O.x","self.I_0.0"],
-          ["self.O.y","self.I_0.1"]
+          ["self.O.x","self.I.0"],
+          ["self.O.y","self.I.1"]
         ]
       }
     }

--- a/tests/test_syntax/gold/return_magma_named_tuple.v
+++ b/tests/test_syntax/gold/return_magma_named_tuple.v
@@ -1,5 +1,5 @@
-module return_magma_named_tuple (input [1:0] I_0, output  O_x, output  O_y);
-assign O_x = I_0[0];
-assign O_y = I_0[1];
+module return_magma_named_tuple (input [1:0] I, output  O_x, output  O_y);
+assign O_x = I[0];
+assign O_y = I[1];
 endmodule
 

--- a/tests/test_syntax/gold/return_magma_tuple.json
+++ b/tests/test_syntax/gold/return_magma_tuple.json
@@ -4,12 +4,12 @@
     "modules":{
       "return_magma_tuple":{
         "type":["Record",[
-          ["I_0",["Array",2,"BitIn"]],
+          ["I",["Array",2,"BitIn"]],
           ["O",["Record",[["_0","Bit"],["_1","Bit"]]]]
         ]],
         "connections":[
-          ["self.O._0","self.I_0.0"],
-          ["self.O._1","self.I_0.1"]
+          ["self.O._0","self.I.0"],
+          ["self.O._1","self.I.1"]
         ]
       }
     }

--- a/tests/test_syntax/gold/return_magma_tuple.v
+++ b/tests/test_syntax/gold/return_magma_tuple.v
@@ -1,5 +1,5 @@
-module return_magma_tuple (input [1:0] I_0, output  O_0, output  O_1);
-assign O_0 = I_0[0];
-assign O_1 = I_0[1];
+module return_magma_tuple (input [1:0] I, output  O_0, output  O_1);
+assign O_0 = I[0];
+assign O_1 = I[1];
 endmodule
 

--- a/tests/test_syntax/gold/return_py_tuple.json
+++ b/tests/test_syntax/gold/return_py_tuple.json
@@ -4,13 +4,13 @@
     "modules":{
       "return_py_tuple":{
         "type":["Record",[
-          ["I_0",["Array",2,"BitIn"]],
+          ["I",["Array",2,"BitIn"]],
           ["O0","Bit"],
           ["O1","Bit"]
         ]],
         "connections":[
-          ["self.O0","self.I_0.0"],
-          ["self.O1","self.I_0.1"]
+          ["self.O0","self.I.0"],
+          ["self.O1","self.I.1"]
         ]
       }
     }

--- a/tests/test_syntax/gold/return_py_tuple.v
+++ b/tests/test_syntax/gold/return_py_tuple.v
@@ -1,5 +1,5 @@
-module return_py_tuple (input [1:0] I_0, output  O0, output  O1);
-assign O0 = I_0[0];
-assign O1 = I_0[1];
+module return_py_tuple (input [1:0] I, output  O0, output  O1);
+assign O0 = I[0];
+assign O1 = I[1];
 endmodule
 

--- a/tests/test_syntax/gold/simple_circuit_1.json
+++ b/tests/test_syntax/gold/simple_circuit_1.json
@@ -14,7 +14,7 @@
         },
         "connections":[
           ["self.c","logic_inst0.O0"],
-          ["self.a","logic_inst0.a_0"]
+          ["self.a","logic_inst0.a"]
         ]
       },
       "Mux2":{
@@ -43,7 +43,7 @@
       },
       "logic":{
         "type":["Record",[
-          ["a_0","BitIn"],
+          ["a","BitIn"],
           ["O0","Bit"]
         ]],
         "instances":{
@@ -68,7 +68,7 @@
           ["self.O0","Mux2_inst0.O"],
           ["eq_inst0.O","Mux2_inst0.S"],
           ["eq_inst0.I1","bit_const_0_None.out"],
-          ["self.a_0","eq_inst0.I0"]
+          ["self.a","eq_inst0.I0"]
         ]
       }
     }

--- a/tests/test_syntax/gold/simple_circuit_1.v
+++ b/tests/test_syntax/gold/simple_circuit_1.v
@@ -2,17 +2,17 @@ module eq (input  I0, input  I1, output  O);
 assign O = 1'b0;
 endmodule
 
-module logic (input  a_0, output  O0);
+module logic (input  a, output  O0);
 wire  eq_inst0_O;
 wire  Mux2_inst0_O;
-eq eq_inst0 (.I0(a_0), .I1(1'b0), .O(eq_inst0_O));
+eq eq_inst0 (.I0(a), .I1(1'b0), .O(eq_inst0_O));
 Mux2 Mux2_inst0 (.I0(1'b0), .I1(1'b1), .S(eq_inst0_O), .O(Mux2_inst0_O));
 assign O0 = Mux2_inst0_O;
 endmodule
 
 module Foo (input  a, output  c);
 wire  logic_inst0_O0;
-logic logic_inst0 (.a_0(a), .O0(logic_inst0_O0));
+logic logic_inst0 (.a(a), .O0(logic_inst0_O0));
 assign c = logic_inst0_O0;
 endmodule
 

--- a/tests/test_syntax/gold/ternary.json
+++ b/tests/test_syntax/gold/ternary.json
@@ -12,8 +12,8 @@
       },
       "ternary":{
         "type":["Record",[
-          ["I_0",["Array",2,"BitIn"]],
-          ["S_0","BitIn"],
+          ["I",["Array",2,"BitIn"]],
+          ["S","BitIn"],
           ["O","Bit"]
         ]],
         "instances":{
@@ -22,10 +22,10 @@
           }
         },
         "connections":[
-          ["self.I_0.1","Mux2_inst0.I0"],
-          ["self.I_0.0","Mux2_inst0.I1"],
+          ["self.I.1","Mux2_inst0.I0"],
+          ["self.I.0","Mux2_inst0.I1"],
           ["self.O","Mux2_inst0.O"],
-          ["self.S_0","Mux2_inst0.S"]
+          ["self.S","Mux2_inst0.S"]
         ]
       }
     }

--- a/tests/test_syntax/gold/ternary.v
+++ b/tests/test_syntax/gold/ternary.v
@@ -1,6 +1,6 @@
-module ternary (input [1:0] I_0, input  S_0, output  O);
+module ternary (input [1:0] I, input  S, output  O);
 wire  Mux2_inst0_O;
-Mux2 Mux2_inst0 (.I0(I_0[1]), .I1(I_0[0]), .S(S_0), .O(Mux2_inst0_O));
+Mux2 Mux2_inst0 (.I0(I[1]), .I1(I[0]), .S(S), .O(Mux2_inst0_O));
 assign O = Mux2_inst0_O;
 endmodule
 

--- a/tests/test_syntax/gold/ternary_nested.json
+++ b/tests/test_syntax/gold/ternary_nested.json
@@ -12,8 +12,8 @@
       },
       "ternary_nested":{
         "type":["Record",[
-          ["I_0",["Array",4,"BitIn"]],
-          ["S_0",["Array",2,"BitIn"]],
+          ["I",["Array",4,"BitIn"]],
+          ["S",["Array",2,"BitIn"]],
           ["O","Bit"]
         ]],
         "instances":{
@@ -25,13 +25,13 @@
           }
         },
         "connections":[
-          ["self.I_0.2","Mux2_inst0.I0"],
-          ["self.I_0.1","Mux2_inst0.I1"],
+          ["self.I.2","Mux2_inst0.I0"],
+          ["self.I.1","Mux2_inst0.I1"],
           ["Mux2_inst1.I0","Mux2_inst0.O"],
-          ["self.S_0.1","Mux2_inst0.S"],
-          ["self.I_0.0","Mux2_inst1.I1"],
+          ["self.S.1","Mux2_inst0.S"],
+          ["self.I.0","Mux2_inst1.I1"],
           ["self.O","Mux2_inst1.O"],
-          ["self.S_0.0","Mux2_inst1.S"]
+          ["self.S.0","Mux2_inst1.S"]
         ]
       }
     }

--- a/tests/test_syntax/gold/ternary_nested.v
+++ b/tests/test_syntax/gold/ternary_nested.v
@@ -1,8 +1,8 @@
-module ternary_nested (input [3:0] I_0, input [1:0] S_0, output  O);
+module ternary_nested (input [3:0] I, input [1:0] S, output  O);
 wire  Mux2_inst0_O;
 wire  Mux2_inst1_O;
-Mux2 Mux2_inst0 (.I0(I_0[2]), .I1(I_0[1]), .S(S_0[1]), .O(Mux2_inst0_O));
-Mux2 Mux2_inst1 (.I0(Mux2_inst0_O), .I1(I_0[0]), .S(S_0[0]), .O(Mux2_inst1_O));
+Mux2 Mux2_inst0 (.I0(I[2]), .I1(I[1]), .S(S[1]), .O(Mux2_inst0_O));
+Mux2 Mux2_inst1 (.I0(Mux2_inst0_O), .I1(I[0]), .S(S[0]), .O(Mux2_inst1_O));
 assign O = Mux2_inst1_O;
 endmodule
 

--- a/tests/test_syntax/gold/ternary_nested2.json
+++ b/tests/test_syntax/gold/ternary_nested2.json
@@ -12,8 +12,8 @@
       },
       "ternary_nested2":{
         "type":["Record",[
-          ["I_0",["Array",4,"BitIn"]],
-          ["S_0",["Array",2,"BitIn"]],
+          ["I",["Array",4,"BitIn"]],
+          ["S",["Array",2,"BitIn"]],
           ["O","Bit"]
         ]],
         "instances":{
@@ -25,13 +25,13 @@
           }
         },
         "connections":[
-          ["self.I_0.1","Mux2_inst0.I0"],
-          ["self.I_0.0","Mux2_inst0.I1"],
+          ["self.I.1","Mux2_inst0.I0"],
+          ["self.I.0","Mux2_inst0.I1"],
           ["Mux2_inst1.I1","Mux2_inst0.O"],
-          ["self.S_0.0","Mux2_inst0.S"],
-          ["self.I_0.2","Mux2_inst1.I0"],
+          ["self.S.0","Mux2_inst0.S"],
+          ["self.I.2","Mux2_inst1.I0"],
           ["self.O","Mux2_inst1.O"],
-          ["self.S_0.1","Mux2_inst1.S"]
+          ["self.S.1","Mux2_inst1.S"]
         ]
       }
     }

--- a/tests/test_syntax/gold/ternary_nested2.v
+++ b/tests/test_syntax/gold/ternary_nested2.v
@@ -1,8 +1,8 @@
-module ternary_nested2 (input [3:0] I_0, input [1:0] S_0, output  O);
+module ternary_nested2 (input [3:0] I, input [1:0] S, output  O);
 wire  Mux2_inst0_O;
 wire  Mux2_inst1_O;
-Mux2 Mux2_inst0 (.I0(I_0[1]), .I1(I_0[0]), .S(S_0[0]), .O(Mux2_inst0_O));
-Mux2 Mux2_inst1 (.I0(I_0[2]), .I1(Mux2_inst0_O), .S(S_0[1]), .O(Mux2_inst1_O));
+Mux2 Mux2_inst0 (.I0(I[1]), .I1(I[0]), .S(S[0]), .O(Mux2_inst0_O));
+Mux2 Mux2_inst1 (.I0(I[2]), .I1(Mux2_inst0_O), .S(S[1]), .O(Mux2_inst1_O));
 assign O = Mux2_inst1_O;
 endmodule
 

--- a/tests/test_syntax/gold/test_map_circuit.json
+++ b/tests/test_syntax/gold/test_map_circuit.json
@@ -14,7 +14,7 @@
         },
         "connections":[
           ["self.c","logic_inst0.O"],
-          ["self.a","logic_inst0.a_0"]
+          ["self.a","logic_inst0.a"]
         ]
       },
       "Not":{
@@ -34,7 +34,7 @@
       },
       "logic":{
         "type":["Record",[
-          ["a_0",["Array",10,"BitIn"]],
+          ["a",["Array",10,"BitIn"]],
           ["O",["Array",10,"Bit"]]
         ]],
         "instances":{
@@ -70,25 +70,25 @@
           }
         },
         "connections":[
-          ["self.a_0.0","Not_inst0.I"],
+          ["self.a.0","Not_inst0.I"],
           ["self.O.0","Not_inst0.O"],
-          ["self.a_0.1","Not_inst1.I"],
+          ["self.a.1","Not_inst1.I"],
           ["self.O.1","Not_inst1.O"],
-          ["self.a_0.2","Not_inst2.I"],
+          ["self.a.2","Not_inst2.I"],
           ["self.O.2","Not_inst2.O"],
-          ["self.a_0.3","Not_inst3.I"],
+          ["self.a.3","Not_inst3.I"],
           ["self.O.3","Not_inst3.O"],
-          ["self.a_0.4","Not_inst4.I"],
+          ["self.a.4","Not_inst4.I"],
           ["self.O.4","Not_inst4.O"],
-          ["self.a_0.5","Not_inst5.I"],
+          ["self.a.5","Not_inst5.I"],
           ["self.O.5","Not_inst5.O"],
-          ["self.a_0.6","Not_inst6.I"],
+          ["self.a.6","Not_inst6.I"],
           ["self.O.6","Not_inst6.O"],
-          ["self.a_0.7","Not_inst7.I"],
+          ["self.a.7","Not_inst7.I"],
           ["self.O.7","Not_inst7.O"],
-          ["self.a_0.8","Not_inst8.I"],
+          ["self.a.8","Not_inst8.I"],
           ["self.O.8","Not_inst8.O"],
-          ["self.a_0.9","Not_inst9.I"],
+          ["self.a.9","Not_inst9.I"],
           ["self.O.9","Not_inst9.O"]
         ]
       }

--- a/tests/test_syntax/gold/test_map_circuit.v
+++ b/tests/test_syntax/gold/test_map_circuit.v
@@ -2,7 +2,7 @@ module Not (input  I, output  O);
 assign O = 1'b0;
 endmodule
 
-module logic (input [9:0] a_0, output [9:0] O);
+module logic (input [9:0] a, output [9:0] O);
 wire  Not_inst0_O;
 wire  Not_inst1_O;
 wire  Not_inst2_O;
@@ -13,22 +13,22 @@ wire  Not_inst6_O;
 wire  Not_inst7_O;
 wire  Not_inst8_O;
 wire  Not_inst9_O;
-Not Not_inst0 (.I(a_0[0]), .O(Not_inst0_O));
-Not Not_inst1 (.I(a_0[1]), .O(Not_inst1_O));
-Not Not_inst2 (.I(a_0[2]), .O(Not_inst2_O));
-Not Not_inst3 (.I(a_0[3]), .O(Not_inst3_O));
-Not Not_inst4 (.I(a_0[4]), .O(Not_inst4_O));
-Not Not_inst5 (.I(a_0[5]), .O(Not_inst5_O));
-Not Not_inst6 (.I(a_0[6]), .O(Not_inst6_O));
-Not Not_inst7 (.I(a_0[7]), .O(Not_inst7_O));
-Not Not_inst8 (.I(a_0[8]), .O(Not_inst8_O));
-Not Not_inst9 (.I(a_0[9]), .O(Not_inst9_O));
+Not Not_inst0 (.I(a[0]), .O(Not_inst0_O));
+Not Not_inst1 (.I(a[1]), .O(Not_inst1_O));
+Not Not_inst2 (.I(a[2]), .O(Not_inst2_O));
+Not Not_inst3 (.I(a[3]), .O(Not_inst3_O));
+Not Not_inst4 (.I(a[4]), .O(Not_inst4_O));
+Not Not_inst5 (.I(a[5]), .O(Not_inst5_O));
+Not Not_inst6 (.I(a[6]), .O(Not_inst6_O));
+Not Not_inst7 (.I(a[7]), .O(Not_inst7_O));
+Not Not_inst8 (.I(a[8]), .O(Not_inst8_O));
+Not Not_inst9 (.I(a[9]), .O(Not_inst9_O));
 assign O = {Not_inst9_O,Not_inst8_O,Not_inst7_O,Not_inst6_O,Not_inst5_O,Not_inst4_O,Not_inst3_O,Not_inst2_O,Not_inst1_O,Not_inst0_O};
 endmodule
 
 module Foo (input [9:0] a, output [9:0] c);
 wire [9:0] logic_inst0_O;
-logic logic_inst0 (.a_0(a), .O(logic_inst0_O));
+logic logic_inst0 (.a(a), .O(logic_inst0_O));
 assign c = logic_inst0_O;
 endmodule
 

--- a/tests/test_syntax/gold/test_seq_simple.json
+++ b/tests/test_syntax/gold/test_seq_simple.json
@@ -19,27 +19,27 @@
           }
         },
         "connections":[
-          ["self.I","Basic_comb_inst0.I_0"],
+          ["self.I","Basic_comb_inst0.I"],
           ["Register2_inst0.I","Basic_comb_inst0.O0"],
           ["Register2_inst1.I","Basic_comb_inst0.O1"],
           ["self.O","Basic_comb_inst0.O2"],
-          ["Register2_inst0.O","Basic_comb_inst0.self_x_0"],
-          ["Register2_inst1.O","Basic_comb_inst0.self_y_0"]
+          ["Register2_inst0.O","Basic_comb_inst0.self_x"],
+          ["Register2_inst1.O","Basic_comb_inst0.self_y"]
         ]
       },
       "Basic_comb":{
         "type":["Record",[
-          ["I_0",["Array",2,"BitIn"]],
-          ["self_x_0",["Array",2,"BitIn"]],
-          ["self_y_0",["Array",2,"BitIn"]],
+          ["I",["Array",2,"BitIn"]],
+          ["self_x",["Array",2,"BitIn"]],
+          ["self_y",["Array",2,"BitIn"]],
           ["O0",["Array",2,"Bit"]],
           ["O1",["Array",2,"Bit"]],
           ["O2",["Array",2,"Bit"]]
         ]],
         "connections":[
-          ["self.O0","self.I_0"],
-          ["self.self_x_0","self.O1"],
-          ["self.self_y_0","self.O2"]
+          ["self.O0","self.I"],
+          ["self.self_x","self.O1"],
+          ["self.self_y","self.O2"]
         ]
       },
       "Register2":{


### PR DESCRIPTION
I'm not sure whether there is a reason or not, but with this small example

    @m.circuit.combinational
    def test(a: m.Bit) -> m.Bit:
      return ~a

the argument name turns into with `_0` suffix, after recent ssa change.

    class test(m.Circuit):
        IO = ['a_0', m.In(m.Bit), 'O', m.Out(m.Bit)]

I assume I can use positional argument to call the combinational logic like this.

    b = test(io.a)

and also keyword argument like this.

    b = test(a=io.a)

but this keyword argument doesn't work due to `_0` suffix. I needed to change it into `test(a_0=io.a)`.
