### PR TITLE
Add initial support for coreir-verilog instance params

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -41,7 +41,7 @@ class Top(m.Circuit):
         io.O <= m.join([ff0, ff1])(d=io.I, rst=io.ASYNCRESET)
 
 
-m.compile("top", Top, output="verilog")
+m.compile("top", Top, output="coreir-verilog")
 ```
 
 This produces the following Verilog, notice how the arguments to the magma
@@ -62,11 +62,11 @@ end
 
 assign q = ff;
 endmodule
-module Top (input [1:0] I, output [1:0] O, input  CLK, input  ASYNCRESET);
-wire  FF_inst0_q;
-wire  FF_inst1_q;
-FF #(.init(0)) FF_inst0 (.clk(CLK), .rst(ASYNCRESET), .d(I[0]), .q(FF_inst0_q));
-FF #(.init(1)) FF_inst1 (.clk(CLK), .rst(ASYNCRESET), .d(I[1]), .q(FF_inst1_q));
+module Top (input ASYNCRESET, input CLK, input [1:0] I, output [1:0] O);
+wire FF_inst0_q;
+wire FF_inst1_q;
+FF #(.init(0)) FF_inst0(.clk(CLK), .d(I[0]), .q(FF_inst0_q), .rst(ASYNCRESET));
+FF #(.init(1)) FF_inst1(.clk(CLK), .d(I[1]), .q(FF_inst1_q), .rst(ASYNCRESET));
 assign O = {FF_inst1_q,FF_inst0_q};
 endmodule
 

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -255,9 +255,9 @@ class CoreIRBackend:
             module_type = self.context.Flip(module_type)
 
         kwargs = {}
-        if hasattr(declaration, "verilog_param_types"):
+        if hasattr(declaration, "coreir_config_param_types"):
             kwargs["cparams"] = \
-                self.make_cparams(declaration.verilog_param_types)
+                self.make_cparams(declaration.coreir_config_param_types)
 
         coreir_module = \
             self.context.global_namespace.new_module(declaration.coreir_name,
@@ -329,9 +329,9 @@ class CoreIRBackend:
         self.check_interface(definition)
         module_type = self.convert_interface_to_module_type(definition.interface)
         kwargs = {}
-        if hasattr(definition, "verilog_param_types"):
+        if hasattr(definition, "coreir_config_param_types"):
             kwargs["cparams"] = \
-                self.make_cparams(definition.verilog_param_types)
+                self.make_cparams(definition.coreir_config_param_types)
 
         coreir_module = \
             self.context.global_namespace.new_module(definition.coreir_name,

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -254,8 +254,14 @@ class CoreIRBackend:
         if isinstance(declaration.interface, InterfaceKind):
             module_type = self.context.Flip(module_type)
 
-        coreir_module = self.context.global_namespace.new_module(declaration.coreir_name,
-                                                                 module_type)
+        kwargs = {}
+        if hasattr(declaration, "verilog_param_types"):
+            kwargs["cparams"] = \
+                self.make_cparams(declaration.verilog_param_types)
+
+        coreir_module = \
+            self.context.global_namespace.new_module(declaration.coreir_name,
+                                                     module_type, **kwargs)
         if get_codegen_debug_info() and declaration.debug_info:
             coreir_module.add_metadata("filename", json.dumps(make_relative(declaration.debug_info.filename)))
             coreir_module.add_metadata("lineno", json.dumps(str(declaration.debug_info.lineno)))
@@ -299,6 +305,22 @@ class CoreIRBackend:
             self.connect(module_definition, port, port.value(),
                          non_input_ports)
 
+    def make_cparams(self, param_types):
+        cparams = {}
+        for param, type_ in param_types.items():
+            if type_ is int:
+                type_ = self.context.Int()
+            elif type_ is bool:
+                type_ = self.context.Bool()
+            elif type_ is str:
+                type_ = self.context.String()
+            elif type_ is BitVector:
+                type_ = self.context.BitVector()
+            else:
+                raise NotImplementedError(type_)
+            cparams[param] = type_
+        return self.context.newParams(cparams)
+
     def compile_definition(self, definition):
         logger.debug(f"Compiling definition {definition}")
         if definition.name in self.modules:
@@ -308,20 +330,8 @@ class CoreIRBackend:
         module_type = self.convert_interface_to_module_type(definition.interface)
         kwargs = {}
         if hasattr(definition, "verilog_param_types"):
-            cparams = {}
-            for param, type_ in definition.verilog_param_types.items():
-                if type_ is int:
-                    type_ = self.context.Int()
-                elif type_ is bool:
-                    type_ = self.context.Bool()
-                elif type_ is str:
-                    type_ = self.context.String()
-                elif type_ is BitVector:
-                    type_ = self.context.BitVector()
-                else:
-                    raise NotImplementedError(type_)
-                cparams[param] = type_
-            kwargs["cparams"] = self.context.newParams(cparams)
+            kwargs["cparams"] = \
+                self.make_cparams(definition.verilog_param_types)
 
         coreir_module = \
             self.context.global_namespace.new_module(definition.coreir_name,

--- a/magma/fromverilog.py
+++ b/magma/fromverilog.py
@@ -187,7 +187,7 @@ def FromVerilog(source, func, type_map, target_modules=None, shallow=False,
         parsed_name, args = ParseVerilogModule(verilog_defn, type_map)
         assert parsed_name == name
         magma_defn = func(name, *args)
-        magma_defn.verilog_param_types = param_map
+        magma_defn.coreir_config_param_types = param_map
         if func == DefineCircuit:
             # Attach relevant lines of verilog source.
             magma_defn.verilogFile = _get_lines(

--- a/magma/fromverilog.py
+++ b/magma/fromverilog.py
@@ -164,7 +164,7 @@ def ParseVerilogModule(node, type_map):
 
 
 def FromVerilog(source, func, type_map, target_modules=None, shallow=False,
-                external_modules={}):
+                external_modules={}, param_map={}):
     parser = VerilogParser()
     ast = parser.parse(source)
     visitor = ModuleVisitor(shallow)
@@ -187,6 +187,7 @@ def FromVerilog(source, func, type_map, target_modules=None, shallow=False,
         parsed_name, args = ParseVerilogModule(verilog_defn, type_map)
         assert parsed_name == name
         magma_defn = func(name, *args)
+        magma_defn.verilog_param_types = param_map
         if func == DefineCircuit:
             # Attach relevant lines of verilog source.
             magma_defn.verilogFile = _get_lines(
@@ -210,11 +211,13 @@ def FromVerilog(source, func, type_map, target_modules=None, shallow=False,
     # Filter modules based on target_modules list.
     return [v for k, v in magma_defns.items() if k in target_modules]
 
-def FromVerilogFile(file, func, type_map, target_modules=None, shallow=False, external_modules={}):
+def FromVerilogFile(file, func, type_map, target_modules=None, shallow=False,
+                    external_modules={}, param_map={}):
     if file is None:
         return None
     verilog = open(file).read()
-    result = FromVerilog(verilog, func, type_map, target_modules, shallow, external_modules)
+    result = FromVerilog(verilog, func, type_map, target_modules, shallow,
+                         external_modules, param_map)
     # Store the original verilog file name, currently used by m.compile to
     # generate a .sv when compiling a circuit that was defined from a verilog
     # file
@@ -233,11 +236,11 @@ def FromTemplatedVerilogFile(file, func, type_map, **kwargs):
     return FromTemplatedVerilog(templatedverilog, func, type_map, **kwargs)
 
 
-def DeclareFromVerilog(source, type_map={}):
-    return FromVerilog(source, DeclareCircuit, type_map)
+def DeclareFromVerilog(source, type_map={}, param_map={}):
+    return FromVerilog(source, DeclareCircuit, type_map, param_map)
 
-def DeclareFromVerilogFile(file, target_modules=None, type_map={}):
-    return FromVerilogFile(file, DeclareCircuit, type_map, target_modules)
+def DeclareFromVerilogFile(file, target_modules=None, type_map={}, param_map={}):
+    return FromVerilogFile(file, DeclareCircuit, type_map, target_modules, param_map)
 
 def DeclareFromTemplatedVerilog(source, type_map={}, **kwargs):
     return FromTemplatedVerilog(source, DeclareCircuit, type_map, **kwargs)
@@ -246,13 +249,17 @@ def DeclareFromTemplatedVerilogFile(file, type_map={}, **kwargs):
     return FromTemplatedVerilogFile(file, DeclareCircuit, type_map, **kwargs)
 
 
-def DefineFromVerilog(source, type_map={}, target_modules=None, shallow=False, external_modules={}):
+def DefineFromVerilog(source, type_map={}, target_modules=None, shallow=False,
+                      external_modules={}, param_map={}):
     return FromVerilog(source, DefineCircuit, type_map, target_modules,
-                       shallow=shallow, external_modules=external_modules)
+                       shallow=shallow, external_modules=external_modules,
+                       param_map=param_map)
 
-def DefineFromVerilogFile(file, target_modules=None, type_map={}, shallow=False, external_modules={}):
+def DefineFromVerilogFile(file, target_modules=None, type_map={},
+                          shallow=False, external_modules={}, param_map={}):
     return FromVerilogFile(file, DefineCircuit, type_map, target_modules,
-                           shallow=shallow, external_modules=external_modules)
+                           shallow=shallow, external_modules=external_modules,
+                           param_map=param_map)
 
 def DefineFromTemplatedVerilog(source, type_map={}, **kwargs):
     return FromTemplatedVerilog(source, DefineCircuit, type_map, **kwargs)

--- a/magma/fromverilog.py
+++ b/magma/fromverilog.py
@@ -217,7 +217,7 @@ def FromVerilogFile(file, func, type_map, target_modules=None, shallow=False,
         return None
     verilog = open(file).read()
     result = FromVerilog(verilog, func, type_map, target_modules, shallow,
-                         external_modules, param_map)
+                         external_modules, param_map=param_map)
     # Store the original verilog file name, currently used by m.compile to
     # generate a .sv when compiling a circuit that was defined from a verilog
     # file
@@ -237,10 +237,10 @@ def FromTemplatedVerilogFile(file, func, type_map, **kwargs):
 
 
 def DeclareFromVerilog(source, type_map={}, param_map={}):
-    return FromVerilog(source, DeclareCircuit, type_map, param_map)
+    return FromVerilog(source, DeclareCircuit, type_map, param_map=param_map)
 
 def DeclareFromVerilogFile(file, target_modules=None, type_map={}, param_map={}):
-    return FromVerilogFile(file, DeclareCircuit, type_map, target_modules, param_map)
+    return FromVerilogFile(file, DeclareCircuit, type_map, target_modules, param_map=param_map)
 
 def DeclareFromTemplatedVerilog(source, type_map={}, **kwargs):
     return FromTemplatedVerilog(source, DeclareCircuit, type_map, **kwargs)

--- a/tests/test_verilog/ff.v
+++ b/tests/test_verilog/ff.v
@@ -1,0 +1,15 @@
+// ff.v
+module FF(input clk, input rst, input d, output q);
+
+parameter init = 0;
+
+reg ff; 
+always @(posedge clk or posedge rst) begin
+  if (!rst)
+    ff <= init;
+  else
+    ff <= d; 
+end
+
+assign q = ff;
+endmodule

--- a/tests/test_verilog/gold/top-coreir-verilog.v
+++ b/tests/test_verilog/gold/top-coreir-verilog.v
@@ -1,0 +1,22 @@
+module FF(input clk, input rst, input d, output q);
+
+parameter init = 0;
+
+reg ff; 
+always @(posedge clk or posedge rst) begin
+  if (!rst)
+    ff <= init;
+  else
+    ff <= d; 
+end
+
+assign q = ff;
+endmodule
+module Top (input ASYNCRESET, input CLK, input [1:0] I, output [1:0] O);
+wire FF_inst0_q;
+wire FF_inst1_q;
+FF #(.init(0)) FF_inst0(.clk(CLK), .d(I[0]), .q(FF_inst0_q), .rst(ASYNCRESET));
+FF #(.init(1)) FF_inst1(.clk(CLK), .d(I[1]), .q(FF_inst1_q), .rst(ASYNCRESET));
+assign O = {FF_inst1_q,FF_inst0_q};
+endmodule
+

--- a/tests/test_verilog/gold/top-coreir.json
+++ b/tests/test_verilog/gold/top-coreir.json
@@ -1,0 +1,46 @@
+{"top":"global.Top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "FF":{
+        "type":["Record",[
+          ["clk",["Named","coreir.clkIn"]],
+          ["rst",["Named","coreir.arstIn"]],
+          ["d","BitIn"],
+          ["q","Bit"]
+        ]],
+        "modparams":{"init":"Int"},
+        "metadata":{"verilog":{"verilog_string":"module FF(input clk, input rst, input d, output q);\n\nparameter init = 0;\n\nreg ff; \nalways @(posedge clk or posedge rst) begin\n  if (!rst)\n    ff <= init;\n  else\n    ff <= d; \nend\n\nassign q = ff;\nendmodule"}}
+      },
+      "Top":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["O",["Array",2,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]],
+          ["ASYNCRESET",["Named","coreir.arstIn"]]
+        ]],
+        "instances":{
+          "FF_inst0":{
+            "modref":"global.FF",
+            "modargs":{"init":["Int",0]}
+          },
+          "FF_inst1":{
+            "modref":"global.FF",
+            "modargs":{"init":["Int",1]}
+          }
+        },
+        "connections":[
+          ["self.CLK","FF_inst0.clk"],
+          ["self.I.0","FF_inst0.d"],
+          ["self.O.0","FF_inst0.q"],
+          ["self.ASYNCRESET","FF_inst0.rst"],
+          ["self.CLK","FF_inst1.clk"],
+          ["self.I.1","FF_inst1.d"],
+          ["self.O.1","FF_inst1.q"],
+          ["self.ASYNCRESET","FF_inst1.rst"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_verilog/gold/top-declare-coreir-verilog.v
+++ b/tests/test_verilog/gold/top-declare-coreir-verilog.v
@@ -1,0 +1,9 @@
+// Module `FF` defined externally
+module Top (input ASYNCRESET, input CLK, input [1:0] I, output [1:0] O);
+wire FF_inst0_q;
+wire FF_inst1_q;
+FF #(.init(0)) FF_inst0(.clk(CLK), .d(I[0]), .q(FF_inst0_q), .rst(ASYNCRESET));
+FF #(.init(1)) FF_inst1(.clk(CLK), .d(I[1]), .q(FF_inst1_q), .rst(ASYNCRESET));
+assign O = {FF_inst1_q,FF_inst0_q};
+endmodule
+

--- a/tests/test_verilog/gold/top-declare-coreir.json
+++ b/tests/test_verilog/gold/top-declare-coreir.json
@@ -1,0 +1,45 @@
+{"top":"global.Top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "FF":{
+        "type":["Record",[
+          ["clk",["Named","coreir.clkIn"]],
+          ["rst",["Named","coreir.arstIn"]],
+          ["d","BitIn"],
+          ["q","Bit"]
+        ]],
+        "modparams":{"init":"Int"}
+      },
+      "Top":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["O",["Array",2,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]],
+          ["ASYNCRESET",["Named","coreir.arstIn"]]
+        ]],
+        "instances":{
+          "FF_inst0":{
+            "modref":"global.FF",
+            "modargs":{"init":["Int",0]}
+          },
+          "FF_inst1":{
+            "modref":"global.FF",
+            "modargs":{"init":["Int",1]}
+          }
+        },
+        "connections":[
+          ["self.CLK","FF_inst0.clk"],
+          ["self.I.0","FF_inst0.d"],
+          ["self.O.0","FF_inst0.q"],
+          ["self.ASYNCRESET","FF_inst0.rst"],
+          ["self.CLK","FF_inst1.clk"],
+          ["self.I.1","FF_inst1.d"],
+          ["self.O.1","FF_inst1.q"],
+          ["self.ASYNCRESET","FF_inst1.rst"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_verilog/gold/top-declare-verilog.v
+++ b/tests/test_verilog/gold/top-declare-verilog.v
@@ -1,0 +1,8 @@
+module Top (input [1:0] I, output [1:0] O, input  CLK, input  ASYNCRESET);
+wire  FF_inst0_q;
+wire  FF_inst1_q;
+FF #(.init(0)) FF_inst0 (.clk(CLK), .rst(ASYNCRESET), .d(I[0]), .q(FF_inst0_q));
+FF #(.init(1)) FF_inst1 (.clk(CLK), .rst(ASYNCRESET), .d(I[1]), .q(FF_inst1_q));
+assign O = {FF_inst1_q,FF_inst0_q};
+endmodule
+

--- a/tests/test_verilog/gold/top-define-coreir-verilog.json
+++ b/tests/test_verilog/gold/top-define-coreir-verilog.json
@@ -1,0 +1,46 @@
+{"top":"global.Top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "FF":{
+        "type":["Record",[
+          ["clk",["Named","coreir.clkIn"]],
+          ["rst",["Named","coreir.arstIn"]],
+          ["d","BitIn"],
+          ["q","Bit"]
+        ]],
+        "modparams":{"init":"Int"},
+        "metadata":{"verilog":{"verilog_string":"module FF(input clk, input rst, input d, output q);\n\nparameter init = 0;\n\nreg ff; \nalways @(posedge clk or posedge rst) begin\n  if (!rst)\n    ff <= init;\n  else\n    ff <= d; \nend\n\nassign q = ff;\nendmodule"}}
+      },
+      "Top":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["O",["Array",2,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]],
+          ["ASYNCRESET",["Named","coreir.arstIn"]]
+        ]],
+        "instances":{
+          "FF_inst0":{
+            "modref":"global.FF",
+            "modargs":{"init":["Int",0]}
+          },
+          "FF_inst1":{
+            "modref":"global.FF",
+            "modargs":{"init":["Int",1]}
+          }
+        },
+        "connections":[
+          ["self.CLK","FF_inst0.clk"],
+          ["self.I.0","FF_inst0.d"],
+          ["self.O.0","FF_inst0.q"],
+          ["self.ASYNCRESET","FF_inst0.rst"],
+          ["self.CLK","FF_inst1.clk"],
+          ["self.I.1","FF_inst1.d"],
+          ["self.O.1","FF_inst1.q"],
+          ["self.ASYNCRESET","FF_inst1.rst"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_verilog/gold/top-define-coreir-verilog.v
+++ b/tests/test_verilog/gold/top-define-coreir-verilog.v
@@ -1,0 +1,22 @@
+module FF(input clk, input rst, input d, output q);
+
+parameter init = 0;
+
+reg ff; 
+always @(posedge clk or posedge rst) begin
+  if (!rst)
+    ff <= init;
+  else
+    ff <= d; 
+end
+
+assign q = ff;
+endmodule
+module Top (input ASYNCRESET, input CLK, input [1:0] I, output [1:0] O);
+wire FF_inst0_q;
+wire FF_inst1_q;
+FF #(.init(0)) FF_inst0(.clk(CLK), .d(I[0]), .q(FF_inst0_q), .rst(ASYNCRESET));
+FF #(.init(1)) FF_inst1(.clk(CLK), .d(I[1]), .q(FF_inst1_q), .rst(ASYNCRESET));
+assign O = {FF_inst1_q,FF_inst0_q};
+endmodule
+

--- a/tests/test_verilog/gold/top-define-coreir.json
+++ b/tests/test_verilog/gold/top-define-coreir.json
@@ -1,0 +1,46 @@
+{"top":"global.Top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "FF":{
+        "type":["Record",[
+          ["clk",["Named","coreir.clkIn"]],
+          ["rst",["Named","coreir.arstIn"]],
+          ["d","BitIn"],
+          ["q","Bit"]
+        ]],
+        "modparams":{"init":"Int"},
+        "metadata":{"verilog":{"verilog_string":"module FF(input clk, input rst, input d, output q);\n\nparameter init = 0;\n\nreg ff; \nalways @(posedge clk or posedge rst) begin\n  if (!rst)\n    ff <= init;\n  else\n    ff <= d; \nend\n\nassign q = ff;\nendmodule"}}
+      },
+      "Top":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["O",["Array",2,"Bit"]],
+          ["CLK",["Named","coreir.clkIn"]],
+          ["ASYNCRESET",["Named","coreir.arstIn"]]
+        ]],
+        "instances":{
+          "FF_inst0":{
+            "modref":"global.FF",
+            "modargs":{"init":["Int",0]}
+          },
+          "FF_inst1":{
+            "modref":"global.FF",
+            "modargs":{"init":["Int",1]}
+          }
+        },
+        "connections":[
+          ["self.CLK","FF_inst0.clk"],
+          ["self.I.0","FF_inst0.d"],
+          ["self.O.0","FF_inst0.q"],
+          ["self.ASYNCRESET","FF_inst0.rst"],
+          ["self.CLK","FF_inst1.clk"],
+          ["self.I.1","FF_inst1.d"],
+          ["self.O.1","FF_inst1.q"],
+          ["self.ASYNCRESET","FF_inst1.rst"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_verilog/gold/top-define-verilog.v
+++ b/tests/test_verilog/gold/top-define-verilog.v
@@ -1,0 +1,22 @@
+module FF(input clk, input rst, input d, output q);
+
+parameter init = 0;
+
+reg ff; 
+always @(posedge clk or posedge rst) begin
+  if (!rst)
+    ff <= init;
+  else
+    ff <= d; 
+end
+
+assign q = ff;
+endmodule
+module Top (input [1:0] I, output [1:0] O, input  CLK, input  ASYNCRESET);
+wire  FF_inst0_q;
+wire  FF_inst1_q;
+FF #(.init(0)) FF_inst0 (.clk(CLK), .rst(ASYNCRESET), .d(I[0]), .q(FF_inst0_q));
+FF #(.init(1)) FF_inst1 (.clk(CLK), .rst(ASYNCRESET), .d(I[1]), .q(FF_inst1_q));
+assign O = {FF_inst1_q,FF_inst0_q};
+endmodule
+

--- a/tests/test_verilog/gold/top-verilog.v
+++ b/tests/test_verilog/gold/top-verilog.v
@@ -1,0 +1,22 @@
+module FF(input clk, input rst, input d, output q);
+
+parameter init = 0;
+
+reg ff; 
+always @(posedge clk or posedge rst) begin
+  if (!rst)
+    ff <= init;
+  else
+    ff <= d; 
+end
+
+assign q = ff;
+endmodule
+module Top (input [1:0] I, output [1:0] O, input  CLK, input  ASYNCRESET);
+wire  FF_inst0_q;
+wire  FF_inst1_q;
+FF #(.init(0)) FF_inst0 (.clk(CLK), .rst(ASYNCRESET), .d(I[0]), .q(FF_inst0_q));
+FF #(.init(1)) FF_inst1 (.clk(CLK), .rst(ASYNCRESET), .d(I[1]), .q(FF_inst1_q));
+assign O = {FF_inst1_q,FF_inst0_q};
+endmodule
+


### PR DESCRIPTION
This fixes a bug where the logic to passthrough instance parameters to verilog (`<mod>(key=value)`) only worked with the `verilog` backend. This adds support to the pattern for the `coreir-verilog` backend by adding an additional parameter `param_map` to the from verilog constructs.  This is required so that the coreir definitions can be instanced with the parameters are config args (otherwise we get a `Args and params are not the same!` assertion failure).

This is a hotfix to add the feature, but we may want to consider an alternative solution for the longer term: Add a metadata field for passing through these verilog parameters as key/value strings. Since this is reserved for working with verilog black boxes, perhaps it's best to just treat this as sidechannel information that's just passed through the compiler, rather than converting from verilog to coreir types then back.

@rdaly525 The basic summary of the issue is: we have black box verilog that is being imported into magma. These verilog modules have parameters that we'd like to pass through when instancing (they don't affect the interface).  The current workaround is to have the user explicitly declare the parameter types so they are converted to coreir config args.  The other option is to have coreir have a notion of black box parameters that are just passed through to the instance of the black box verilog.

Other comments/suggestions welcome