### PR TITLE
Make debug mode optional

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -364,7 +364,7 @@ class CoreIRBackend:
             source = module_definition.select(non_input_ports[value])
         sink = module_definition.select(magma_port_to_coreir(port))
         module_definition.connect(source, sink)
-        if get_codegen_debug_info() and hasattr(port, "debug_info"):
+        if get_codegen_debug_info() and getattr(port, "debug_info", False):
             module_definition.add_metadata(source, sink, "filename", json.dumps(make_relative(port.debug_info.filename)))
             module_definition.add_metadata(source, sink, "lineno", json.dumps(str(port.debug_info.lineno)))
 

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -268,7 +268,7 @@ class CoreIRBackend:
             wiredefaultclock(definition, instance)
             wireclock(definition, instance)
             coreir_instance = self.compile_instance(instance, module_definition)
-            if get_codegen_debug_info() and instance.debug_info:
+            if get_codegen_debug_info() and getattr(instance, "debug_info", False):
                 coreir_instance.add_metadata("filename", json.dumps(make_relative(instance.debug_info.filename)))
                 coreir_instance.add_metadata("lineno", json.dumps(str(instance.debug_info.lineno)))
             for name, port in instance.interface.ports.items():

--- a/magma/backend/verilog.py
+++ b/magma/backend/verilog.py
@@ -199,7 +199,9 @@ def compiledefinition(cls):
             # emit the structured verilog for each instance
             for instance in cls.instances:
                 wiredefaultclock(cls, instance)
-                if instance.debug_info.filename and instance.debug_info.lineno and get_codegen_debug_info():
+                if getattr(instance, "debug_info", False) and \
+                        instance.debug_info.filename and instance.debug_info.lineno and \
+                        get_codegen_debug_info():
                     s += f"// Instanced at {make_relative(instance.debug_info.filename)}:{instance.debug_info.lineno}\n"
                 s += compileinstance(instance) + ";\n"
 

--- a/magma/backend/verilog.py
+++ b/magma/backend/verilog.py
@@ -113,7 +113,7 @@ def compileinstance(self):
     args = []
     debug_str = ""
     for k, v in self.interface.ports.items():
-        if hasattr(v, "debug_info") and get_codegen_debug_info():
+        if getattr(v, "debug_info", False) and get_codegen_debug_info():
             filename, lineno, module = v.debug_info
         #print('arg', k, v,)
         if v.isinput():
@@ -131,7 +131,7 @@ def compileinstance(self):
             args.append( vname(v) )
         else:
             args.append( arg(k,vname(v)) )
-        if hasattr(v, "debug_info") and get_codegen_debug_info():
+        if getattr(v, "debug_info", False) and get_codegen_debug_info():
             debug_str += f"// Argument {k}({vname(v)}) wired at {make_relative(filename)}:{lineno}\n"
 
     params = []
@@ -220,7 +220,7 @@ def compiledefinition(cls):
                         else:
                             iname = vname(port)
                             oname = vname(output)
-                            if hasattr(port, "debug_info") and get_codegen_debug_info():
+                            if getattr(port, "debug_info", False) and get_codegen_debug_info():
                                 s += f"// Wired at {make_relative(port.debug_info[0])}:{port.debug_info[1]}\n"
                             s += 'assign %s = %s;\n' % (iname, oname)
                     else:

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -487,7 +487,8 @@ class DefineCircuitKind(CircuitKind):
             inst.name = f"{type(inst).name}_inst{str(cls.instanced_circuits_counter[type(inst).name])}"
             cls.instanced_circuits_counter[type(inst).name] += 1
         inst.defn = cls
-        inst.stack = inspect.stack()
+        if get_debug_mode():
+            inst.stack = inspect.stack()
         cls.instances.append(inst)
 
 

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -74,11 +74,15 @@ class CircuitKind(type):
 
         if 'coreir_lib' not in dct:
             dct['coreir_lib'] = "global"
-        if "debug_info" not in dct:
+        if get_debug_mode() and "debug_info" not in dct:
             callee_frame = inspect.getframeinfo(inspect.currentframe().f_back.f_back)
             module = inspect.getmodule(inspect.stack()[2][0])
-            dct["debug_info"] = debug_info(callee_frame.filename,
-                                           callee_frame.lineno, module)
+            debug_info = debug_info(callee_frame.filename, callee_frame.lineno,
+                                    module)
+        else:
+            debug_info = None
+
+        dct["debug_info"] = debug_info
 
         # create a new circuit class
         cls = type.__new__(metacls, name, bases, dct)

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -13,6 +13,7 @@ from .t import Flip
 from .array import ArrayType
 from .tuple import TupleType
 from .bit import VCC, GND
+from .config import get_debug_mode
 from .debug import get_callee_frame_info, debug_info
 from .logging import warning
 from .port import report_wiring_warning
@@ -95,9 +96,10 @@ class CircuitKind(type):
 
     def __call__(cls, *largs, **kwargs):
         #print('CircuitKind call:', largs, kwargs)
-        debug_info = get_callee_frame_info()
         self = super(CircuitKind, cls).__call__(*largs, **kwargs)
-        self.set_debug_info(debug_info)
+        if get_debug_mode():
+            debug_info = get_callee_frame_info()
+            self.set_debug_info(debug_info)
 
         # instance interface for this instance
         if hasattr(cls, 'IO'):
@@ -262,7 +264,10 @@ class AnonymousCircuitType(object):
         return f"{defn_str}.{self.name}"
 
     def __call__(input, *outputs, **kw):
-        debug_info = get_callee_frame_info()
+        if get_debug_mode():
+            debug_info = get_callee_frame_info()
+        else:
+            debug_info = None
 
         no = len(outputs)
         if len(outputs) == 1:
@@ -364,7 +369,10 @@ class CircuitType(AnonymousCircuitType):
 
 # DeclareCircuit Factory
 def DeclareCircuit(name, *decl, **args):
-    debug_info = get_callee_frame_info()
+    if get_debug_mode():
+        debug_info = get_callee_frame_info()
+    else:
+        debug_info = None
     dct = dict(
         IO=decl,
         debug_info=debug_info,

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -74,15 +74,15 @@ class CircuitKind(type):
 
         if 'coreir_lib' not in dct:
             dct['coreir_lib'] = "global"
-        if get_debug_mode() and "debug_info" not in dct:
-            callee_frame = inspect.getframeinfo(inspect.currentframe().f_back.f_back)
-            module = inspect.getmodule(inspect.stack()[2][0])
-            debug_info = debug_info(callee_frame.filename, callee_frame.lineno,
-                                    module)
+        if get_debug_mode():
+            if not dct.get("debug_info", False):
+                callee_frame = inspect.getframeinfo(inspect.currentframe().f_back.f_back)
+                module = inspect.getmodule(inspect.stack()[2][0])
+                dct["debug_info"] = debug_info(callee_frame.filename,
+                                               callee_frame.lineno, module)
         else:
-            debug_info = None
+            dct["debug_info"] = None
 
-        dct["debug_info"] = debug_info
 
         # create a new circuit class
         cls = type.__new__(metacls, name, bases, dct)
@@ -511,7 +511,10 @@ class Circuit(CircuitType):
 
 # DefineCircuit Factory
 def DefineCircuit(name, *decl, **args):
-    debug_info = get_callee_frame_info()
+    if get_debug_mode():
+        debug_info = get_callee_frame_info()
+    else:
+        debug_info = None
     global currentDefinition
     if currentDefinition:
         currentDefinitionStack.append(currentDefinition)

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -25,7 +25,7 @@ class CheckAnyMantleCircuits(DefinitionPass):
         self.has_mantle_circuit = False
 
     def __call__(self, definition):
-        if definition.debug_info.module is not None and \
+        if getattr(definition, "debug_info", False) and \
                 definition.debug_info.module.__name__.split(".")[0] == "mantle":
             self.has_mantle_circuit = True
 

--- a/magma/config.py
+++ b/magma/config.py
@@ -9,3 +9,16 @@ def set_compile_dir(target):
 
 def get_compile_dir():
     return __COMPILE_DIR
+
+
+__DEBUG_MODE = False
+
+
+def set_debug_mode(value=True):
+    global __DEBUG_MODE
+    assert value in {True, False}
+    __DEBUG_MODE = value
+
+
+def get_debug_mode():
+    return __DEBUG_MODE

--- a/magma/debug.py
+++ b/magma/debug.py
@@ -1,6 +1,7 @@
 import inspect
 import collections
 import magma
+from magma.config import get_debug_mode
 
 
 debug_info = collections.namedtuple("debug_info", ["filename", "lineno", "module"])
@@ -28,7 +29,7 @@ def debug_wire(fn):
     # TODO: We could check that fn has the correct interface
     #       wire(i, o, debug_info)
     def wire(i, o, debug_info=None):
-        if debug_info is None:
+        if get_debug_mode() and debug_info is None:
             debug_info = get_callee_frame_info()
         return fn(i, o, debug_info)
     return wire

--- a/magma/port.py
+++ b/magma/port.py
@@ -12,21 +12,27 @@ INOUT = 'inout'
 
 
 def report_wiring_error(message, debug_info):
-    error(f"\033[1m{make_relative(debug_info[0])}:{debug_info[1]}: {message}",
-          include_wire_traceback=True)
-    try:
-        error(get_source_line(debug_info[0], debug_info[1]))
-    except FileNotFoundError:
-        error(f"    Could not find file {debug_info[0]}")
+    if debug_info:
+        error(f"\033[1m{make_relative(debug_info[0])}:{debug_info[1]}: {message}",
+              include_wire_traceback=True)
+        try:
+            error(get_source_line(debug_info[0], debug_info[1]))
+        except FileNotFoundError:
+            error(f"    Could not find file {debug_info[0]}")
+    else:
+        error(message)
 
 
 def report_wiring_warning(message, debug_info):
     # TODO: Include wire traceback support
-    warning(f"\033[1m{make_relative(debug_info[0])}:{debug_info[1]}: {message}")
-    try:
-        warning(get_source_line(debug_info[0], debug_info[1]))
-    except FileNotFoundError:
-        warning(f"    Could not find file {debug_info[0]}")
+    if debug_info:
+        warning(f"\033[1m{make_relative(debug_info[0])}:{debug_info[1]}: {message}")
+        try:
+            warning(get_source_line(debug_info[0], debug_info[1]))
+        except FileNotFoundError:
+            warning(f"    Could not find file {debug_info[0]}")
+    else:
+        warning(message)
 
 
 def flip(direction):

--- a/magma/ssa/ssa.py
+++ b/magma/ssa/ssa.py
@@ -2,7 +2,6 @@ import magma.ast_utils as ast_utils
 import ast
 import types
 from collections import defaultdict
-import inspect
 import astor
 
 

--- a/magma/syntax/combinational.py
+++ b/magma/syntax/combinational.py
@@ -213,9 +213,10 @@ def combinational(defn_env: dict, fn: types.FunctionType):
     debug(source)
     circuit_def = ast_utils.compile_function_to_file(tree, fn.__name__,
                                                      defn_env)
-    circuit_def.debug_info = debug_info(circuit_def.debug_info.filename,
-                                        circuit_def.debug_info.lineno,
-                                        inspect.getmodule(fn))
+    if getattr(circuit_def, "debug_info", False):
+        circuit_def.debug_info = debug_info(circuit_def.debug_info.filename,
+                                            circuit_def.debug_info.lineno,
+                                            inspect.getmodule(fn))
 
     @functools.wraps(fn)
     def func(*args, **kwargs):

--- a/magma/syntax/combinational.py
+++ b/magma/syntax/combinational.py
@@ -12,6 +12,7 @@ import magma.ast_utils as ast_utils
 import types
 from magma.debug import debug_info
 from magma.ssa import convert_tree_to_ssa
+from magma.config import get_debug_mode
 
 
 class CircuitDefinitionSyntaxError(Exception):
@@ -213,7 +214,7 @@ def combinational(defn_env: dict, fn: types.FunctionType):
     debug(source)
     circuit_def = ast_utils.compile_function_to_file(tree, fn.__name__,
                                                      defn_env)
-    if getattr(circuit_def, "debug_info", False):
+    if get_debug_mode() and getattr(circuit_def, "debug_info", False):
         circuit_def.debug_info = debug_info(circuit_def.debug_info.filename,
                                             circuit_def.debug_info.lineno,
                                             inspect.getmodule(fn))

--- a/magma/syntax/combinational.py
+++ b/magma/syntax/combinational.py
@@ -32,7 +32,10 @@ class IfTransformer(ast.NodeTransformer):
     def __init__(self, filename, lines):
         super().__init__()
         self.filename = filename
-        self.lines, self.starting_line = lines
+        if lines:
+            self.lines, self.starting_line = lines
+        else:
+            self.lines, self.starting_line = None, None
 
     def flatten(self, _list):
         """1-deep flatten"""

--- a/magma/syntax/sequential.py
+++ b/magma/syntax/sequential.py
@@ -269,8 +269,8 @@ class SpecializeConstantInts(ast.NodeTransformer):
 
 
 def _sequential(defn_env: dict, cls):
-    if not inspect.isclass(cls):
-        raise ValueError("sequential decorator only works with classes")
+    # if not inspect.isclass(cls):
+    #     raise ValueError("sequential decorator only works with classes")
 
     initial_value_map = get_initial_value_map(cls.__init__, defn_env)
 

--- a/magma/syntax/sequential.py
+++ b/magma/syntax/sequential.py
@@ -355,9 +355,10 @@ def _sequential(defn_env: dict, cls):
             ast.parse("from mantle import DefineRegister").body[0],
         ] + tree.body)
     circuit_def = ast_utils.compile_function_to_file(tree, cls.__name__, defn_env)
-    circuit_def.debug_info = debug_info(circuit_def.debug_info.filename,
-                                        circuit_def.debug_info.lineno,
-                                        inspect.getmodule(cls))
+    if getattr(circuit_def, "debug_info", False):
+        circuit_def.debug_info = debug_info(circuit_def.debug_info.filename,
+                                            circuit_def.debug_info.lineno,
+                                            inspect.getmodule(cls))
 
     return circuit_def
 

--- a/magma/syntax/sequential.py
+++ b/magma/syntax/sequential.py
@@ -7,6 +7,7 @@ from magma.debug import debug_info
 import functools
 import magma as m
 from magma.ssa import convert_tree_to_ssa
+from magma.config import get_debug_mode
 from collections import Counter
 
 
@@ -355,7 +356,7 @@ def _sequential(defn_env: dict, cls):
             ast.parse("from mantle import DefineRegister").body[0],
         ] + tree.body)
     circuit_def = ast_utils.compile_function_to_file(tree, cls.__name__, defn_env)
-    if getattr(circuit_def, "debug_info", False):
+    if get_debug_mode() and getattr(circuit_def, "debug_info", False):
         circuit_def.debug_info = debug_info(circuit_def.debug_info.filename,
                                             circuit_def.debug_info.lineno,
                                             inspect.getmodule(cls))

--- a/tests/test_circuit/gold/test_for_loop_def.json
+++ b/tests/test_circuit/gold/test_for_loop_def.json
@@ -8,7 +8,7 @@
           ["I1","BitIn"],
           ["O","Bit"]
         ]],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"53"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"54"}
       },
       "main":{
         "type":["Record",[
@@ -18,33 +18,33 @@
         "instances":{
           "And2_inst0":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"60"}
           },
           "And2_inst1":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"60"}
           },
           "And2_inst2":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"60"}
           },
           "And2_inst3":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"60"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"61"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"62"}],
-          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
-          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
-          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
-          ["self.I.1","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
-          ["And2_inst3.I0","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
-          ["self.I.1","And2_inst3.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
-          ["self.O","And2_inst3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"68"}]
+          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"62"}],
+          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"63"}],
+          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
+          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
+          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
+          ["self.I.1","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
+          ["And2_inst3.I0","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
+          ["self.I.1","And2_inst3.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
+          ["self.O","And2_inst3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"69"}]
         ],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"55"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"56"}
       }
     }
   }

--- a/tests/test_circuit/gold/test_for_loop_def.v
+++ b/tests/test_circuit/gold/test_for_loop_def.v
@@ -1,30 +1,30 @@
-// Defined at tests/test_circuit/test_define.py:55
+// Defined at tests/test_circuit/test_define.py:56
 module main (input [1:0] I, output  O);
 wire  And2_inst0_O;
 wire  And2_inst1_O;
 wire  And2_inst2_O;
 wire  And2_inst3_O;
-// Instanced at tests/test_circuit/test_define.py:59
-// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:61
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:62
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:64
+// Instanced at tests/test_circuit/test_define.py:60
+// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:62
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:63
+// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:65
 And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
-// Instanced at tests/test_circuit/test_define.py:59
-// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:64
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:65
-// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:64
+// Instanced at tests/test_circuit/test_define.py:60
+// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:65
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:66
+// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:65
 And2 And2_inst1 (.I0(And2_inst0_O), .I1(I[1]), .O(And2_inst1_O));
-// Instanced at tests/test_circuit/test_define.py:59
-// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:64
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:65
-// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:64
+// Instanced at tests/test_circuit/test_define.py:60
+// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:65
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:66
+// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:65
 And2 And2_inst2 (.I0(And2_inst1_O), .I1(I[1]), .O(And2_inst2_O));
-// Instanced at tests/test_circuit/test_define.py:59
-// Argument I0(And2_inst2_O) wired at tests/test_circuit/test_define.py:64
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:65
-// Argument O(And2_inst3_O) wired at tests/test_circuit/test_define.py:68
+// Instanced at tests/test_circuit/test_define.py:60
+// Argument I0(And2_inst2_O) wired at tests/test_circuit/test_define.py:65
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:66
+// Argument O(And2_inst3_O) wired at tests/test_circuit/test_define.py:69
 And2 And2_inst3 (.I0(And2_inst2_O), .I1(I[1]), .O(And2_inst3_O));
-// Wired at tests/test_circuit/test_define.py:68
+// Wired at tests/test_circuit/test_define.py:69
 assign O = And2_inst3_O;
 endmodule
 

--- a/tests/test_circuit/gold/test_interleaved_instance_wiring.json
+++ b/tests/test_circuit/gold/test_interleaved_instance_wiring.json
@@ -8,7 +8,7 @@
           ["I1","BitIn"],
           ["O","Bit"]
         ]],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"83"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"84"}
       },
       "main":{
         "type":["Record",[
@@ -18,27 +18,27 @@
         "instances":{
           "And2_inst0":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"87"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"88"}
           },
           "And2_inst1":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"88"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"89"}
           },
           "And2_inst2":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"94"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"95"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"90"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"91"}],
-          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"92"}],
-          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"93"}],
-          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"95"}],
-          ["self.I.0","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"96"}],
-          ["self.O","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"98"}]
+          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"91"}],
+          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"92"}],
+          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"93"}],
+          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"94"}],
+          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"96"}],
+          ["self.I.0","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"97"}],
+          ["self.O","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"99"}]
         ],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"85"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"86"}
       }
     }
   }

--- a/tests/test_circuit/gold/test_interleaved_instance_wiring.v
+++ b/tests/test_circuit/gold/test_interleaved_instance_wiring.v
@@ -1,24 +1,24 @@
-// Defined at tests/test_circuit/test_define.py:85
+// Defined at tests/test_circuit/test_define.py:86
 module main (input [1:0] I, output  O);
 wire  And2_inst0_O;
 wire  And2_inst1_O;
 wire  And2_inst2_O;
-// Instanced at tests/test_circuit/test_define.py:87
-// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:90
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:91
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:92
-And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
 // Instanced at tests/test_circuit/test_define.py:88
-// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:92
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:93
-// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:95
+// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:91
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:92
+// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:93
+And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
+// Instanced at tests/test_circuit/test_define.py:89
+// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:93
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:94
+// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:96
 And2 And2_inst1 (.I0(And2_inst0_O), .I1(I[1]), .O(And2_inst1_O));
-// Instanced at tests/test_circuit/test_define.py:94
-// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:95
-// Argument I1(I[0]) wired at tests/test_circuit/test_define.py:96
-// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:98
+// Instanced at tests/test_circuit/test_define.py:95
+// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:96
+// Argument I1(I[0]) wired at tests/test_circuit/test_define.py:97
+// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:99
 And2 And2_inst2 (.I0(And2_inst1_O), .I1(I[0]), .O(And2_inst2_O));
-// Wired at tests/test_circuit/test_define.py:98
+// Wired at tests/test_circuit/test_define.py:99
 assign O = And2_inst2_O;
 endmodule
 

--- a/tests/test_circuit/gold/test_simple_def.json
+++ b/tests/test_circuit/gold/test_simple_def.json
@@ -8,7 +8,7 @@
           ["I1","BitIn"],
           ["O","Bit"]
         ]],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"13"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"14"}
       },
       "main":{
         "type":["Record",[
@@ -18,15 +18,15 @@
         "instances":{
           "And2_inst0":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"17"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"18"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"19"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"20"}],
-          ["self.O","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"21"}]
+          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"20"}],
+          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"21"}],
+          ["self.O","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"22"}]
         ],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"15"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"16"}
       }
     }
   }

--- a/tests/test_circuit/gold/test_simple_def.v
+++ b/tests/test_circuit/gold/test_simple_def.v
@@ -1,12 +1,12 @@
-// Defined at tests/test_circuit/test_define.py:15
+// Defined at tests/test_circuit/test_define.py:16
 module main (input [1:0] I, output  O);
 wire  And2_inst0_O;
-// Instanced at tests/test_circuit/test_define.py:17
-// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:19
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:20
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:21
+// Instanced at tests/test_circuit/test_define.py:18
+// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:20
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:21
+// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:22
 And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
-// Wired at tests/test_circuit/test_define.py:21
+// Wired at tests/test_circuit/test_define.py:22
 assign O = And2_inst0_O;
 endmodule
 

--- a/tests/test_circuit/gold/test_simple_def_class.json
+++ b/tests/test_circuit/gold/test_simple_def_class.json
@@ -8,7 +8,7 @@
           ["I1","BitIn"],
           ["O","Bit"]
         ]],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"13"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"14"}
       },
       "Main":{
         "type":["Record",[
@@ -18,15 +18,15 @@
         "instances":{
           "And2_inst0":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"35"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"36"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"36"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"37"}],
-          ["self.O","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"38"}]
+          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"37"}],
+          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"38"}],
+          ["self.O","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"39"}]
         ],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"30"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"31"}
       }
     }
   }

--- a/tests/test_circuit/gold/test_simple_def_class.v
+++ b/tests/test_circuit/gold/test_simple_def_class.v
@@ -1,12 +1,12 @@
-// Defined at tests/test_circuit/test_define.py:30
+// Defined at tests/test_circuit/test_define.py:31
 module Main (input [1:0] I, output  O);
 wire  And2_inst0_O;
-// Instanced at tests/test_circuit/test_define.py:35
-// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:36
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:37
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:38
+// Instanced at tests/test_circuit/test_define.py:36
+// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:37
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:38
+// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:39
 And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
-// Wired at tests/test_circuit/test_define.py:38
+// Wired at tests/test_circuit/test_define.py:39
 assign O = And2_inst0_O;
 endmodule
 

--- a/tests/test_circuit/test_define.py
+++ b/tests/test_circuit/test_define.py
@@ -1,5 +1,6 @@
 import magma as m
 from magma.testing import check_files_equal
+m.config.set_debug_mode(True)
 import logging
 import pytest
 import coreir

--- a/tests/test_coreir/test_compile_coreir_verilog.py
+++ b/tests/test_coreir/test_compile_coreir_verilog.py
@@ -3,6 +3,7 @@ import os
 from magma.testing.utils import check_files_equal
 import magma as m
 m.set_mantle_target("coreir")
+m.config.set_debug_mode(True)
 import pytest
 
 

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -1,4 +1,5 @@
 from magma import *
+magma.config.set_debug_mode(True)
 
 
 def test_input_as_output(caplog):
@@ -9,7 +10,7 @@ def test_input_as_output(caplog):
     buf = Buf()
     wire(main.O, buf.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:10: Using `main.O` (an input) as an output
+\033[1mtests/test_wire/test_errors.py:11: Using `main.O` (an input) as an output
     wire(main.O, buf.I)
 """
 
@@ -22,7 +23,7 @@ def test_output_as_input(caplog):
     a = A()
     wire(main.I, a.O)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:23: Using `main.A_inst0.O` (an output) as an input
+\033[1mtests/test_wire/test_errors.py:24: Using `main.A_inst0.O` (an output) as an input
     wire(main.I, a.O)
 """
 
@@ -36,7 +37,7 @@ def test_multiple_outputs_to_input_warning(caplog):
     wire(main.I[0], a.I)
     wire(main.I[1], a.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:37: Adding the output `main.I[1]` to the wire `main.A_inst0.I` which already has output(s) `[main.I[0]]`
+\033[1mtests/test_wire/test_errors.py:38: Adding the output `main.I[1]` to the wire `main.A_inst0.I` which already has output(s) `[main.I[0]]`
     wire(main.I[1], a.I)
 """
 
@@ -49,7 +50,7 @@ def test_muliple_outputs_circuit(caplog):
     a = A()
     wire(a, main.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:50: Can only wire circuits with one output. Argument 0 to wire `main.A_inst0` has outputs [inst0.O, inst0.U]
+\033[1mtests/test_wire/test_errors.py:51: Can only wire circuits with one output. Argument 0 to wire `main.A_inst0` has outputs [inst0.O, inst0.U]
     wire(a, main.I)
 """
 
@@ -62,7 +63,7 @@ def test_muliple_outputs_circuit(caplog):
     a = A()
     a(main)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:63: Number of inputs is not equal to the number of outputs, expected 2 inputs, got 1. Only 1 will be wired.
+\033[1mtests/test_wire/test_errors.py:64: Number of inputs is not equal to the number of outputs, expected 2 inputs, got 1. Only 1 will be wired.
     a(main)
 """
 
@@ -75,7 +76,7 @@ def test_no_inputs_circuit(caplog):
     a = A()
     wire(main.I, a)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:76: Wiring an output to a circuit with no input arguments, skipping
+\033[1mtests/test_wire/test_errors.py:77: Wiring an output to a circuit with no input arguments, skipping
     wire(main.I, a)
 """
 
@@ -88,7 +89,7 @@ def test_muliple_inputs_circuit(caplog):
     a = A()
     wire(main.I, a)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:89: Wiring an output to a circuit with more than one input argument, using the first input main.A_inst0.I
+\033[1mtests/test_wire/test_errors.py:90: Wiring an output to a circuit with more than one input argument, using the first input main.A_inst0.I
     wire(main.I, a)
 """
 
@@ -101,7 +102,7 @@ def test_no_key(caplog):
     a = A()
     a(K=main.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:102: Instance main.A_inst0 does not have input K
+\033[1mtests/test_wire/test_errors.py:103: Instance main.A_inst0 does not have input K
     a(K=main.I)
 """
 
@@ -117,6 +118,6 @@ def test_const_array_error(caplog):
     wire(buf.O, main.O)
 
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:116: Cannot wire 1 (type=<class 'int'>) to main.Buf_inst0.I (type=Array[1, In(Bit)]) because conversions from IntegerTypes are only defined for Bits, not general Arrays
+\033[1mtests/test_wire/test_errors.py:117: Cannot wire 1 (type=<class 'int'>) to main.Buf_inst0.I (type=Array[1, In(Bit)]) because conversions from IntegerTypes are only defined for Bits, not general Arrays
     wire(1, buf.I)
 """


### PR DESCRIPTION
By default, don't call `get_callee_frame_info` which in turn calls inspect to get the original source line/file of wire calls and instances.