### PR TITLE
Rework logic for flattenning name

### DIFF
--- a/magma/simulator/coreir_simulator.py
+++ b/magma/simulator/coreir_simulator.py
@@ -57,6 +57,7 @@ def convert_to_coreir_path(bit, scope):
             return str(name)
         if isinstance(name, ArrayRef):
             array_name = flattened_name(name.array.name)
+            # CoreIR simulator doesn't flatten array of bits
             if isinstance(name.array.T, BitKind):
                 return f"{array_name}.{name.index}"
             else:


### PR DESCRIPTION
@David-Durst I was seeing other aetherling tests fail with the recent patch to the naming logic, so I rewrote the logic based on the fault implementation and I think it makes more sense, can you review it?

I think the issue is that the coreir simulator does not flatten array of bits (but it does flatten a tuple of bits), so the we needed to rework the check for when to flatten the name.

Also let me know if you're running into other/related test failures.