### PR TITLE
Prototype logic for automatically collecting instance name

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -1,3 +1,5 @@
+import ast
+import textwrap
 import sys
 import six
 import inspect
@@ -95,10 +97,10 @@ class CircuitKind(type):
 
     def __call__(cls, *largs, **kwargs):
         #print('CircuitKind call:', largs, kwargs)
-        self = super(CircuitKind, cls).__call__(*largs, **kwargs)
         if get_debug_mode():
             debug_info = get_callee_frame_info()
-            self.set_debug_info(debug_info)
+            kwargs["debug_info"] = debug_info
+        self = super(CircuitKind, cls).__call__(*largs, **kwargs)
 
         # instance interface for this instance
         if hasattr(cls, 'IO'):
@@ -187,7 +189,10 @@ class AnonymousCircuitType(object):
 
     def __init__(self, *largs, **kwargs):
 
-        self.kwargs = kwargs
+        self.kwargs = dict(**kwargs)
+        if "debug_info" in self.kwargs:
+            # Not an instance parameter, internal debug argument
+            del self.kwargs["debug_info"]
         if hasattr(self, 'default_kwargs'):
             for key in self.default_kwargs:
                 if key not in kwargs:
@@ -204,7 +209,7 @@ class AnonymousCircuitType(object):
         self.used = False
         self.is_instance = True
 
-        self.debug_info = None
+        self.debug_info = kwargs.get("debug_info", None)
 
     def set_debug_info(self, debug_info):
         self.debug_info = debug_info
@@ -460,6 +465,8 @@ class DefineCircuitKind(CircuitKind):
 
         self._instances = []
         self.instanced_circuits_counter = Counter()
+        self.instance_name_counter = Counter()
+        self.instance_name_map = {}
         self._is_definition = dct.get('is_definition', False)
         self.is_instance = False
 
@@ -487,8 +494,38 @@ class DefineCircuitKind(CircuitKind):
     #
     def place(cls, inst):
         if not inst.name:
-            inst.name = f"{type(inst).name}_inst{str(cls.instanced_circuits_counter[type(inst).name])}"
-            cls.instanced_circuits_counter[type(inst).name] += 1
+            if get_debug_mode():
+                # Try to fetch instance name
+                with open(inst.debug_info.filename, "r") as f:
+                    line = f.read().splitlines()[inst.debug_info.lineno - 1]
+                    tree = ast.parse(textwrap.dedent(line)).body[0]
+                    # Simple case when <Name> = <Instance>()
+                    if isinstance(tree, ast.Assign) and len(tree.targets) == 1 \
+                            and isinstance(tree.targets[0], ast.Name):
+                        name = tree.targets[0].id
+                        # Handle case when we've seen a name multiple times
+                        # (e.g. reused inside a loop)
+                        if cls.instance_name_counter[name] == 0:
+                            inst.name = name
+                            cls.instance_name_counter[name] += 1
+                        else:
+                            if cls.instance_name_counter[name] == 1:
+                                # Append `_0` to the first instance with this
+                                # name
+                                orig = cls.instance_name_map[name]
+                                orig.name += "_0"
+                                del cls.instance_name_map[name]
+                                cls.instance_name_map[orig.name] = orig
+                            inst.name = f"{name}_{cls.instance_name_counter[name]}"
+                            cls.instance_name_counter[name] += 1
+            if not inst.name:
+                # Default name if we could not find one or debug mode is off
+                inst.name = f"{type(inst).name}_inst{str(cls.instanced_circuits_counter[type(inst).name])}"
+                cls.instanced_circuits_counter[type(inst).name] += 1
+                cls.instance_name_counter[inst.name] += 1
+        else:
+            cls.instance_name_counter[inst.name] += 1
+        cls.instance_name_map[inst.name] = inst
         inst.defn = cls
         if get_debug_mode():
             inst.stack = inspect.stack()

--- a/tests/test_circuit/gold/test_for_loop_def.json
+++ b/tests/test_circuit/gold/test_for_loop_def.json
@@ -8,7 +8,7 @@
           ["I1","BitIn"],
           ["O","Bit"]
         ]],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"53"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"55"}
       },
       "main":{
         "type":["Record",[
@@ -16,35 +16,35 @@
           ["O","Bit"]
         ]],
         "instances":{
-          "And2_inst0":{
+          "and2_0":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"61"}
           },
-          "And2_inst1":{
+          "and2_1":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"61"}
           },
-          "And2_inst2":{
+          "and2_2":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"61"}
           },
-          "And2_inst3":{
+          "and2_3":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"59"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"61"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"61"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"62"}],
-          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
-          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
-          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
-          ["self.I.1","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
-          ["And2_inst3.I0","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
-          ["self.I.1","And2_inst3.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"65"}],
-          ["self.O","And2_inst3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"68"}]
+          ["self.I.0","and2_0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"63"}],
+          ["self.I.1","and2_0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"64"}],
+          ["and2_1.I0","and2_0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
+          ["self.I.1","and2_1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"67"}],
+          ["and2_2.I0","and2_1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
+          ["self.I.1","and2_2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"67"}],
+          ["and2_3.I0","and2_2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"66"}],
+          ["self.I.1","and2_3.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"67"}],
+          ["self.O","and2_3.O",{"filename":"tests/test_circuit/test_define.py","lineno":"70"}]
         ],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"55"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"57"}
       }
     }
   }

--- a/tests/test_circuit/gold/test_for_loop_def.v
+++ b/tests/test_circuit/gold/test_for_loop_def.v
@@ -1,30 +1,30 @@
-// Defined at tests/test_circuit/test_define.py:55
+// Defined at tests/test_circuit/test_define.py:57
 module main (input [1:0] I, output  O);
-wire  And2_inst0_O;
-wire  And2_inst1_O;
-wire  And2_inst2_O;
-wire  And2_inst3_O;
-// Instanced at tests/test_circuit/test_define.py:59
-// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:61
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:62
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:64
-And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
-// Instanced at tests/test_circuit/test_define.py:59
-// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:64
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:65
-// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:64
-And2 And2_inst1 (.I0(And2_inst0_O), .I1(I[1]), .O(And2_inst1_O));
-// Instanced at tests/test_circuit/test_define.py:59
-// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:64
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:65
-// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:64
-And2 And2_inst2 (.I0(And2_inst1_O), .I1(I[1]), .O(And2_inst2_O));
-// Instanced at tests/test_circuit/test_define.py:59
-// Argument I0(And2_inst2_O) wired at tests/test_circuit/test_define.py:64
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:65
-// Argument O(And2_inst3_O) wired at tests/test_circuit/test_define.py:68
-And2 And2_inst3 (.I0(And2_inst2_O), .I1(I[1]), .O(And2_inst3_O));
-// Wired at tests/test_circuit/test_define.py:68
-assign O = And2_inst3_O;
+wire  and2_0_O;
+wire  and2_1_O;
+wire  and2_2_O;
+wire  and2_3_O;
+// Instanced at tests/test_circuit/test_define.py:61
+// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:63
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:64
+// Argument O(and2_0_O) wired at tests/test_circuit/test_define.py:66
+And2 and2_0 (.I0(I[0]), .I1(I[1]), .O(and2_0_O));
+// Instanced at tests/test_circuit/test_define.py:61
+// Argument I0(and2_0_O) wired at tests/test_circuit/test_define.py:66
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:67
+// Argument O(and2_1_O) wired at tests/test_circuit/test_define.py:66
+And2 and2_1 (.I0(and2_0_O), .I1(I[1]), .O(and2_1_O));
+// Instanced at tests/test_circuit/test_define.py:61
+// Argument I0(and2_1_O) wired at tests/test_circuit/test_define.py:66
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:67
+// Argument O(and2_2_O) wired at tests/test_circuit/test_define.py:66
+And2 and2_2 (.I0(and2_1_O), .I1(I[1]), .O(and2_2_O));
+// Instanced at tests/test_circuit/test_define.py:61
+// Argument I0(and2_2_O) wired at tests/test_circuit/test_define.py:66
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:67
+// Argument O(and2_3_O) wired at tests/test_circuit/test_define.py:70
+And2 and2_3 (.I0(and2_2_O), .I1(I[1]), .O(and2_3_O));
+// Wired at tests/test_circuit/test_define.py:70
+assign O = and2_3_O;
 endmodule
 

--- a/tests/test_circuit/gold/test_interleaved_instance_wiring.json
+++ b/tests/test_circuit/gold/test_interleaved_instance_wiring.json
@@ -8,7 +8,7 @@
           ["I1","BitIn"],
           ["O","Bit"]
         ]],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"83"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"87"}
       },
       "main":{
         "type":["Record",[
@@ -16,29 +16,29 @@
           ["O","Bit"]
         ]],
         "instances":{
-          "And2_inst0":{
+          "and2_0":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"87"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"91"}
           },
-          "And2_inst1":{
+          "and2_1":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"88"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"92"}
           },
-          "And2_inst2":{
+          "and2_2":{
             "modref":"global.And2",
-            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"94"}
+            "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"98"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"90"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"91"}],
-          ["And2_inst1.I0","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"92"}],
-          ["self.I.1","And2_inst1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"93"}],
-          ["And2_inst2.I0","And2_inst1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"95"}],
-          ["self.I.0","And2_inst2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"96"}],
-          ["self.O","And2_inst2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"98"}]
+          ["self.I.0","and2_0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"94"}],
+          ["self.I.1","and2_0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"95"}],
+          ["and2_1.I0","and2_0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"96"}],
+          ["self.I.1","and2_1.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"97"}],
+          ["and2_2.I0","and2_1.O",{"filename":"tests/test_circuit/test_define.py","lineno":"99"}],
+          ["self.I.0","and2_2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"100"}],
+          ["self.O","and2_2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"102"}]
         ],
-        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"85"}
+        "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"89"}
       }
     }
   }

--- a/tests/test_circuit/gold/test_interleaved_instance_wiring.v
+++ b/tests/test_circuit/gold/test_interleaved_instance_wiring.v
@@ -1,24 +1,24 @@
-// Defined at tests/test_circuit/test_define.py:85
+// Defined at tests/test_circuit/test_define.py:89
 module main (input [1:0] I, output  O);
-wire  And2_inst0_O;
-wire  And2_inst1_O;
-wire  And2_inst2_O;
-// Instanced at tests/test_circuit/test_define.py:87
-// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:90
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:91
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:92
-And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
-// Instanced at tests/test_circuit/test_define.py:88
-// Argument I0(And2_inst0_O) wired at tests/test_circuit/test_define.py:92
-// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:93
-// Argument O(And2_inst1_O) wired at tests/test_circuit/test_define.py:95
-And2 And2_inst1 (.I0(And2_inst0_O), .I1(I[1]), .O(And2_inst1_O));
-// Instanced at tests/test_circuit/test_define.py:94
-// Argument I0(And2_inst1_O) wired at tests/test_circuit/test_define.py:95
-// Argument I1(I[0]) wired at tests/test_circuit/test_define.py:96
-// Argument O(And2_inst2_O) wired at tests/test_circuit/test_define.py:98
-And2 And2_inst2 (.I0(And2_inst1_O), .I1(I[0]), .O(And2_inst2_O));
-// Wired at tests/test_circuit/test_define.py:98
-assign O = And2_inst2_O;
+wire  and2_0_O;
+wire  and2_1_O;
+wire  and2_2_O;
+// Instanced at tests/test_circuit/test_define.py:91
+// Argument I0(I[0]) wired at tests/test_circuit/test_define.py:94
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:95
+// Argument O(and2_0_O) wired at tests/test_circuit/test_define.py:96
+And2 and2_0 (.I0(I[0]), .I1(I[1]), .O(and2_0_O));
+// Instanced at tests/test_circuit/test_define.py:92
+// Argument I0(and2_0_O) wired at tests/test_circuit/test_define.py:96
+// Argument I1(I[1]) wired at tests/test_circuit/test_define.py:97
+// Argument O(and2_1_O) wired at tests/test_circuit/test_define.py:99
+And2 and2_1 (.I0(and2_0_O), .I1(I[1]), .O(and2_1_O));
+// Instanced at tests/test_circuit/test_define.py:98
+// Argument I0(and2_1_O) wired at tests/test_circuit/test_define.py:99
+// Argument I1(I[0]) wired at tests/test_circuit/test_define.py:100
+// Argument O(and2_2_O) wired at tests/test_circuit/test_define.py:102
+And2 and2_2 (.I0(and2_1_O), .I1(I[0]), .O(and2_2_O));
+// Wired at tests/test_circuit/test_define.py:102
+assign O = and2_2_O;
 endmodule
 

--- a/tests/test_circuit/gold/test_simple_def.json
+++ b/tests/test_circuit/gold/test_simple_def.json
@@ -16,15 +16,15 @@
           ["O","Bit"]
         ]],
         "instances":{
-          "And2_inst0":{
+          "and2":{
             "modref":"global.And2",
             "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"18"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"20"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"21"}],
-          ["self.O","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"22"}]
+          ["self.I.0","and2.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"20"}],
+          ["self.I.1","and2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"21"}],
+          ["self.O","and2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"22"}]
         ],
         "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"16"}
       }

--- a/tests/test_circuit/gold/test_simple_def.v
+++ b/tests/test_circuit/gold/test_simple_def.v
@@ -1,12 +1,12 @@
 // Defined at tests/test_circuit/test_define.py:16
 module main (input [1:0] I, output  O);
-wire  And2_inst0_O;
+wire  and2_O;
 // Instanced at tests/test_circuit/test_define.py:18
 // Argument I0(I[0]) wired at tests/test_circuit/test_define.py:20
 // Argument I1(I[1]) wired at tests/test_circuit/test_define.py:21
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:22
-And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
+// Argument O(and2_O) wired at tests/test_circuit/test_define.py:22
+And2 and2 (.I0(I[0]), .I1(I[1]), .O(and2_O));
 // Wired at tests/test_circuit/test_define.py:22
-assign O = And2_inst0_O;
+assign O = and2_O;
 endmodule
 

--- a/tests/test_circuit/gold/test_simple_def_class.json
+++ b/tests/test_circuit/gold/test_simple_def_class.json
@@ -16,15 +16,15 @@
           ["O","Bit"]
         ]],
         "instances":{
-          "And2_inst0":{
+          "and2":{
             "modref":"global.And2",
             "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"36"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"37"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"38"}],
-          ["self.O","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"39"}]
+          ["self.I.0","and2.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"37"}],
+          ["self.I.1","and2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"38"}],
+          ["self.O","and2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"39"}]
         ],
         "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"31"}
       },
@@ -34,15 +34,15 @@
           ["O","Bit"]
         ]],
         "instances":{
-          "And2_inst0":{
+          "and2":{
             "modref":"global.And2",
             "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"18"}
           }
         },
         "connections":[
-          ["self.I.0","And2_inst0.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"20"}],
-          ["self.I.1","And2_inst0.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"21"}],
-          ["self.O","And2_inst0.O",{"filename":"tests/test_circuit/test_define.py","lineno":"22"}]
+          ["self.I.0","and2.I0",{"filename":"tests/test_circuit/test_define.py","lineno":"20"}],
+          ["self.I.1","and2.I1",{"filename":"tests/test_circuit/test_define.py","lineno":"21"}],
+          ["self.O","and2.O",{"filename":"tests/test_circuit/test_define.py","lineno":"22"}]
         ],
         "metadata":{"filename":"tests/test_circuit/test_define.py","lineno":"16"}
       }

--- a/tests/test_circuit/gold/test_simple_def_class.v
+++ b/tests/test_circuit/gold/test_simple_def_class.v
@@ -1,12 +1,12 @@
 // Defined at tests/test_circuit/test_define.py:31
 module Main (input [1:0] I, output  O);
-wire  And2_inst0_O;
+wire  and2_O;
 // Instanced at tests/test_circuit/test_define.py:36
 // Argument I0(I[0]) wired at tests/test_circuit/test_define.py:37
 // Argument I1(I[1]) wired at tests/test_circuit/test_define.py:38
-// Argument O(And2_inst0_O) wired at tests/test_circuit/test_define.py:39
-And2 And2_inst0 (.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
+// Argument O(and2_O) wired at tests/test_circuit/test_define.py:39
+And2 and2 (.I0(I[0]), .I1(I[1]), .O(and2_O));
 // Wired at tests/test_circuit/test_define.py:39
-assign O = And2_inst0_O;
+assign O = and2_O;
 endmodule
 

--- a/tests/test_circuit/test_define.py
+++ b/tests/test_circuit/test_define.py
@@ -1,6 +1,5 @@
 import magma as m
 from magma.testing import check_files_equal
-m.config.set_debug_mode(True)
 import logging
 import pytest
 import coreir
@@ -9,6 +8,7 @@ import coreir
 @pytest.mark.parametrize("target,suffix",
                          [("verilog", "v"), ("coreir", "json")])
 def test_simple_def(target, suffix):
+    m.config.set_debug_mode(True)
     m.set_codegen_debug_info(True)
     And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                             "O", m.Out(m.Bit))
@@ -41,6 +41,7 @@ def test_simple_def(target, suffix):
     # Create a fresh context for second compilation.
     m.compile("build/test_simple_def_class", Main, output=target)
     m.set_codegen_debug_info(False)
+    m.config.set_debug_mode(False)
     assert check_files_equal(__file__, f"build/test_simple_def_class.{suffix}",
                              f"gold/test_simple_def_class.{suffix}")
 
@@ -48,6 +49,7 @@ def test_simple_def(target, suffix):
 @pytest.mark.parametrize("target,suffix",
                          [("verilog", "v"), ("coreir", "json")])
 def test_for_loop_def(target, suffix):
+    m.config.set_debug_mode(True)
     m.set_codegen_debug_info(True)
     And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                             "O", m.Out(m.Bit))
@@ -71,6 +73,7 @@ def test_for_loop_def(target, suffix):
 
     m.compile("build/test_for_loop_def", main, output=target)
     m.set_codegen_debug_info(False)
+    m.config.set_debug_mode(False)
     assert check_files_equal(__file__, f"build/test_for_loop_def.{suffix}",
                              f"gold/test_for_loop_def.{suffix}")
 
@@ -78,6 +81,7 @@ def test_for_loop_def(target, suffix):
 @pytest.mark.parametrize("target,suffix",
                          [("verilog", "v"), ("coreir", "json")])
 def test_interleaved_instance_wiring(target, suffix):
+    m.config.set_debug_mode(True)
     m.set_codegen_debug_info(True)
     And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                             "O", m.Out(m.Bit))
@@ -101,6 +105,7 @@ def test_interleaved_instance_wiring(target, suffix):
 
     m.compile("build/test_interleaved_instance_wiring", main, output=target)
     m.set_codegen_debug_info(False)
+    m.config.set_debug_mode(False)
     assert check_files_equal(__file__, f"build/test_interleaved_instance_wiring.{suffix}",
                              f"gold/test_interleaved_instance_wiring.{suffix}")
 

--- a/tests/test_coreir/gold/test_compile_coreir_verilog.v
+++ b/tests/test_coreir/gold/test_compile_coreir_verilog.v
@@ -1,7 +1,7 @@
 // Module `And2` defined externally
 module main (input [1:0] I, output O);
-wire And2_inst0_O;
-And2 And2_inst0(.I0(I[0]), .I1(I[1]), .O(And2_inst0_O));
-assign O = And2_inst0_O;
+wire and2_O;
+And2 and2(.I0(I[0]), .I1(I[1]), .O(and2_O));
+assign O = and2_O;
 endmodule
 

--- a/tests/test_coreir/test_compile_coreir_verilog.py
+++ b/tests/test_coreir/test_compile_coreir_verilog.py
@@ -3,11 +3,11 @@ import os
 from magma.testing.utils import check_files_equal
 import magma as m
 m.set_mantle_target("coreir")
-m.config.set_debug_mode(True)
 import pytest
 
 
 def test_compile(caplog):
+    m.config.set_debug_mode(True)
     And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                             "O", m.Out(m.Bit))
     # Make it a mock mantle module
@@ -28,6 +28,7 @@ def test_compile(caplog):
 
     m.EndCircuit()
     m.compile("build/test_compile_coreir_verilog", main)
+    m.config.set_debug_mode(False)
     assert check_files_equal(__file__, "build/test_compile_coreir_verilog.v",
                              "gold/test_compile_coreir_verilog.v")
     assert caplog.records[0].msg == "`m.compile` called with `output == verilog` and `m.mantle_target == \"coreir\"` and mantle has been imported, When generating verilog from circuits from the \"coreir\" mantle target, you should set `output=\"coreir-verilog\"`. Doing this automatically."

--- a/tests/test_dot/test_dot.py
+++ b/tests/test_dot/test_dot.py
@@ -1,6 +1,8 @@
 from magma import *
+import magma as m
 
 def test():
+    m.config.set_debug_mode(True)
     Add = DeclareCircuit("Add", "A", In(Bit), "B", In(Bit), "C", Out(Bit))
 
     main = DefineCircuit("main", "I0", In(Bit), "I1", In(Bit), "O", Out(Bit))
@@ -10,6 +12,7 @@ def test():
     EndCircuit()
 
     compile("build/dot", main, output='dot')
+    m.config.set_debug_mode(False)
     # FIXME: Do equality check.
     # Let's not check for equality / check in gold until we've finalized this format.
     # assert magma_check_files_equal(__file__, "build/dot.dot", "gold/dot.dot")

--- a/tests/test_simulator/test_mdb.py
+++ b/tests/test_simulator/test_mdb.py
@@ -1,4 +1,5 @@
 from .test_primitives import *
+import magma as m
 from magma.simulator import PythonSimulator
 from magma.simulator.mdb import SimulationConsole
 from magma import *
@@ -6,6 +7,7 @@ from magma.scope import *
 from magma.passes.debug_name import DebugNamePass
 
 def test(capsys):
+    m.config.set_debug_mode(True)
     def get_out(capsys):
         out, err = capsys.readouterr()
         assert(err == "")
@@ -109,3 +111,4 @@ def test(capsys):
 
     console.runcmd("p counter.reg.O")
     assert get_out(capsys) == "2"
+    m.config.set_debug_mode(False)

--- a/tests/test_type/test_type_errors.py
+++ b/tests/test_type/test_type_errors.py
@@ -1,7 +1,9 @@
 from magma import *
+import magma as m
 
 
 def test_array_lengths(caplog):
+    m.config.set_debug_mode(True)
     Buf = DeclareCircuit('Buf', "I", In(Array[8, Bit]), "O", Out(Array[8, Bit]))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Array[7, Bit]))
@@ -9,12 +11,14 @@ def test_array_lengths(caplog):
     buf = Buf()
     wire(main.O, buf.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_type/test_type_errors.py:10: Cannot wire main.O (type=Array[7, In(Bit)]) to main.Buf_inst0.I (type=Array[8, In(Bit)]) because the arrays do not have the same length
+\033[1mtests/test_type/test_type_errors.py:12: Cannot wire main.O (type=Array[7, In(Bit)]) to main.buf.I (type=Array[8, In(Bit)]) because the arrays do not have the same length
     wire(main.O, buf.I)
 """
+    m.config.set_debug_mode(False)
 
 
 def test_array_to_bit(caplog):
+    m.config.set_debug_mode(True)
     Buf = DeclareCircuit('Buf', "I", In(Array[8, Bit]), "O", Out(Array[8, Bit]))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Bit))
@@ -22,12 +26,14 @@ def test_array_to_bit(caplog):
     buf = Buf()
     wire(main.O, buf.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_type/test_type_errors.py:23: Cannot wire main.O (type=In(Bit)) to main.Buf_inst0.I (type=Array[8, In(Bit)]) because main.O is not an Array
+\033[1mtests/test_type/test_type_errors.py:27: Cannot wire main.O (type=In(Bit)) to main.buf.I (type=Array[8, In(Bit)]) because main.O is not an Array
     wire(main.O, buf.I)
 """
+    m.config.set_debug_mode(False)
 
 
 def test_bit_to_array(caplog):
+    m.config.set_debug_mode(True)
     Buf = DeclareCircuit('Buf', "I", In(Bit), "O", Out(Array[8, Bit]))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Array[7, Bit]))
@@ -35,12 +41,14 @@ def test_bit_to_array(caplog):
     buf = Buf()
     wire(buf.I, main.O)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_type/test_type_errors.py:36: Cannot wire main.Buf_inst0.I (type=In(Bit)) to main.O (type=Array[7, In(Bit)]) because main.Buf_inst0.I is not an Array
+\033[1mtests/test_type/test_type_errors.py:36: Cannot wire main.buf.I (type=In(Bit)) to main.O (type=Array[7, In(Bit)]) because main.buf.I is not an Array
     wire(buf.I, main.O)
 """
+    m.config.set_debug_mode(False)
 
 
 def test_tuple_to_array(caplog):
+    m.config.set_debug_mode(True)
     Buf = DeclareCircuit('Buf', "I", In(Tuple(a=Bit,b=Bit)), "O", Out(Array[8, Bit]))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Bit))
@@ -48,12 +56,14 @@ def test_tuple_to_array(caplog):
     buf = Buf()
     wire(main.O, buf.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_type/test_type_errors.py:49: Cannot wire main.O (type=In(Bit)) to main.Buf_inst0.I (type=Tuple(a=In(Bit),b=In(Bit))) because main.O is not a Tuple
+\033[1mtests/test_type/test_type_errors.py:57: Cannot wire main.O (type=In(Bit)) to main.buf.I (type=Tuple(a=In(Bit),b=In(Bit))) because main.O is not a Tuple
     wire(main.O, buf.I)
 """
+    m.config.set_debug_mode(False)
 
 
 def test_bad_tuples(caplog):
+    m.config.set_debug_mode(True)
     Buf = DeclareCircuit('Buf', "I", In(Tuple(a=Bit,b=Bit)), "O", Out(Array[8, Bit]))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Tuple(c=Bit,d=Bit)))
@@ -61,12 +71,14 @@ def test_bad_tuples(caplog):
     buf = Buf()
     wire(main.O, buf.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_type/test_type_errors.py:62: Cannot wire main.O (type=Tuple(c=In(Bit),d=In(Bit)), keys=['a', 'b']) to main.Buf_inst0.I (type=Tuple(a=In(Bit),b=In(Bit)), keys=['c', 'd']) because the tuples do not have the same keys
+\033[1mtests/test_type/test_type_errors.py:72: Cannot wire main.O (type=Tuple(c=In(Bit),d=In(Bit)), keys=['a', 'b']) to main.buf.I (type=Tuple(a=In(Bit),b=In(Bit)), keys=['c', 'd']) because the tuples do not have the same keys
     wire(main.O, buf.I)
 """
+    m.config.set_debug_mode(False)
 
 
 def test_bit_to_array(caplog):
+    m.config.set_debug_mode(True)
     Buf = DeclareCircuit('Buf', "I", In(Array[8, Bit]), "O", Out(Array[8, Bit]))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Bit))
@@ -74,6 +86,7 @@ def test_bit_to_array(caplog):
     buf = Buf()
     wire(buf.I, main.O)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_type/test_type_errors.py:75: Cannot wire main.O (type=In(Bit)) to I (type=Array[8, In(Bit)]) because main.Buf_inst0.I is not a _Bit
+\033[1mtests/test_type/test_type_errors.py:87: Cannot wire main.O (type=In(Bit)) to I (type=Array[8, In(Bit)]) because main.buf.I is not a _Bit
     wire(buf.I, main.O)
 """
+    m.config.set_debug_mode(False)

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -1,8 +1,8 @@
 from magma import *
-magma.config.set_debug_mode(True)
 
 
 def test_input_as_output(caplog):
+    magma.config.set_debug_mode(True)
     Buf = DeclareCircuit('Buf', "I", In(Bit), "O", Out(Bit))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Bit))
@@ -13,9 +13,11 @@ def test_input_as_output(caplog):
 \033[1mtests/test_wire/test_errors.py:11: Using `main.O` (an input) as an output
     wire(main.O, buf.I)
 """
+    magma.config.set_debug_mode(False)
 
 
 def test_output_as_input(caplog):
+    magma.config.set_debug_mode(True)
     A = DeclareCircuit('A', "I", In(Bit), "O", Out(Bit))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Bit))
@@ -26,9 +28,11 @@ def test_output_as_input(caplog):
 \033[1mtests/test_wire/test_errors.py:24: Using `main.A_inst0.O` (an output) as an input
     wire(main.I, a.O)
 """
+    magma.config.set_debug_mode(False)
 
 
 def test_multiple_outputs_to_input_warning(caplog):
+    magma.config.set_debug_mode(True)
     A = DeclareCircuit('A', "I", In(Bit), "O", Out(Bit))
 
     main = DefineCircuit("main", "I", In(Bits[2]), "O", Out(Bit))
@@ -40,9 +44,11 @@ def test_multiple_outputs_to_input_warning(caplog):
 \033[1mtests/test_wire/test_errors.py:38: Adding the output `main.I[1]` to the wire `main.A_inst0.I` which already has output(s) `[main.I[0]]`
     wire(main.I[1], a.I)
 """
+    magma.config.set_debug_mode(False)
 
 
 def test_muliple_outputs_circuit(caplog):
+    magma.config.set_debug_mode(True)
     A = DeclareCircuit('A', "I", In(Bit), "O", Out(Bit), "U", Out(Bit))
 
     main = DefineCircuit("main", "I", In(Bits(2)), "O", Out(Bit))
@@ -53,9 +59,11 @@ def test_muliple_outputs_circuit(caplog):
 \033[1mtests/test_wire/test_errors.py:51: Can only wire circuits with one output. Argument 0 to wire `main.A_inst0` has outputs [inst0.O, inst0.U]
     wire(a, main.I)
 """
+    magma.config.set_debug_mode(False)
 
 
 def test_muliple_outputs_circuit(caplog):
+    magma.config.set_debug_mode(True)
     A = DeclareCircuit('A', "I", In(Bit), "J", In(Bit), "O", Out(Bit), "U", Out(Bit))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Bit))
@@ -66,9 +74,11 @@ def test_muliple_outputs_circuit(caplog):
 \033[1mtests/test_wire/test_errors.py:64: Number of inputs is not equal to the number of outputs, expected 2 inputs, got 1. Only 1 will be wired.
     a(main)
 """
+    magma.config.set_debug_mode(False)
 
 
 def test_no_inputs_circuit(caplog):
+    magma.config.set_debug_mode(True)
     A = DeclareCircuit('A', "O", Out(Bit), "U", Out(Bit))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Bit))
@@ -79,9 +89,11 @@ def test_no_inputs_circuit(caplog):
 \033[1mtests/test_wire/test_errors.py:77: Wiring an output to a circuit with no input arguments, skipping
     wire(main.I, a)
 """
+    magma.config.set_debug_mode(False)
 
 
 def test_muliple_inputs_circuit(caplog):
+    magma.config.set_debug_mode(True)
     A = DeclareCircuit('A', "I", In(Bit), "J", In(Bit), "O", Out(Bit), "U", Out(Bit))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Bit))
@@ -92,9 +104,11 @@ def test_muliple_inputs_circuit(caplog):
 \033[1mtests/test_wire/test_errors.py:90: Wiring an output to a circuit with more than one input argument, using the first input main.A_inst0.I
     wire(main.I, a)
 """
+    magma.config.set_debug_mode(False)
 
 
 def test_no_key(caplog):
+    magma.config.set_debug_mode(True)
     A = DeclareCircuit('A', "I", In(Bit), "J", In(Bit), "O", Out(Bit), "U", Out(Bit))
 
     main = DefineCircuit("main", "I", In(Bit), "O", Out(Bit))
@@ -105,9 +119,11 @@ def test_no_key(caplog):
 \033[1mtests/test_wire/test_errors.py:103: Instance main.A_inst0 does not have input K
     a(K=main.I)
 """
+    magma.config.set_debug_mode(False)
 
 
 def test_const_array_error(caplog):
+    magma.config.set_debug_mode(True)
     Buf = DeclareCircuit('Buf', "I", In(Array[1, Bit]), "O", Out(Array[1, Bit]))
 
     main = DefineCircuit("main", "O", Out(Array[1, Bit]))
@@ -121,3 +137,4 @@ def test_const_array_error(caplog):
 \033[1mtests/test_wire/test_errors.py:117: Cannot wire 1 (type=<class 'int'>) to main.Buf_inst0.I (type=Array[1, In(Bit)]) because conversions from IntegerTypes are only defined for Bits, not general Arrays
     wire(1, buf.I)
 """
+    magma.config.set_debug_mode(False)

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -25,7 +25,7 @@ def test_output_as_input(caplog):
     a = A()
     wire(main.I, a.O)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:24: Using `main.A_inst0.O` (an output) as an input
+\033[1mtests/test_wire/test_errors.py:26: Using `main.a.O` (an output) as an input
     wire(main.I, a.O)
 """
     magma.config.set_debug_mode(False)
@@ -41,7 +41,7 @@ def test_multiple_outputs_to_input_warning(caplog):
     wire(main.I[0], a.I)
     wire(main.I[1], a.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:38: Adding the output `main.I[1]` to the wire `main.A_inst0.I` which already has output(s) `[main.I[0]]`
+\033[1mtests/test_wire/test_errors.py:42: Adding the output `main.I[1]` to the wire `main.a.I` which already has output(s) `[main.I[0]]`
     wire(main.I[1], a.I)
 """
     magma.config.set_debug_mode(False)
@@ -56,7 +56,7 @@ def test_muliple_outputs_circuit(caplog):
     a = A()
     wire(a, main.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:51: Can only wire circuits with one output. Argument 0 to wire `main.A_inst0` has outputs [inst0.O, inst0.U]
+\033[1mtests/test_wire/test_errors.py:51: Can only wire circuits with one output. Argument 0 to wire `main.a` has outputs [inst0.O, inst0.U]
     wire(a, main.I)
 """
     magma.config.set_debug_mode(False)
@@ -71,7 +71,7 @@ def test_muliple_outputs_circuit(caplog):
     a = A()
     a(main)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:64: Number of inputs is not equal to the number of outputs, expected 2 inputs, got 1. Only 1 will be wired.
+\033[1mtests/test_wire/test_errors.py:72: Number of inputs is not equal to the number of outputs, expected 2 inputs, got 1. Only 1 will be wired.
     a(main)
 """
     magma.config.set_debug_mode(False)
@@ -86,7 +86,7 @@ def test_no_inputs_circuit(caplog):
     a = A()
     wire(main.I, a)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:77: Wiring an output to a circuit with no input arguments, skipping
+\033[1mtests/test_wire/test_errors.py:87: Wiring an output to a circuit with no input arguments, skipping
     wire(main.I, a)
 """
     magma.config.set_debug_mode(False)
@@ -101,7 +101,7 @@ def test_muliple_inputs_circuit(caplog):
     a = A()
     wire(main.I, a)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:90: Wiring an output to a circuit with more than one input argument, using the first input main.A_inst0.I
+\033[1mtests/test_wire/test_errors.py:102: Wiring an output to a circuit with more than one input argument, using the first input main.a.I
     wire(main.I, a)
 """
     magma.config.set_debug_mode(False)
@@ -116,7 +116,7 @@ def test_no_key(caplog):
     a = A()
     a(K=main.I)
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:103: Instance main.A_inst0 does not have input K
+\033[1mtests/test_wire/test_errors.py:117: Instance main.a does not have input K
     a(K=main.I)
 """
     magma.config.set_debug_mode(False)
@@ -134,7 +134,7 @@ def test_const_array_error(caplog):
     wire(buf.O, main.O)
 
     assert "\n".join(x.msg for x in caplog.records) == """\
-\033[1mtests/test_wire/test_errors.py:117: Cannot wire 1 (type=<class 'int'>) to main.Buf_inst0.I (type=Array[1, In(Bit)]) because conversions from IntegerTypes are only defined for Bits, not general Arrays
+\033[1mtests/test_wire/test_errors.py:133: Cannot wire 1 (type=<class 'int'>) to main.buf.I (type=Array[1, In(Bit)]) because conversions from IntegerTypes are only defined for Bits, not general Arrays
     wire(1, buf.I)
 """
     magma.config.set_debug_mode(False)


### PR DESCRIPTION
This PR shows where we can insert logic to automatically determine the name of a magma instance using `inspect`.

Basically, when placing an instance in a definition, before naming it checks if we have debug mode enabled.  If so, we know that we have access to the filename/lineno where the instance was created. Then, we can parse the line to try to determine the name of the instance.  This works well for simple cases of the form `<name> = <instance>()`.  It also handles the case when a name is reused (by simply appending a counter value to the end of the name), so this should work when instances are created in a loop.

More complex forms might be supportable, e.g. `(<name_0>, <name_1> = <instance_0>(), <instance_1>)`.

One issue is how to handle when multiple instances are chained in the same line, e.g. `x = F()(G()(io.I))`. In this case, the instances of F and G would be named `x_1` and `x_0`. This should still work, but we may consider doing an SSA transformation on the original line, and introduce temporary variables/instance names for the "anonymous" instances, so it's more clear that these were unnamed instances.

CC @Kuree 