### PR TITLE
Add basic pretty printer for types

### DIFF
--- a/magma/bits.py
+++ b/magma/bits.py
@@ -179,10 +179,10 @@ class UIntKind(BitsKind):
 
     def __str__(cls):
         if cls.isinput():
-            return "In(UInt({}))".format(cls.N)
+            return "In(UInt[{}])".format(cls.N)
         if cls.isoutput():
-            return "Out(UInt({}))".format(cls.N)
-        return "UInt({})".format(cls.N)
+            return "Out(UInt[{}])".format(cls.N)
+        return "UInt[{}]".format(cls.N)
 
     def qualify(cls, direction):
         if cls.T.isoriented(direction):
@@ -247,10 +247,10 @@ class SIntKind(BitsKind):
 
     def __str__(cls):
         if cls.isinput():
-            return "In(SInt({}))".format(cls.N)
+            return "In(SInt[{}])".format(cls.N)
         if cls.isoutput():
-            return "Out(SInt({}))".format(cls.N)
-        return "SInt({})".format(cls.N)
+            return "Out(SInt[{}])".format(cls.N)
+        return "SInt[{}]".format(cls.N)
 
     def qualify(cls, direction):
         if cls.T.isoriented(direction):
@@ -321,10 +321,10 @@ class BFloatKind(BitsKind):
 
     def __str__(cls):
         if cls.isinput():
-            return "In(BFloat({}))".format(cls.N)
+            return "In(BFloat[{}])".format(cls.N)
         if cls.isoutput():
-            return "Out(BFloat({}))".format(cls.N)
-        return "BFloat({})".format(cls.N)
+            return "Out(BFloat[{}])".format(cls.N)
+        return "BFloat[{}]".format(cls.N)
 
     def qualify(cls, direction):
         if cls.T.isoriented(direction):

--- a/magma/util.py
+++ b/magma/util.py
@@ -7,3 +7,30 @@ def BitOrBits(width):
     if not isinstance(width, int):
         raise ValueError(f"Expected width to be None or int, got {width}")
     return m.Bits[width]
+
+
+def pretty_str(t):
+    if isinstance(t, m.TupleKind):
+        args = []
+        for i in range(t.N):
+            key_str = str(t.Ks[i])
+            val_str = pretty_str(t.Ts[i])
+            indent = " " * 4
+            val_str = f"\n{indent}".join(val_str.splitlines())
+            args.append(f"{key_str} = {val_str}")
+        # Pretty print by using newlines + indent
+        joiner = ",\n    "
+        result = joiner.join(args)
+        # Insert first newline + indent and last newline
+        result = "\n    " + result + "\n"
+        s = f"Tuple({result})"
+    elif isinstance(t, m.ArrayKind):
+        s = "Array[%d, %s]" % (t.N, t.T)
+        s = f"Array[{t.N}, {pretty_str(t.T)}]"
+    else:
+        s = str(t)
+    return s
+
+
+def pretty_print_type(t):
+    print(pretty_str(t))

--- a/magma/util.py
+++ b/magma/util.py
@@ -24,12 +24,8 @@ def pretty_str(t):
         # Insert first newline + indent and last newline
         result = "\n    " + result + "\n"
         s = f"Tuple({result})"
-    elif isinstance(t, m.SIntKind):
-        s = f"SInt[{t.N}]"
-    elif isinstance(t, m.UIntKind):
-        s = f"UInt[{t.N}]"
     elif isinstance(t, m.BitsKind):
-        s = f"Bits[{t.N}]"
+        s = str(t)
     elif isinstance(t, m.ArrayKind):
         s = f"Array[{t.N}, {pretty_str(t.T)}]"
     else:

--- a/magma/util.py
+++ b/magma/util.py
@@ -24,8 +24,13 @@ def pretty_str(t):
         # Insert first newline + indent and last newline
         result = "\n    " + result + "\n"
         s = f"Tuple({result})"
+    elif isinstance(t, m.SIntKind):
+        s = f"SInt[{t.N}]"
+    elif isinstance(t, m.UIntKind):
+        s = f"UInt[{t.N}]"
+    elif isinstance(t, m.BitsKind):
+        s = f"Bits[{t.N}]"
     elif isinstance(t, m.ArrayKind):
-        s = "Array[%d, %s]" % (t.N, t.T)
         s = f"Array[{t.N}, {pretty_str(t.T)}]"
     else:
         s = str(t)

--- a/tests/test_type/test_pretty_print.py
+++ b/tests/test_type/test_pretty_print.py
@@ -1,0 +1,63 @@
+import magma as m
+
+
+def test_pretty_print_tuple():
+    t = m.Tuple(a=m.Bit, b=m.Bit, c=m.Bit)
+    assert m.util.pretty_str(t) == """\
+Tuple(
+    a = Bit,
+    b = Bit,
+    c = Bit
+)\
+"""
+
+
+def test_pretty_print_tuple_recursive():
+    t = m.Tuple(a=m.Bit, b=m.Bit, c=m.Bit)
+    u = m.Tuple(x=t, y=t)
+    assert m.util.pretty_str(u) == """\
+Tuple(
+    x = Tuple(
+        a = Bit,
+        b = Bit,
+        c = Bit
+    ),
+    y = Tuple(
+        a = Bit,
+        b = Bit,
+        c = Bit
+    )
+)\
+"""
+
+
+def test_pretty_print_array_of_tuple():
+    t = m.Tuple(a=m.Bit, b=m.Bit, c=m.Bit)
+    u = m.Array[3, t]
+    assert m.util.pretty_str(u) == """\
+Array[3, Tuple(
+    a = Bit,
+    b = Bit,
+    c = Bit
+)]\
+"""
+
+
+def test_pretty_print_array_of_nested_tuple():
+    t = m.Tuple(a=m.Bit, b=m.Bit, c=m.Bit)
+    u = m.Tuple(x=t, y=t)
+    v = m.Array[3, u]
+    assert m.util.pretty_str(v) == """\
+Array[3, Tuple(
+    x = Tuple(
+        a = Bit,
+        b = Bit,
+        c = Bit
+    ),
+    y = Tuple(
+        a = Bit,
+        b = Bit,
+        c = Bit
+    )
+)]\
+"""

--- a/tests/test_type/test_pretty_print.py
+++ b/tests/test_type/test_pretty_print.py
@@ -44,20 +44,20 @@ Array[3, Tuple(
 
 
 def test_pretty_print_array_of_nested_tuple():
-    t = m.Tuple(a=m.Bit, b=m.Bit, c=m.Bit)
+    t = m.Tuple(a=m.Bits[5], b=m.UInt[3], c=m.SInt[4])
     u = m.Tuple(x=t, y=t)
     v = m.Array[3, u]
     assert m.util.pretty_str(v) == """\
 Array[3, Tuple(
     x = Tuple(
-        a = Bit,
-        b = Bit,
-        c = Bit
+        a = Bits[5],
+        b = UInt[3],
+        c = SInt[4]
     ),
     y = Tuple(
-        a = Bit,
-        b = Bit,
-        c = Bit
+        a = Bits[5],
+        b = UInt[3],
+        c = SInt[4]
     )
 )]\
 """


### PR DESCRIPTION
Formats tuples during printing to separate key/value pairs by line.

Turns something like this:
```
Tuple(PCLK=Out(Clock),PRESETn=Out(Reset),PADDR=Out(Bits[16]),PPROT=Out(Bit),PENABLE=Out(Bit),PWRITE=Out(Bit),PWDATA=Out(Bits[32]),PSTRB=Out(Bits[4]),PREADY=In(Bit),PRDATA=In(Bits[32]),PSLVERR=In(Bit),PSEL0=Out(Bit),PSEL1=Out(Bit))
```

into something like this:
```
Tuple(
    PCLK = Out(Clock),
    PRESETn = Out(Reset),
    PADDR = Out(Bits[16]),
    PPROT = Out(Bit),
    PENABLE = Out(Bit),
    PWRITE = Out(Bit),
    PWDATA = Out(Bits[32]),
    PSTRB = Out(Bits[4]),
    PREADY = In(Bit),
    PRDATA = In(Bits[32]),
    PSLVERR = In(Bit),
    PSEL0 = Out(Bit),
    PSEL1 = Out(Bit)
)
```