### PR TITLE
2x (almost) speed up for magma

### DIFF
--- a/magma/port.py
+++ b/magma/port.py
@@ -61,12 +61,14 @@ def mergewires(new, old, debug_info):
 
 
 def fast_mergewires(w, i, o):
-    assert len(w.outputs) + len(o.wires.outputs) <= 2
     w.inputs = i.wires.inputs + o.wires.inputs
     w.outputs = i.wires.outputs + o.wires.outputs
     w.inputs = list(set(w.inputs))
     w.outputs = list(set(w.outputs))
-    assert len(w.outputs) <= 1
+    if len(w.outputs) > 1:
+        outputs = [o.bit.debug_name for o in w.outputs]
+        # use w.inputs[0] as i, similar to {i.bit.debug_name}
+        report_wiring_error(f"Connecting more than one output ({outputs}) to an input `{w.inputs[0].bit.debug_name}`", debug_info)  # noqa
     for p in w.inputs:
         p.wires = w
     for p in w.outputs:


### PR DESCRIPTION
`cProfile` comparison for `garnet` when compiling 32x16
Before this PR:
![image](https://user-images.githubusercontent.com/6099149/57978327-1684e280-79c0-11e9-9fd3-01db77ca52f6.png)
After this PR:
![image](https://user-images.githubusercontent.com/6099149/57978329-24d2fe80-79c0-11e9-8f44-dbcff9247412.png)

What happened here:
1. Lots of unnecessary conversation from set and back
2. Lots of unnecessary comparisons.

Solution:
- More efficient code to implement the same logic.

I think there are opportunities to achieve even more speed ups, e.g. another 2x at least. I will dig around more.