### PR TITLE
update reset logic to support asyncresetn

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -4,7 +4,9 @@ import os
 from ..bit import VCC, GND, BitType, BitIn, BitOut, MakeBit, BitKind
 from ..array import ArrayKind, ArrayType, Array
 from ..tuple import TupleKind, TupleType, Tuple
-from ..clock import wiredefaultclock, wireclock, ClockType, Clock, ResetType, ClockKind, EnableKind, ResetKind, AsyncResetType, AsyncResetKind, ResetNKind, AsyncResetNKind
+from ..clock import wiredefaultclock, wireclock, ClockType, Clock, ResetType, \
+    ClockKind, EnableKind, ResetKind, AsyncResetType, AsyncResetKind, ResetNKind, \
+    AsyncResetNKind, AsyncResetNType, ResetType
 from ..bitutils import seq2int
 from ..backend.verilog import find
 from ..logging import error
@@ -138,14 +140,16 @@ class CoreIRBackend:
         elif port.isinput():
             if isinstance(port, (ClockType, ClockKind)):
                 _type = self.context.named_types[("coreir", "clk")]
-            elif isinstance(port, (AsyncResetType, AsyncResetKind)):
+            elif isinstance(port, (AsyncResetType, AsyncResetKind,
+                                   AsyncResetNType, AsyncResetNKind)):
                 _type = self.context.named_types[("coreir", "arst")]
             else:
                 _type = self.context.Bit()
         elif port.isoutput():
             if isinstance(port, (ClockType, ClockKind)):
                 _type = self.context.named_types[("coreir", "clkIn")]
-            elif isinstance(port, (AsyncResetType, AsyncResetKind)):
+            elif isinstance(port, (AsyncResetType, AsyncResetKind,
+                                   AsyncResetNType, AsyncResetNKind)):
                 _type = self.context.named_types[("coreir", "arstIn")]
             else:
                 _type = self.context.BitIn()

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -182,7 +182,8 @@ ClockTypes = (ClockType, ResetType, AsyncResetType, EnableType)
 
 
 def ClockInterface(has_enable=False, has_reset=False, has_set=False,
-                   has_ce=False, has_async_reset=False):
+                   has_ce=False, has_async_reset=False,
+                   has_async_resetn=False):
     args = ['CLK', In(Clock)]
     has_enable |= has_ce
     if has_enable:
@@ -191,6 +192,8 @@ def ClockInterface(has_enable=False, has_reset=False, has_set=False,
         args += ['RESET', In(Reset)]
     if has_async_reset:
         args += ['ASYNCRESET', In(AsyncReset)]
+    if has_async_resetn:
+        args += ['ASYNCRESETN', In(AsyncResetN)]
     return args
 
 
@@ -214,4 +217,5 @@ def wiredefaultclock(defn, inst):
 def wireclock(define, circuit):
     wireclocktype(define, circuit, ResetType)
     wireclocktype(define, circuit, AsyncResetType)
+    wireclocktype(define, circuit, AsyncResetNType)
     wireclocktype(define, circuit, EnableType)

--- a/tests/test_type/gold/Bar.json
+++ b/tests/test_type/gold/Bar.json
@@ -1,0 +1,29 @@
+{"top":"global.Bar",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Bar":{
+        "type":["Record",[
+          ["CLK",["Named","coreir.clkIn"]],
+          ["ASYNCRESETN",["Named","coreir.arstIn"]]
+        ]],
+        "instances":{
+          "Foo_inst0":{
+            "modref":"global.Foo"
+          }
+        },
+        "connections":[
+          ["self.ASYNCRESETN","Foo_inst0.ASYNCRESETN"],
+          ["self.CLK","Foo_inst0.CLK"]
+        ]
+      },
+      "Foo":{
+        "type":["Record",[
+          ["CLK",["Named","coreir.clkIn"]],
+          ["ASYNCRESETN",["Named","coreir.arstIn"]]
+        ]]
+      }
+    }
+  }
+}
+}

--- a/tests/test_type/gold/Bar.v
+++ b/tests/test_type/gold/Bar.v
@@ -1,0 +1,5 @@
+// Module `Foo` defined externally
+module Bar (input ASYNCRESETN, input CLK);
+Foo Foo_inst0(.ASYNCRESETN(ASYNCRESETN), .CLK(CLK));
+endmodule
+

--- a/tests/test_type/test_reset.py
+++ b/tests/test_type/test_reset.py
@@ -16,6 +16,6 @@ def test_asyncreset_n():
             # backend
             foo = Foo()
 
-    m.compile("build/Foo", "coreir-verilog")
-    assert check_files_equal(__file__, f"build/Foo.v",
-                             f"gold/Foo.v")
+    m.compile("build/Bar", Bar, "coreir-verilog")
+    assert check_files_equal(__file__, f"build/Bar.v",
+                             f"gold/Bar.v")

--- a/tests/test_type/test_reset.py
+++ b/tests/test_type/test_reset.py
@@ -1,0 +1,21 @@
+import magma as m
+import pytest
+from magma.testing import check_files_equal
+
+
+def test_asyncreset_n():
+    class Foo(m.Circuit):
+        IO = m.ClockInterface(has_async_resetn=True)
+
+    class Bar(m.Circuit):
+        IO = m.ClockInterface(has_async_resetn=True)
+
+        @classmethod
+        def definition(io):
+            # asyncresetn ports should be automatically connected in the
+            # backend
+            foo = Foo()
+
+    m.compile("build/Foo", "coreir-verilog")
+    assert check_files_equal(__file__, f"build/Foo.v",
+                             f"gold/Foo.v")

--- a/tests/test_type/test_reset.py
+++ b/tests/test_type/test_reset.py
@@ -17,5 +17,7 @@ def test_asyncreset_n():
             foo = Foo()
 
     m.compile("build/Bar", Bar, "coreir-verilog")
+    assert check_files_equal(__file__, f"build/Bar.json",
+                             f"gold/Bar.json")
     assert check_files_equal(__file__, f"build/Bar.v",
                              f"gold/Bar.v")


### PR DESCRIPTION
This extends the features added by @jameshegarty to include AsyncResetN in the clock interface logic, automatic clock wiring logic, and coreir backend logic.

* Adds a parameter `has_async_resetn` to `m.ClockInterface` (enables us to use consistent interfaces for asyncresetn)
* Adds support for automatically wiring asyncresetn types (similar to how we wire clocks/resets/enables automatically)
* Adds support for compiling asyncresetn to coreir (coreir uses a namedtype for reset/asyncreset which we have to convert to when compiling magma's reset types)