### PR TITLE
Change port renaming logic for coreir frontend to use `renamed_ports` interface

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -160,15 +160,12 @@ class CoreIRBackend:
         elif (coreir_type.kind == "Record"):
             elements = {}
             for item in coreir_type.items():
+                name = item[0]
                 # replace  the in port with I as can't reference that
-                name = "I" if (item[0] == "in") else item[0]
-                elements[name] = self.get_ports(item[1], renamed_ports)
-                # save the renaming data for later use
-                if item[0] == "in":
-                    if isinstance(elements[name], BitKind):
-                        # making a copy of bit, as don't want to affect all other bits
-                        elements[name] = MakeBit(direction=elements[name].direction)
+                if name == "in":
+                    name = "I"
                     renamed_ports[name] = "in"
+                elements[name] = self.get_ports(item[1], renamed_ports)
             return Tuple(**elements)
         elif (coreir_type.kind == "Named"):
             # exception to handle clock types, since other named types not handled

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -150,25 +150,25 @@ class CoreIRBackend:
         "coreir.clkIn": Clock
     }
 
-    def get_ports(self, coreir_type):
+    def get_ports(self, coreir_type, renamed_ports):
         if (coreir_type.kind == "Bit"):
             return BitOut
         elif (coreir_type.kind == "BitIn"):
             return BitIn
         elif (coreir_type.kind == "Array"):
-            return Array[len(coreir_type), self.get_ports(coreir_type.element_type)]
+            return Array[len(coreir_type), self.get_ports(coreir_type.element_type, renamed_ports)]
         elif (coreir_type.kind == "Record"):
             elements = {}
             for item in coreir_type.items():
                 # replace  the in port with I as can't reference that
                 name = "I" if (item[0] == "in") else item[0]
-                elements[name] = self.get_ports(item[1])
+                elements[name] = self.get_ports(item[1], renamed_ports)
                 # save the renaming data for later use
                 if item[0] == "in":
                     if isinstance(elements[name], BitKind):
                         # making a copy of bit, as don't want to affect all other bits
                         elements[name] = MakeBit(direction=elements[name].direction)
-                    elements[name].origPortName = "in"
+                    renamed_ports[name] = "in"
             return Tuple(**elements)
         elif (coreir_type.kind == "Named"):
             # exception to handle clock types, since other named types not handled

--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -6,7 +6,8 @@ from coreir.generator import Generator
 def DefineModuleWrapper(cirb: CoreIRBackend, coreirModule, uniqueName, deps):
     class ModuleWrapper(Circuit):
         name = uniqueName
-        IO = cirb.get_ports_as_list(cirb.get_ports(coreirModule.type))
+        renamed_ports = {}
+        IO = cirb.get_ports_as_list(cirb.get_ports(coreirModule.type, renamed_ports))
         wrappedModule = coreirModule
         coreir_wrapped_modules_libs_used = set(deps)
 

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -206,8 +206,6 @@ class _DeclareInterface(_Interface):
             elif defn: ref = DefnRef(defn, name)
             else:      ref = AnonRef(name)
 
-            if hasattr(port, "origPortName"):
-                ref.name = port.origPortName
             if name in renamed_ports:
                 ref.name = renamed_ports[name]
 


### PR DESCRIPTION
Fixes https://github.com/David-Durst/aetherling/issues/18

The issue was that `origPortName` was stored on the type, and changes to how types are cached meant that setting the field would propagate to all types with the same parameters.  In reality, we would like `origPortName` to be associated with the instances of types that get created when a circuit is instanced.

There is another interface at the `Circuit` level that enables the renaming of ports using a `renamed_ports` dictionary that contains mappings from the magma "external" port name (exposed to the user) to the magma "internal" port name (used by the backend).

This changes the coreir frontend logic to use the `renamed_ports` interface instead of `origPortName`. The downside to this is that `renamed_ports` current only supports renaming top level ports (i.e. a port named `in` in the leaf elements of a coreir `Record` won't be renamed yet).  We can extend the interface to support arbitrary renaming of recursive types, but this was sufficient to unblock the above test.

@David-Durst, do you need the ability to rename ports that are not the top level? Or is supporting only top level types enough to get aetherling unblocked? I tried running other tests but a bunch failed with `E       AttributeError: 'Bits' object has no attribute 'N'` which I suspect is related to an old use of the `Bits` syntax, so I couldn't easily verify whether removing support for non top level types broke other tests.