### PR TITLE
Add basic for loop to combinational

### DIFF
--- a/docs/circuit_definitions.md
+++ b/docs/circuit_definitions.md
@@ -91,6 +91,31 @@ def return_magma_named_tuple(I: m.Bits(2)) -> m.Tuple(x=m.Bit, y=m.Bit):
     return m.namedtuple(x=I[0], y=I[1])
 ```
 
+## Basic for loops
+Basic for loops ranging over integer values are supported (they are ignored by
+the syntax transformations so they will be executed as standard Python/magma
+code). However, `if` statements are subject to an `ssa` transformation, so
+they use the above described form (you can only assign to values inside an if
+statement).
+
+This code:
+```python
+n = 4
+@m.circuit.combinational
+def logic(a: m.Bits[n]) -> m.Bits[n]:
+    O = []
+    for i in range(n):
+        O.append(a[n - 1 - i])
+    return m.bits(O, n)
+```
+
+produces this verilog
+```python
+module logic (input [3:0] a, output [3:0] O);
+assign O = {a[0],a[1],a[2],a[3]};
+endmodule
+```
+
 # Sequential Circuit Definition
 The `@m.circuit.sequential` decorator extends the `@m.circuit.combinational`
 syntax with the ability to use Python's class system to describe stateful

--- a/docs/circuit_definitions.md
+++ b/docs/circuit_definitions.md
@@ -1,7 +1,26 @@
 # Combinational Circuit Definitions
-Circuit defintions can be marked with the `@m.circuit.combinational` decorator.
-This introduces a set of syntax level features for defining combinational magma
-circuits, including the use of `if` statements to generate `Mux`es.
+The `@m.circuit.combinational` decorator provides a way to use function syntax
+for describing combinational circuits.  Inputs are given names and annotated
+with a Magma type using Python 3's type annotation syntax.  Output type(s) are
+provided using Python 3's return annotation syntax (`->`).  If a single output
+type is specified, the magma circuit will have a single output named `O`.  If
+`n` types are specified separated by commas, the magma circuit will have `n`
+outputs named `O{i}` where `i` is the index of the type in the annotation.
+Inside the combinational function, circuits can be described using control
+flow, specifically `if` statements and `return` statements.  These constructs
+will be compiled by magma using an SSA transformation pass, that turns `if`
+statements into `phi` nodes that are equivalent to hardware muxes.  This
+essentially allows the user to define muxes using if statements instead of
+structural muxes.  All other code is untouched and will be passed through to
+the normal downstream magma compiler, so things like instantiating another
+magma circuit or basic for loops will work.
+
+### Limitations
+Because `if` statements are subject to the SSA transformation passes, normal
+Python `if` statements (e.g. dispatching on a parameter) to a circuit generator
+are not supported.  All `if` statements are treated as if they correspond to
+hardware mux.  Support for the use of both Python `if`s and Magma `if`s is
+forthcoming.
 
 This feature is currently experimental, and therefor expect bugs to occur.
 Please file any issues on the magma GitHub repository.

--- a/docs/circuit_definitions.md
+++ b/docs/circuit_definitions.md
@@ -109,7 +109,22 @@ def logic(a: m.Bits[n]) -> m.Bits[n]:
     return m.bits(O, n)
 ```
 
-produces this verilog
+compiles to this magma circuit
+```python
+class logic(m.Circuit):
+    IO = ['a', m.In(m.Bits[n]), 'O', m.Out(m.Bits[n])]
+
+    @classmethod
+    def definition(io):
+        O_0 = []
+        for i_0 in range(n):
+            O_0.append(io.a[n - 1 - i_0])
+        __magma_ssa_return_value_0 = m.bits(O_0, n)
+        O = __magma_ssa_return_value_0
+        m.wire(O, io.O)
+```
+
+which produces this verilog
 ```python
 module logic (input [3:0] a, output [3:0] O);
 assign O = {a[0],a[1],a[2],a[3]};

--- a/tests/test_syntax/gold/for_loop_simple.json
+++ b/tests/test_syntax/gold/for_loop_simple.json
@@ -1,0 +1,35 @@
+{"top":"global.Foo",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Foo":{
+        "type":["Record",[
+          ["a",["Array",4,"BitIn"]],
+          ["c",["Array",4,"Bit"]]
+        ]],
+        "instances":{
+          "logic_inst0":{
+            "modref":"global.logic"
+          }
+        },
+        "connections":[
+          ["self.c","logic_inst0.O"],
+          ["self.a","logic_inst0.a"]
+        ]
+      },
+      "logic":{
+        "type":["Record",[
+          ["a",["Array",4,"BitIn"]],
+          ["O",["Array",4,"Bit"]]
+        ]],
+        "connections":[
+          ["self.a.3","self.O.0"],
+          ["self.a.2","self.O.1"],
+          ["self.a.1","self.O.2"],
+          ["self.a.0","self.O.3"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_syntax/gold/for_loop_simple.v
+++ b/tests/test_syntax/gold/for_loop_simple.v
@@ -1,0 +1,10 @@
+module logic (input [3:0] a, output [3:0] O);
+assign O = {a[0],a[1],a[2],a[3]};
+endmodule
+
+module Foo (input [3:0] a, output [3:0] c);
+wire [3:0] logic_inst0_O;
+logic logic_inst0 (.a(a), .O(logic_inst0_O));
+assign c = logic_inst0_O;
+endmodule
+

--- a/tests/test_syntax/test_combinational.py
+++ b/tests/test_syntax/test_combinational.py
@@ -298,3 +298,24 @@ def test_renamed_args_wire(target):
             io.O <= inv.O
 
     compile_and_check("test_renamed_args_wire", Foo, target)
+
+
+def test_for_loop(target):
+    n = 4
+    @m.circuit.combinational
+    def logic(a: m.Bits[n]) -> m.Bits[n]:
+        O = []
+        for i in range(n):
+            O.append(a[n - 1 - i])
+        return m.bits(O, n)
+
+    class Foo(m.Circuit):
+        IO = ["a", m.In(m.Bits[n]),
+              "c", m.Out(m.Bits[n])]
+
+        @classmethod
+        def definition(io):
+            c = logic(io.a)
+            m.wire(c, io.c)
+
+    compile_and_check("for_loop_simple", Foo, target)

--- a/tests/test_syntax/test_combinational.py
+++ b/tests/test_syntax/test_combinational.py
@@ -306,10 +306,7 @@ def test_for_loop(target):
     def logic(a: m.Bits[n]) -> m.Bits[n]:
         O = []
         for i in range(n):
-            b = a[n - 1 - i]
-            if i % 2:
-                b = Not()(b)
-            O.append(b)
+            O.append(a[n - 1 - i])
         return m.bits(O, n)
 
     class Foo(m.Circuit):

--- a/tests/test_syntax/test_combinational.py
+++ b/tests/test_syntax/test_combinational.py
@@ -306,7 +306,10 @@ def test_for_loop(target):
     def logic(a: m.Bits[n]) -> m.Bits[n]:
         O = []
         for i in range(n):
-            O.append(a[n - 1 - i])
+            b = a[n - 1 - i]
+            if i % 2:
+                b = Not()(b)
+            O.append(b)
         return m.bits(O, n)
 
     class Foo(m.Circuit):


### PR DESCRIPTION
It turns out, because for loops are ignored and passed through to the Python magma circuit definition, using them in some basic forms works, see the example.

There are some issues, for example you can't do something different based on the loop index, for example
```python
    n = 4
    @m.circuit.combinational
    def logic(a: m.Bits[n]) -> m.Bits[n]:
        O = []
        for i in range(n):
            b = a[n - 1 - i]
            if i % 2:
                b = Not()(b)
            O.append(b)
        return m.bits(O, n)
```
will actually get translated into
```python
class logic(m.Circuit):
    IO = ['a', m.In(m.Bits[n]), 'O', m.Out(m.Bits[n])]

    @classmethod
    def definition(io):
        O_0 = []
        for i_0 in range(n):
            b_0 = io.a[n - 1 - i_0]
            b_1 = Not()(b_0)
            b_2 = phi([b_0, b_1], i_0 % 2)
            O_0.append(b_2)
        __magma_ssa_return_value_0 = m.bits(O_0, n)
        O = __magma_ssa_return_value_0
        m.wire(O, io.O)
```
Notice that `Not()` is called regardless if the `if` statement is taken, because the SSA transformation doesn't preserve behavior w.r.t. to side effects. I think the solution here is to do a type inference pass, determine that `if` statement conditions are python or magma values. If it is a python value, don't do an ssa transformation and leave it as a python value (or the inverse, only do ssa on magma values).

We could use an explicit escape pattern, such as (the curly braces):
```python
    n = 4
    @m.circuit.combinational
    def logic(a: m.Bits[n]) -> m.Bits[n]:
        O = []
        for i in range(n):
            b = a[n - 1 - i]
            if {i % 2}:
                b = Not()(b)
            O.append(b)
        return m.bits(O, n)
```

Here's another version that explicitly escapes the for loop (curly braces quote magma code)

```python
    n = 4
    @m.circuit.combinational
    def logic(a: m.Bits[n]) -> m.Bits[n]:
        O = []
        with syntax as python:
            for i in range(n):
                {b = a[n - 1 - i]}
                if i % 2:
                    {b = Not()(b)}
                {O.append(b)}
            {return m.bits(O, n)}
```