### PR TITLE
Fix bug in handling of tuple names

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -9,7 +9,7 @@ from ..bitutils import seq2int
 from ..backend.verilog import find
 from ..logging import error
 import coreir
-from ..ref import ArrayRef, DefnRef, TupleRef
+from ..ref import ArrayRef, DefnRef, TupleRef, InstRef
 from ..passes import InstanceGraphPass
 from ..t import In
 import logging
@@ -45,31 +45,28 @@ class keydefaultdict(defaultdict):
             ret = self[key] = self.default_factory(key)
             return ret
 
-def get_top_name(name):
-    if isinstance(name, TupleRef):
-        return get_top_name(name.tuple.name)
-    if isinstance(name, ArrayRef):
-        return get_top_name(name.array.name)
-    return name
+
+def name_to_coreir_select(name):
+    if isinstance(name, InstRef):
+        return name.inst.name + "." + str(name.name)
+    elif isinstance(name, DefnRef):
+        return "self." + name.name
+    elif isinstance(name, ArrayRef):
+        return name_to_coreir_select(name.array.name) + "." + str(name.index)
+    elif isinstance(name, TupleRef):
+        index = name.index
+        try:
+            int(index)
+            index = f"_{index}"
+        except ValueError:
+            pass
+        return name_to_coreir_select(name.tuple.name) + "." + index
+    else:
+        raise NotImplementedError(name)
+
 
 def magma_port_to_coreir(port):
-    select = repr(port)
-
-    name = port.name
-    if isinstance(name, TupleRef):
-        # Prefix integer indexes for unnamed tuples (e.g. 0, 1, 2) with "_"
-        if name.index.isdigit():
-            select = select.split(".")
-            select[-1] = "_" + select[-1]
-            select = ".".join(select)
-    name = get_top_name(name)
-    if isinstance(name, DefnRef):
-        if name.defn.name != "":
-            select_list = select.split(".")
-            select_list[0] = "self"
-            select = ".".join(select_list)
-
-    return select.replace("[", ".").replace("]", "")
+    return name_to_coreir_select(port.name)
 
 # Singleton context meant to be used with coreir/magma code
 @singleton

--- a/tests/test_coreir/gold/test_anon_tuple.json
+++ b/tests/test_coreir/gold/test_anon_tuple.json
@@ -1,0 +1,16 @@
+{"top":"global.Foo",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Foo":{
+        "type":["Record",[
+          ["ifc",["Record",[["_0","BitIn"],["_1","Bit"]]]]
+        ]],
+        "connections":[
+          ["self.ifc._1","self.ifc._0"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/gold/test_anon_tuple_nested_array.json
+++ b/tests/test_coreir/gold/test_anon_tuple_nested_array.json
@@ -1,0 +1,17 @@
+{"top":"global.Foo",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Foo":{
+        "type":["Record",[
+          ["ifc",["Record",[["_0",["Array",2,"BitIn"]],["_1",["Array",2,"Bit"]]]]]
+        ]],
+        "connections":[
+          ["self.ifc._1.1","self.ifc._0.0"],
+          ["self.ifc._1.0","self.ifc._0.1"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/gold/test_nested_anon_tuple.json
+++ b/tests/test_coreir/gold/test_nested_anon_tuple.json
@@ -1,0 +1,17 @@
+{"top":"global.Foo",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Foo":{
+        "type":["Record",[
+          ["ifc",["Array",2,["Record",[["_0","BitIn"],["_1","Bit"]]]]]
+        ]],
+        "connections":[
+          ["self.ifc.1._1","self.ifc.0._0"],
+          ["self.ifc.1._0","self.ifc.0._1"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_coreir/test_coreir_tuple.py
+++ b/tests/test_coreir/test_coreir_tuple.py
@@ -74,5 +74,34 @@ def test_array_nesting():
     assert check_files_equal(__file__, f"build/test_array_nesting.json",
                              f"gold/test_array_nesting.json")
 
+
+def test_anon_tuple():
+    foo = m.DefineCircuit("Foo", "ifc", m.Tuple(m.In(m.Bit), m.Out(m.Bit)))
+    m.wire(foo.ifc[0], foo.ifc[1])
+    m.EndCircuit()
+    m.compile("build/test_anon_tuple", foo, output="coreir")
+    assert check_files_equal(__file__, f"build/test_anon_tuple.json",
+                             f"gold/test_anon_tuple.json")
+
+
+def test_nested_anon_tuple():
+    foo = m.DefineCircuit("Foo", "ifc", m.Array[2, m.Tuple(m.In(m.Bit), m.Out(m.Bit))])
+    m.wire(foo.ifc[0][0], foo.ifc[1][1])
+    m.wire(foo.ifc[1][0], foo.ifc[0][1])
+    m.EndCircuit()
+    m.compile("build/test_nested_anon_tuple", foo, output="coreir")
+    assert check_files_equal(__file__, f"build/test_nested_anon_tuple.json",
+                             f"gold/test_nested_anon_tuple.json")
+
+
+def test_anon_tuple_nested_array():
+    foo = m.DefineCircuit("Foo", "ifc", m.Tuple(m.In(m.Bits[2]), m.Out(m.Bits[2])))
+    m.wire(foo.ifc[0][0], foo.ifc[1][1])
+    m.wire(foo.ifc[0][1], foo.ifc[1][0])
+    m.EndCircuit()
+    m.compile("build/test_anon_tuple_nested_array", foo, output="coreir")
+    assert check_files_equal(__file__, f"build/test_anon_tuple_nested_array.json",
+                             f"gold/test_anon_tuple_nested_array.json")
+
 if __name__ == "__main__":
     test_multi_direction_tuple()


### PR DESCRIPTION
This generalizes the logic for handling tuple/array selects in the coreir backend.

Before, it would only work if the current select value, was an array or port, but not if the parent select values were (so selecting nested array/tuple values).  See the new tests for the use cases that were before unsupported. This issue arose when trying to use nested tuples with integer keys. (e.g. anon tuple with array children)