### PR TITLE
Clean up the magma install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ language: python
 # - '3.6'
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
-    - g++-4.9
     - verilator    
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ addons:
     packages:
     - g++-4.9
     - verilator    
-before_install:
-- source .travis/install_coreir.sh
+
 install:
 # install conda for py 3.7
 - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh


### PR DESCRIPTION
Since coreir's python binding is shipping with all the required libraries, there is no need to download the binaries any more.