### PR TITLE
Relax condition for rewriting select path for nested type

### DIFF
--- a/magma/simulator/coreir_simulator.py
+++ b/magma/simulator/coreir_simulator.py
@@ -53,9 +53,8 @@ def convert_to_coreir_path(bit, scope):
     # Handle renaming due to flatten types
     arrOrTuple = bit
     while isinstance(arrOrTuple.name, ArrayRef) or isinstance(arrOrTuple.name, TupleRef):
-        if isinstance(arrOrTuple, ArrayType) or isinstance(arrOrTuple, TupleType):
-            port, idx = port.split('.', 1)
-            port += '_' + idx
+        port, idx = port.split('.', 1)
+        port += '_' + idx
         if isinstance(arrOrTuple.name, ArrayRef):
             arrOrTuple = arrOrTuple.name.array
         elif isinstance(arrOrTuple.name, TupleRef):


### PR DESCRIPTION
Before the logic was only rewriting the select path when an array or
tuple object was reference from an Array or Tuple. This relaxes it
to always rewrite the select path when any object is referenced from
an Array or Tuple.

In the case of https://github.com/phanrahan/magma/issues/415, a Bit was
being selected from a Tuple, but was not rewritten because it failed
the condition:

    isinstance(arrOrTuple, ArrayType) or \
    isinstance(arrOrTuple, TupleType)

However, regardless of the type of the child object that is being
selected from the tuple/array, we should be rewriting the select path
to flatten out the tuple/array

Fixes https://github.com/phanrahan/magma/issues/415