### PR TITLE
Share setports logic for defn/decl

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -94,7 +94,8 @@ class CircuitKind(type):
         if hasattr(cls, 'IO') and not isinstance(cls.IO, InterfaceKind):
             # turn IO attribite into an Interface
             cls.IO = DeclareInterface(*cls.IO)
-            cls.interface = cls.IO
+            cls.interface = cls.IO(defn=cls, renamed_ports=dct["renamed_ports"])
+            setports(cls, cls.interface.ports)
 
         return cls
 
@@ -466,9 +467,6 @@ class DefineCircuitKind(CircuitKind):
         self.is_instance = False
 
         if hasattr(self, 'IO'):
-            # instantiate interface
-            self.interface = self.IO(defn=self, renamed_ports=dct["renamed_ports"])
-            setports(self, self.interface.ports)
 
             # create circuit definition
             if hasattr(self, 'definition'):

--- a/tests/test_circuit/test_declare.py
+++ b/tests/test_circuit/test_declare.py
@@ -6,3 +6,13 @@ def test_declare_simple():
     And2 = m.DeclareCircuit("And2", "I0", m.In(m.Bit), "I1", m.In(m.Bit), "O",
                             m.Out(m.Bit))
     assert isinstance(And2.I0, m.BitType)
+
+
+def test_declare_interface_polarity():
+    And2Decl = m.DeclareCircuit("And2", "I0", m.In(m.Bit), "I1", m.In(m.Bit),
+                                "O", m.Out(m.Bit))
+    And2Defn = m.DefineCircuit("And2", "I0", m.In(m.Bit), "I1", m.In(m.Bit),
+                               "O", m.Out(m.Bit))
+
+    assert And2Decl.interface.ports["I0"].isinput() == \
+        And2Defn.interface.ports["I0"].isinput()

--- a/tests/test_circuit/test_declare.py
+++ b/tests/test_circuit/test_declare.py
@@ -1,0 +1,8 @@
+
+import magma as m
+
+
+def test_declare_simple():
+    And2 = m.DeclareCircuit("And2", "I0", m.In(m.Bit), "I1", m.In(m.Bit), "O",
+                            m.Out(m.Bit))
+    assert isinstance(And2.I0, m.BitType)


### PR DESCRIPTION
Right now circuits declared using `m.DeclareCircuit` do not have attributes corresponding to their ports, so the following simple test fails:
```python
import magma as m
And2 = m.DeclareCircuit("And2", "I0", m.In(m.Bit), "I1", m.In(m.Bit), "O", m.Out(m.Bit))
assert isinstance(And2.I0, m.BitType)
```
with
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'And2' has no attribute 'I0'
```

The logic to set the port attributes is contained with `DefineCircuitKind.__new__`, so it's only used for definitions, whereas in `CircuitKind.__new__` the interface is never instantiated nor is `setports` called.

These changes move the `cls.interface = cls.IO(...)` instantiation and `setports` logic to `CircuitKind.__new__` so both definitions and declarations have the port attributes set.

This also resolves the issue with mismatched polarities with definitions/declarations and their `interface` attribute.  This test fails before these changes
```python
import magma as m
And2Decl = m.DeclareCircuit("And2", "I0", m.In(m.Bit), "I1", m.In(m.Bit), "O", m.Out(m.Bit))
And2Defn = m.DefineCircuit("And2", "I0", m.In(m.Bit), "I1", m.In(m.Bit), "O", m.Out(m.Bit))

assert And2Decl.interface.ports["I0"].isinput() == And2Defn.interface.ports["I0"].isinput()
```

with

```
    def test_declare_interface_polarity():
        And2Decl = m.DeclareCircuit("And2", "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                                    "O", m.Out(m.Bit))
        And2Defn = m.DefineCircuit("And2", "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                                   "O", m.Out(m.Bit))

>       assert And2Decl.interface.ports["I0"].isinput() == \
            And2Defn.interface.ports["I0"].isinput()
E       assert True == False
E        +  where True = <bound method Type.isinput of Bit>()
E        +    where <bound method Type.isinput of Bit> = Bit.isinput
E        +  and   False = <bound method Type.isinput of Bit>()
E        +    where <bound method Type.isinput of Bit> = And2.I0.isinput
```