### PR TITLE
CoreIR Context And Backend Singletons

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,4 +8,4 @@ def magma_test():
     import magma.config
     magma.config.set_compile_dir('callee_file_dir')
     clear_cachedFunctions()
-    magma.backend.coreir_.__reset_context()
+    magma.backend.coreir_.CoreIRContextSingleton().reset_instance()

--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -15,6 +15,14 @@ def cache_definition(fn):
     cachedFunctions.append(lru_cache(maxsize=None)(fn))
     return cachedFunctions[-1]
 
+def singleton(cls):
+    instance = [None]
+    def wrapper(*args, **kwargs):
+        if instance[0] is None:
+            instance[0] = cls(*args, **kwargs)
+        return instance[0]
+
+    return wrapper
 
 # wires
 from .port import *

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -18,6 +18,7 @@ from ..interface import InterfaceKind
 import inspect
 import copy
 import json
+from .. import singleton
 
 from collections import defaultdict
 
@@ -69,21 +70,26 @@ def magma_port_to_coreir(port):
 
     return select.replace("[", ".").replace("]", "")
 
+# Singleton context meant to be used with coreir/magma code
+@singleton
+class CoreIRContextSingleton:
+    __instance = None
 
-magma_coreir_context = coreir.Context()  # Singleton context meant to be used with coreir/magma code
-def __reset_context():
-    """
-    Testing hook so every test has a fresh context
-    """
-    global magma_coreir_context
-    magma_coreir_context = coreir.Context()
+    def get_instance(self):
+        return self.__instance
 
+    def reset_instance(self):
+        self.__instance = coreir.Context()
+
+    def __init__(self):
+        self.__instance = coreir.Context()
+CoreIRContextSingleton()
 
 class CoreIRBackend:
     context_to_modules_map = {}
     def __init__(self, context=None):
         if context is None:
-            context = magma_coreir_context
+            context = CoreIRContextSingleton().get_instance()
         if context not in CoreIRBackend.context_to_modules_map:
             CoreIRBackend.context_to_modules_map[context] = {}
         self.modules = CoreIRBackend.context_to_modules_map[context]

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -19,6 +19,7 @@ import inspect
 import copy
 import json
 from .. import singleton
+from warnings import warn
 
 from collections import defaultdict
 
@@ -87,9 +88,13 @@ CoreIRContextSingleton()
 
 class CoreIRBackend:
     context_to_modules_map = {}
-    def __init__(self, context=None):
+    def __init__(self, context=None, check_context_is_default=True):
         if context is None:
             context = CoreIRContextSingleton().get_instance()
+        elif check_context_is_default & (context != CoreIRContextSingleton().get_instance()):
+            warn("Creating CoreIRBackend with non-singleton CoreIR context. "
+                 "If you're sure you want to do this, set check_context_is_default "
+                 "when initializing the CoreIRBackend.")
         if context not in CoreIRBackend.context_to_modules_map:
             CoreIRBackend.context_to_modules_map[context] = {}
         self.modules = CoreIRBackend.context_to_modules_map[context]

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -44,9 +44,8 @@ class CheckAnyMantleCircuits(DefinitionPass):
 def __compile_to_coreir(main, file_name, opts):
     # Underscore so our coreir module doesn't conflict with coreir bindings
     # package.
-    from .backend import coreir_
-    context = opts.get("context", None)
-    backend = coreir_.CoreIRBackend(context)
+    from .frontend import coreir_
+    backend = coreir_.GetCoreIRBackend()
     backend.compile(main)
     passes = opts.get("passes", [])
     if "markdirty" not in passes:

--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -1,5 +1,5 @@
 from magma import cache_definition
-from magma.backend.coreir_ import CoreIRBackend, magma_coreir_context
+from magma.backend.coreir_ import CoreIRBackend, CoreIRContextSingleton
 from magma.circuit import DefineCircuitKind, Circuit
 from magma import cache_definition
 from coreir.generator import Generator
@@ -10,7 +10,7 @@ def GetCoreIRBackend():
 
 @cache_definition
 def GetMagmaContext():
-    return magma_coreir_context
+    return CoreIRContextSingleton().get_instance()
 
 def DefineModuleWrapper(cirb: CoreIRBackend, coreirModule, uniqueName, deps):
     class ModuleWrapper(Circuit):

--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -27,7 +27,7 @@ def DefineModuleWrapper(cirb: CoreIRBackend, coreirModule, uniqueName, deps):
 
 def DefineCircuitFromGeneratorWrapper(cirb: CoreIRBackend, namespace: str, generator: str,
                                       uniqueName: str, dependentNamespaces: list = [],
-                                      genargs: dict = {}, runGenerators = True, print_error=False):
+                                      genargs: dict = {}, runGenerators = True):
     moduleToWrap = cirb.context.import_generator(namespace,generator)(**genargs)
 
     deps = [namespace] + dependentNamespaces

--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -3,7 +3,6 @@ from magma.backend.coreir_ import CoreIRBackend, magma_coreir_context
 from magma.circuit import DefineCircuitKind, Circuit
 from magma import cache_definition
 from coreir.generator import Generator
-import coreir
 
 @cache_definition
 def GetCoreIRBackend():
@@ -30,12 +29,6 @@ def DefineCircuitFromGeneratorWrapper(cirb: CoreIRBackend, namespace: str, gener
                                       uniqueName: str, dependentNamespaces: list = [],
                                       genargs: dict = {}, runGenerators = True, print_error=False):
     moduleToWrap = cirb.context.import_generator(namespace,generator)(**genargs)
-
-    if print_error:
-        print(f"Cached cirb IO: {moduleToWrap.type.items()}")
-        fresh_context = coreir.Context()
-        fresh_moduleToWrap = fresh_context.import_generator(namespace,generator)(**genargs)
-        print(f"Fresh cirb IO: {fresh_moduleToWrap.type.items()}")
 
     deps = [namespace] + dependentNamespaces
     if runGenerators:

--- a/magma/simulator/coreir_simulator.py
+++ b/magma/simulator/coreir_simulator.py
@@ -3,6 +3,7 @@ from tempfile import NamedTemporaryFile
 
 from .simulator import CircuitSimulator, ExecutionState
 from ..backend import coreir_
+from ..frontend.coreir_ import GetMagmaContext
 from ..scope import Scope
 from ..ref import DefnRef, ArrayRef, TupleRef
 from ..array import ArrayType
@@ -134,7 +135,7 @@ class CoreIRSimulator(CircuitSimulator):
         setup_clocks(circuit)
 
         if context is None:
-            self.ctx = coreir.Context()
+            self.ctx = GetMagmaContext()
         else:
             self.ctx = context
         coreir_.compile(circuit, coreir_filename, context=self.ctx)

--- a/tests/test_circuit/gold/test_for_loop_def.json
+++ b/tests/test_circuit/gold/test_for_loop_def.json
@@ -8,7 +8,7 @@
           ["I1","BitIn"],
           ["O","Bit"]
         ]],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"54"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"53"}
       },
       "main":{
         "type":["Record",[
@@ -18,33 +18,33 @@
         "instances":{
           "And2_inst0":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"60"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
           },
           "And2_inst1":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"60"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
           },
           "And2_inst2":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"60"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
           },
           "And2_inst3":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"60"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"62"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"63"}],
-          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
-          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
-          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
-          ["self.I.1","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
-          ["And2_inst3.I0","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
-          ["self.I.1","And2_inst3.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
-          ["self.O","And2_inst3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"69"}]
+          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"61"}],
+          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"62"}],
+          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
+          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
+          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
+          ["self.I.1","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
+          ["And2_inst3.I0","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
+          ["self.I.1","And2_inst3.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
+          ["self.O","And2_inst3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"68"}]
         ],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"56"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"55"}
       }
     }
   }

--- a/tests/test_circuit/gold/test_for_loop_def.v
+++ b/tests/test_circuit/gold/test_for_loop_def.v
@@ -1,30 +1,30 @@
-// Defined at tests/test_circuit/test_define.py:56
+// Defined at tests/test_circuit/test_define.py:55
 module main (input [1:0] I, output  O);
 wire  And2_inst0_O;
 wire  And2_inst1_O;
 wire  And2_inst2_O;
 wire  And2_inst3_O;
-// Instanced at tests/test_circuit/test_define.py:60
-// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:62
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:63
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:65
+// Instanced at tests/test_circuit/test_define.py:59
+// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:61
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:62
+// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:64
 And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
-// Instanced at tests/test_circuit/test_define.py:60
-// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:65
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:66
-// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:65
+// Instanced at tests/test_circuit/test_define.py:59
+// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:64
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:65
+// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:64
 And2 And2_inst1 (.I0(And2_inst0_O), .I1(I[1]), .O(And2_inst1_O));
-// Instanced at tests/test_circuit/test_define.py:60
-// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:65
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:66
-// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:65
+// Instanced at tests/test_circuit/test_define.py:59
+// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:64
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:65
+// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:64
 And2 And2_inst2 (.I0(And2_inst1_O), .I1(I[1]), .O(And2_inst2_O));
-// Instanced at tests/test_circuit/test_define.py:60
-// Argument I0(And2_inst2_O) wired at tests/test_circuit/test_define.py:65
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:66
-// Argument O(And2_inst3_O) wired at tests/test_circuit/test_define.py:69
+// Instanced at tests/test_circuit/test_define.py:59
+// Argument I0(And2_inst2_O) wired at tests/test_circuit/test_define.py:64
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:65
+// Argument O(And2_inst3_O) wired at tests/test_circuit/test_define.py:68
 And2 And2_inst3 (.I0(And2_inst2_O), .I1(I[1]), .O(And2_inst3_O));
-// Wired at tests/test_circuit/test_define.py:69
+// Wired at tests/test_circuit/test_define.py:68
 assign O = And2_inst3_O;
 endmodule
 

--- a/tests/test_circuit/gold/test_interleaved_instance_wiring.json
+++ b/tests/test_circuit/gold/test_interleaved_instance_wiring.json
@@ -8,7 +8,7 @@
           ["I1","BitIn"],
           ["O","Bit"]
         ]],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"84"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"83"}
       },
       "main":{
         "type":["Record",[
@@ -18,27 +18,27 @@
         "instances":{
           "And2_inst0":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"88"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"87"}
           },
           "And2_inst1":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"89"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"88"}
           },
           "And2_inst2":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"95"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"94"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"91"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"92"}],
-          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"93"}],
-          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"94"}],
-          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"96"}],
-          ["self.I.0","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"97"}],
-          ["self.O","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"99"}]
+          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"90"}],
+          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"91"}],
+          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"92"}],
+          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"93"}],
+          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"95"}],
+          ["self.I.0","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"96"}],
+          ["self.O","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"98"}]
         ],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"86"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"85"}
       }
     }
   }

--- a/tests/test_circuit/gold/test_interleaved_instance_wiring.v
+++ b/tests/test_circuit/gold/test_interleaved_instance_wiring.v
@@ -1,24 +1,24 @@
-// Defined at tests/test_circuit/test_define.py:86
+// Defined at tests/test_circuit/test_define.py:85
 module main (input [1:0] I, output  O);
 wire  And2_inst0_O;
 wire  And2_inst1_O;
 wire  And2_inst2_O;
-// Instanced at tests/test_circuit/test_define.py:88
-// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:91
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:92
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:93
+// Instanced at tests/test_circuit/test_define.py:87
+// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:90
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:91
+// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:92
 And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
-// Instanced at tests/test_circuit/test_define.py:89
-// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:93
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:94
-// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:96
+// Instanced at tests/test_circuit/test_define.py:88
+// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:92
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:93
+// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:95
 And2 And2_inst1 (.I0(And2_inst0_O), .I1(I[1]), .O(And2_inst1_O));
-// Instanced at tests/test_circuit/test_define.py:95
-// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:96
-// Argument I1(I[0]) wired at tests/test_circuit/test_define.py:97
-// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:99
+// Instanced at tests/test_circuit/test_define.py:94
+// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:95
+// Argument I1(I[0]) wired at tests/test_circuit/test_define.py:96
+// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:98
 And2 And2_inst2 (.I0(And2_inst1_O), .I1(I[0]), .O(And2_inst2_O));
-// Wired at tests/test_circuit/test_define.py:99
+// Wired at tests/test_circuit/test_define.py:98
 assign O = And2_inst2_O;
 endmodule
 

--- a/tests/test_circuit/gold/test_simple_def_class.json
+++ b/tests/test_circuit/gold/test_simple_def_class.json
@@ -27,6 +27,24 @@
           ["self.O","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"39"}]
         ],
         "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"31"}
+      },
+      "main":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "And2_inst0":{
+            "modref":"global.And2",
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"18"}
+          }
+        },
+        "connections":[
+          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"20"}],
+          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"21"}],
+          ["self.O","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"22"}]
+        ],
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"16"}
       }
     }
   }

--- a/tests/test_circuit/test_define.py
+++ b/tests/test_circuit/test_define.py
@@ -39,8 +39,7 @@ def test_simple_def(target, suffix):
             m.wire(and2.O, io.O)
 
     # Create a fresh context for second compilation.
-    m.compile("build/test_simple_def_class", Main, output=target,
-              context=coreir.Context())
+    m.compile("build/test_simple_def_class", Main, output=target)
     m.set_codegen_debug_info(False)
     assert check_files_equal(__file__, f"build/test_simple_def_class.{suffix}",
                              f"gold/test_simple_def_class.{suffix}")


### PR DESCRIPTION
1. Added methods in the CoreIR frontend file for getting a singleton CoreIR context and backend
2. Replaced the global magma_coreir_context with a singleton object that wraps the context
    1. This fixed the issue with __reset_context noted https://github.com/phanrahan/magma/issues/407#issuecomment-501019630 and https://github.com/phanrahan/magma/issues/407#issuecomment-501040969. __reset_context() wasn't replacing all references to magma_coreir_context. The singleton object handles resets correctly. I know it handles resets correctly because I'm using the singleton CoreIR context and backend in Aetherling's unit tests.