### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -1,4 +1,5 @@
-from collections import Sequence, Mapping, OrderedDict
+from collections.abc import Sequence, Mapping
+from collections import OrderedDict
 from .ref import AnonRef, TupleRef
 from .t import Type, Kind
 from .compatibility import IntegerTypes


### PR DESCRIPTION
Importing ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working.

