### PR TITLE
Named phi

### DIFF
--- a/magma/ast_utils.py
+++ b/magma/ast_utils.py
@@ -73,6 +73,34 @@ def inspect_enclosing_env(fn):
         return fn(enclosing_env, *args, **kwargs)
     return wrapped
 
+class NameCollector(ast.NodeVisitor):
+    def __init__(self):
+        self.names = set()
+
+    def visit_Name(self, node: ast.Name):
+        self.names.add(node.id)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        self.names.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+        self.names.add(node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef):
+        self.names.add(node.name)
+
+def gen_free_name(tree: ast.AST, defn_env: dict, prefix: str = '__auto_name_'):
+    visitor = NameCollector()
+    visitor.visit(tree)
+    used_names = visitor.names | defn_env.keys()
+    f_str = prefix+'{}'
+    c = 0
+    name = f_str.format(c)
+    while name in used_names:
+        c += 1
+        name = f_str.format(c)
+
+    return name
 
 def filter_decorator(decorator : typing.Callable, decorator_list : typing.List[ast.AST], env : dict):
     def _filter(node):

--- a/magma/ast_utils.py
+++ b/magma/ast_utils.py
@@ -104,6 +104,13 @@ def gen_free_name(tree: ast.AST, defn_env: dict, prefix: str = '__auto_name_'):
 
 def filter_decorator(decorator : typing.Callable, decorator_list : typing.List[ast.AST], env : dict):
     def _filter(node):
-        code = compile(ast.Expression(node), filename="<string>", mode="eval")
-        return eval(code, env) != decorator
+        if isinstance(node, ast.Call):
+            expr = ast.Expression(node.func)
+        elif isinstance(node, ast.Name):
+            expr = ast.Expression(node)
+        else:
+            return True
+        code = compile(expr, filename="<string>", mode="eval")
+        e = eval(code, env)
+        return e != decorator
     return list(filter(_filter, decorator_list))


### PR DESCRIPTION
Adds utility function `gen_free_name`

changes `ssa`:
* `ssa` now takes an optional argument `phi` which can be either a function or a string
  * default value `"phi"`
  * if `phi` is a string then `ssa` will assume that such a name exists in the environment of the decorated function
  * if `phi` is a function then `ssa` will generate a new name and associate `phi` with the name in the generated code
* moves the stripping of decorators from `convert_tree_to_ssa` to `ssa`