### PR TITLE
Sort instances during repr

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -118,12 +118,13 @@ class CircuitKind(type):
         if hasattr(cls,"instances"):
             s = '{} = DefineCircuit("{}", {})\n'.format(name, name, args)
 
+            sorted_instances = sorted(cls.instances, key=lambda x : x.name)
             # emit instances
-            for instance in cls.instances:
+            for instance in sorted_instances:
                 s += repr(instance) + '\n'
 
             # emit wires from instances
-            for instance in cls.instances:
+            for instance in sorted_instances:
                 s += repr(instance.interface)
 
             # for input in cls.interface.inputs():

--- a/tests/test_circuit/test_inspect.py
+++ b/tests/test_circuit/test_inspect.py
@@ -14,12 +14,12 @@ def test_str_repr():
     print(repr(Logic2))
     assert repr(Logic2) == """\
 Logic2 = DefineCircuit("Logic2", "I0", In(Bit), "I1", In(Bit), "O", Out(Bit))
-XOr2_inst0 = XOr2()
 And2_inst0 = And2()
-wire(And2_inst0.O, XOr2_inst0.I0)
-wire(1, XOr2_inst0.I1)
+XOr2_inst0 = XOr2()
 wire(Logic2.I0, And2_inst0.I0)
 wire(Logic2.I1, And2_inst0.I1)
+wire(And2_inst0.O, XOr2_inst0.I0)
+wire(1, XOr2_inst0.I1)
 wire(XOr2_inst0.O, Logic2.O)
 EndCircuit()\
 """


### PR DESCRIPTION
This fixes an issue related to uniquification where two definitions with the same instance/connection structure are treated as two unique circuits because the order in which the instances are placed is different.

The workaround was to sort the instance list before generating the `__repr__` string, so both these circuits have the same `__repr__` result (so they hash to the same value and aren't uniquified). The other option is to use a separate "sorted repr" code path that uses this logic just for uniquification (if we want to preserve definition order in the repr string).

Basically, we can either (a) have repr use sorted instance ordering (by name) or (b) hash on a repr string with sorted instance ordering, but preserve definition ordering for `__repr__`.