### PR TITLE
Initial implementation of new style class definition syntax

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -70,6 +70,8 @@ from .product import Product
 
 from hwtypes.bit_vector_abc import TypeFamily
 
+from .generator import Generator
+
 
 BitVector = Bits
 UIntVector = UInt

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -592,16 +592,18 @@ class DefineCircuitKind(CircuitKind):
     def instances(self):
         return self._instances
 
-    #
-    # place a circuit instance in this definition
-    #
     def place(cls, inst):
+        """
+        Place a circuit instance in this definition.
+        """
         if inst.defn:
             raise Exception(f"Can not place instance twice. Instance "
                             f"{repr(inst)} already placed in defn {cls.name}.")
+        type_ = type(inst)
         if not inst.name:
-            inst.name = f"{type(inst).name}_inst{str(cls.instanced_circuits_counter[type(inst).name])}"
-            cls.instanced_circuits_counter[type(inst).name] += 1
+            count = cls.instanced_circuits_counter[type_.name]
+            inst.name = f"{type(inst).name}_inst{str(count)}"
+            cls.instanced_circuits_counter[type_.name] += 1
         inst.defn = cls
         if get_debug_mode():
             inst.stack = inspect.stack()

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -503,13 +503,13 @@ class DefineCircuitKind(CircuitKind):
             raise Exception("Found multiple instances of IO")
         elif io:
             io = next(iter(io))
-            self.process_new_style_definition(io, dct["renamed_ports"])
+            self.__process_new_style_definition(io, dct["renamed_ports"])
 
         return self
 
-    def process_new_style_definition(self, io, renamed_ports):
+    def __process_new_style_definition(self, io, renamed_ports):
         """
-        The `process_new_style_definition` method constructs an "old-style" IO
+        The `__process_new_style_definition` method constructs an "old-style" IO
         list (e.g. `["I0", m.In(m.Bit), ...]`) and passes this to the old logic
         for setting up interfaces (`DeclareInterface`).  This required the
         minimal amount of changes to the existing code, although we may consider
@@ -520,7 +520,7 @@ class DefineCircuitKind(CircuitKind):
         `IO` object and replace the anonymous interface values with the concrete
         values from the old-style interface setup logic.
 
-        `process_new_style_definition` also traverses the definition graph and
+        `__process_new_style_definition` also traverses the definition graph and
         "places" the instances (by using `self.place`) within the current
         definition.
         """

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -596,6 +596,9 @@ class DefineCircuitKind(CircuitKind):
     # place a circuit instance in this definition
     #
     def place(cls, inst):
+        if inst.defn:
+            raise Exception(f"Can not place instance twice. Instance "
+                            f"{repr(inst)} already placed in defn {cls.name}.")
         if not inst.name:
             inst.name = f"{type(inst).name}_inst{str(cls.instanced_circuits_counter[type(inst).name])}"
             cls.instanced_circuits_counter[type(inst).name] += 1

--- a/magma/generator.py
+++ b/magma/generator.py
@@ -1,0 +1,17 @@
+from .circuit import DefineCircuitKind, Circuit, CircuitType, CircuitKind, IO
+
+
+class GeneratorKind(type):
+    def __new__(metacls, name, bases, dct):
+        return super().__new__(metacls, name, bases, dct)
+
+    def __call__(cls, *args, **kwargs):
+        bases = (Circuit,)
+        io = cls.new(*args, **kwargs)
+        name = cls.__name__
+        return super().__call__(name, bases, {"io": io})
+
+
+class Generator(DefineCircuitKind, metaclass=GeneratorKind):
+    def new():
+        return IO()

--- a/magma/port.py
+++ b/magma/port.py
@@ -78,7 +78,14 @@ class Wire:
         #print(str(o), o.anon(), o.bit.isinput(), o.bit.isoutput())
         #print(str(i), i.anon(), i.bit.isinput(), i.bit.isoutput())
 
-        if not o.anon():
+        # TODO: Need this check for tests/test_type/test_anon.py, basically if
+        # we have two anonymous ports, they share the same wire rather than
+        # using the same wiring logic as everything else. Why?
+        # For the new syntax without `def definition` we leverage the fact that
+        # we can normally wire up anonymous ports and give them names later. To
+        # do this, we need to restrict this check to only skip anonymous ports
+        # that are undirected (before it skipped all anonymous ports)
+        if not (o.anon() and o.bit.direction is None):
             #assert o.bit.direction is not None
             if o.bit.isinput():
                 report_wiring_error(f"Using `{o.bit.debug_name}` (an input) as an output", debug_info)
@@ -91,7 +98,7 @@ class Wire:
                 #print('adding output', o)
                 self.outputs.append(o)
 
-        if not i.anon():
+        if not (i.anon() and i.bit.direction is None):
             #assert i.bit.direction is not None
             if i.bit.isoutput():
                 report_wiring_error(f"Using `{i.bit.debug_name}` (an output) as an input", debug_info)

--- a/tests/test_circuit/gold/test_new_style_simple_mux.v
+++ b/tests/test_circuit/gold/test_new_style_simple_mux.v
@@ -1,0 +1,90 @@
+/* External Modules
+module or (
+  input  I0,
+  input  I1,
+  output  O
+);
+
+endmodule  // or
+
+*/
+/* External Modules
+module invert (
+  input  I,
+  output  O
+);
+
+endmodule  // invert
+
+*/
+/* External Modules
+module and (
+  input  I0,
+  input  I1,
+  output  O
+);
+
+endmodule  // and
+
+*/
+module Test (
+  input  I0,
+  input  I1,
+  output  O,
+  input  S
+);
+
+
+  wire  and_inst0__I0;
+  wire  and_inst0__I1;
+  wire  and_inst0__O;
+  and and_inst0(
+    .I0(and_inst0__I0),
+    .I1(and_inst0__I1),
+    .O(and_inst0__O)
+  );
+
+  wire  and_inst1__I0;
+  wire  and_inst1__I1;
+  wire  and_inst1__O;
+  and and_inst1(
+    .I0(and_inst1__I0),
+    .I1(and_inst1__I1),
+    .O(and_inst1__O)
+  );
+
+  wire  invert_inst0__I;
+  wire  invert_inst0__O;
+  invert invert_inst0(
+    .I(invert_inst0__I),
+    .O(invert_inst0__O)
+  );
+
+  wire  or_inst0__I0;
+  wire  or_inst0__I1;
+  wire  or_inst0__O;
+  or or_inst0(
+    .I0(or_inst0__I0),
+    .I1(or_inst0__I1),
+    .O(or_inst0__O)
+  );
+
+  assign and_inst0__I0 = S;
+
+  assign and_inst0__I1 = I1;
+
+  assign or_inst0__I0 = and_inst0__O;
+
+  assign and_inst1__I0 = invert_inst0__O;
+
+  assign and_inst1__I1 = I0;
+
+  assign or_inst0__I1 = and_inst1__O;
+
+  assign invert_inst0__I = S;
+
+  assign O = or_inst0__O;
+
+
+endmodule  // Test
+

--- a/tests/test_circuit/test_new_style.py
+++ b/tests/test_circuit/test_new_style.py
@@ -46,3 +46,53 @@ EndCircuit()\
     m.compile('build/test_new_style_simple_mux', Test, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/test_new_style_simple_mux.v",
                              f"gold/test_new_style_simple_mux.v")
+
+
+def test_new_style_nested():
+    Top = m.DefineCircuit("Top", "S", m.In(m.Bit), "I0", m.In(m.Bit),
+                          "I1", m.In(m.Bit), "O", m.Out(m.Bit),)
+
+    # Begin definition of Mux while in the middle of defining Top.
+    class Mux(m.Circuit):
+        io = m.IO(
+            S=m.In(m.Bit),
+            I0=m.In(m.Bit),
+            I1=m.In(m.Bit),
+            O=m.Out(m.Bit),
+        )
+
+        io.O <= (io.S & io.I1) | (~io.S & io.I0)
+
+    # Continue defining Top.
+    mux = Mux()
+    mux.I0 <= Top.I0
+    mux.I1 <= Top.I1
+    mux.S <= Top.S
+    Top.O <= mux.O
+    m.EndDefine()
+
+    assert repr(Mux) == """\
+Mux = DefineCircuit("Mux", "S", In(Bit), "I0", In(Bit), "I1", In(Bit), "O", Out(Bit))
+or_inst0 = or()
+and_inst0 = and()
+and_inst1 = and()
+invert_inst0 = invert()
+wire(and_inst0.O, or_inst0.I0)
+wire(and_inst1.O, or_inst0.I1)
+wire(Mux.S, and_inst0.I0)
+wire(Mux.I1, and_inst0.I1)
+wire(invert_inst0.O, and_inst1.I0)
+wire(Mux.I0, and_inst1.I1)
+wire(Mux.S, invert_inst0.I)
+wire(or_inst0.O, Mux.O)
+EndCircuit()\
+"""
+    assert repr(Top) == """\
+Top = DefineCircuit("Top", "S", In(Bit), "I0", In(Bit), "I1", In(Bit), "O", Out(Bit))
+Mux_inst0 = Mux()
+wire(Top.S, Mux_inst0.S)
+wire(Top.I0, Mux_inst0.I0)
+wire(Top.I1, Mux_inst0.I1)
+wire(Mux_inst0.O, Top.O)
+EndCircuit()\
+"""

--- a/tests/test_circuit/test_new_style.py
+++ b/tests/test_circuit/test_new_style.py
@@ -1,0 +1,48 @@
+import magma as m
+from magma.testing import check_files_equal
+
+# Stub operators for test
+m.BitType.__and__ = \
+    lambda x, y: m.DeclareCircuit("and", "I0", m.In(m.Bit),
+                                         "I1", m.In(m.Bit),
+                                         "O", m.Out(m.Bit))()(x, y)
+m.BitType.__or__ = \
+    lambda x, y: m.DeclareCircuit("or", "I0", m.In(m.Bit),
+                                        "I1", m.In(m.Bit),
+                                        "O", m.Out(m.Bit))()(x, y)
+m.BitType.__invert__ = \
+    lambda x: m.DeclareCircuit("invert", "I", m.In(m.Bit),
+                               "O", m.Out(m.Bit))()(x)
+
+
+def test_new_style_simple_mux():
+    class Test(m.Circuit):
+        io = m.IO(
+            S=m.In(m.Bit),
+            I0=m.In(m.Bit),
+            I1=m.In(m.Bit),
+            O=m.Out(m.Bit),
+        )
+
+        io.O <= (io.S & io.I1) | (~io.S & io.I0)
+    print(repr(Test))
+    assert repr(Test) == """\
+Test = DefineCircuit("Test", "S", In(Bit), "I0", In(Bit), "I1", In(Bit), "O", Out(Bit))
+or_inst0 = or()
+and_inst0 = and()
+and_inst1 = and()
+invert_inst0 = invert()
+wire(and_inst0.O, or_inst0.I0)
+wire(and_inst1.O, or_inst0.I1)
+wire(Test.S, and_inst0.I0)
+wire(Test.I1, and_inst0.I1)
+wire(invert_inst0.O, and_inst1.I0)
+wire(Test.I0, and_inst1.I1)
+wire(Test.S, invert_inst0.I)
+wire(or_inst0.O, Test.O)
+EndCircuit()\
+"""
+
+    m.compile('build/test_new_style_simple_mux', Test, output="coreir-verilog")
+    assert check_files_equal(__file__, f"build/test_new_style_simple_mux.v",
+                             f"gold/test_new_style_simple_mux.v")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,30 @@
+import magma as m
+
+
+def test_type_relations():
+    class _MyGen(m.Generator):
+        pass
+
+    MyCircuit = _MyGen()
+
+    assert issubclass(MyCircuit, m.Circuit)
+    assert isinstance(MyCircuit, m.circuit.DefineCircuitKind)
+    assert issubclass(m.circuit.Circuit, m.circuit.CircuitType)
+    assert issubclass(m.circuit.DefineCircuitKind, m.circuit.CircuitKind)
+    assert isinstance(MyCircuit, m.circuit.CircuitKind)
+
+    assert isinstance(MyCircuit, _MyGen)
+    assert issubclass(_MyGen, m.circuit.DefineCircuitKind)
+
+
+def test_generation():
+    class _MyGen(m.Generator):
+        def new(width):
+            io = m.IO(I=m.In(m.Bits[width]),
+                      O=m.Out(m.Bits[width]))
+            m.wire(io.O, io.I)
+            return io
+
+    MyCircuit8 = _MyGen(8)
+    print (repr(MyCircuit8))
+    m.compile("test", MyCircuit8, output="coreir")

--- a/tests/test_type/test_anon.py
+++ b/tests/test_type/test_anon.py
@@ -14,7 +14,7 @@ def test():
     assert b0.port.wires is b1.port.wires
 
     wires = b0.port.wires
-    assert len(wires.inputs) == 0
-    assert len(wires.outputs) == 1
     print('inputs:', [str(p) for p in wires.inputs])
     print('outputs:', [str(p) for p in wires.outputs])
+    assert len(wires.inputs) == 0
+    assert len(wires.outputs) == 1


### PR DESCRIPTION
This is a first pass attempt at a "new-style" class definition
syntax for magma circuits.  This removes the requirement that the user
specify the definition inside a `definition` classmethod. Instead,
the user constructs an `IO` object with the interface and then performs
the desired wiring operators to define the circuit.

The `IO` object constructs a set of anonymous values to be used for the
ports.  The circuit definition is defined in terms of the anonymous
values.  These changes add a final stage to the metaclass `__new__`
logic defined in the method `process_new_style_definition`.

The `process_new_style_definition` method constructs an "old-style" IO
list (e.g. `["I0", m.In(m.Bit), ...]`) and passes this to the old logic
for setting up interfaces (`DeclareInterface`).  This required the
minimal amount of changes to the existing code, although we may consider
rearchitecting the entire interface pipeline given this opportunity.

Because we use the old-style interface setup logic, we must traverse the
definition graph defined on the temporary anonymous values setup by the
`IO` object and replace the anonymous interface values with the concrete
values from the old-style interface setup logic.

`process_new_style_definition` also traverses the definition graph and
"places" the instances (by using `self.place`) within the current
definition.