### PR TITLE
Add documentation for values

### DIFF
--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -1,0 +1,52 @@
+**NOTE** This is a work in progress, please let us know via issue/gitter/email
+if you'd like to see anything added to this.
+
+This is inspired by https://github.com/freechipsproject/chisel-cheatsheet and
+will be rendered in a similar single page layout soon.
+
+# Basic Magma Constructs
+Magma Values
+```
+class Test(Circuit):
+    IO = ["I", In(Bits[5]), "O", Out(Bits[5])]
+
+    @classmethod
+    def definition(io):
+        # Allocate `x` as a value of type `Bits`
+        x = Bits[5]()
+        # Wire io.I to x
+        x <= io.I
+        # Wire x to io.O
+        io.O <= x
+```
+
+**NOTE** Currently magma only supports wiring two intermediate temporary values
+if the driver already has a driver.  The following example will work, because `y` is 
+driven by `io.I` before wiring to the temporary `x`.
+
+```python
+class Test(Circuit):
+    IO = ["I", In(Bits[5]), "O", Out(Bits[5])]
+
+    @classmethod
+    def definition(io):
+        x = Bits[5]()
+        y = Bits[5]()
+        y <= io.I
+        x <= y
+        io.O <= x
+```
+while this example will not work, because `y` has no driver when being wired to
+`x`.  A fix for this issue is forthcoming.
+```python
+class Test(Circuit):
+    IO = ["I", In(Bits[5]), "O", Out(Bits[5])]
+
+    @classmethod
+    def definition(io):
+        x = Bits[5]()
+        y = Bits[5]()
+        y <= io.I
+        x <= y
+        io.O <= x
+```

--- a/magma/t.py
+++ b/magma/t.py
@@ -68,7 +68,7 @@ class Type(object):
         return f"{defn_str}{inst_str}{str(self)}"
 
     def __le__(self, other):
-        if self.isinput():
+        if not self.isoutput():
             self.wire(other)
         else:
             raise TypeError(f"Cannot use <= to assign to output: {self.debug_name} (trying to assign {other.debug_name})")

--- a/tests/test_type/gold/test_anon_bits.v
+++ b/tests/test_type/gold/test_anon_bits.v
@@ -1,0 +1,4 @@
+module Test (input [4:0] I, output [4:0] O);
+assign O = I;
+endmodule
+

--- a/tests/test_type/test_anon.py
+++ b/tests/test_type/test_anon.py
@@ -1,4 +1,5 @@
 from magma import *
+from magma.testing import check_files_equal
 
 # test anonymous bits
 
@@ -18,3 +19,19 @@ def test():
     assert len(wires.outputs) == 1
     print('inputs:', [str(p) for p in wires.inputs])
     print('outputs:', [str(p) for p in wires.outputs])
+
+
+def test_anon_bits():
+    class Test(Circuit):
+        IO = ["I", In(Bits[5]), "O", Out(Bits[5])]
+
+        @classmethod
+        def definition(io):
+            x = Bits[5]()
+            y = Bits[5]()
+            y <= io.I
+            x <= y
+            io.O <= x
+    compile("build/test_anon_bits", Test, output="coreir-verilog")
+    assert check_files_equal(__file__, f"build/test_anon_bits.v",
+                             f"gold/test_anon_bits.v")


### PR DESCRIPTION
This initializes the cheat sheet doc (inspired by https://github.com/freechipsproject/chisel-cheatsheet) with documentation on magma values.  Note that I discovered a weird issue with how values currently work, which is included in the documentation.  This should be fixed by the `hwtypes` branch, so instead of working on a patch (which requires a non trivial change to how values work), I think effort is best put into getting the `hwtypes` branch in which will fundamentally change how values work.