### PR TITLE
Fix bug in tuple iswhole logic for bulk connections

### DIFF
--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -131,6 +131,10 @@ class TupleType(Type):
             if ts[i].name.index != self.Ks[i]:
                 return False
 
+        if len(ts) != len(ts[0].name.tuple):
+            # elements should refer to a whole tuple
+            return False
+
         return True
 
 

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -171,3 +171,39 @@ def test_nested():
 
     baseMH = DefineHier()
     m.compile("build/baseMH", baseMH, output="coreir-verilog")
+
+
+def test_tuple_nested_tuple_value():
+    def IFC0(params):
+        return m.Tuple(**{
+            "port0": m.In(m.Bits[params['param0']]),
+            "port1": m.In(m.Bits[params['param0']]),
+            "port2": m.In(m.Array[params['param0'], m.Bits[2]]),
+            "port3": m.In(m.Bits[params['param0']]),
+            "port4": m.In(m.Bit),
+            "port5": m.In(m.Bit),
+            "port7": m.In(m.Bit),
+            "port8": m.In(m.Bit),
+            "port9": m.In(m.Bit),
+            "port10": m.In(m.Bits[m.bitutils.clog2(params['param0'])]),
+        })
+
+    def IFC1(params):
+        dictOut = {"port4": m.Out(m.Bit)}
+        return m.Tuple(**dictOut)
+
+    def DefineMyCircuit(params):
+        class MyCircuit(m.Circuit):
+            IO = ["IFC0", IFC0(params).flip()]
+        return MyCircuit
+
+    def DefineTop(params):
+        class Top(m.Circuit):
+            IO = ["IFC1", IFC1(params)]
+            @classmethod
+            def definition(io):
+               m.wire(io.IFC1.port4, DefineMyCircuit(params)().IFC0.port4)
+        return Top
+
+
+    m.compile("top", DefineTop({'param0': 5}))


### PR DESCRIPTION
This fixes the case where the compiler improperly tries to do a bulk
connection.

The desired behavior is to check:
is the value connected to the current tuple "whole", which means
that a tuple of the same type is connected to the current tuple,
in this case we can  connect the two tuples together, rather than
their components.

However, this check was improperly indicating a bulk connection in the
case when the driving value satisfied all the properties for a whole
tuple, except that it doesn't contain all the keys of the parent tuple.

This change strengthens the check to ensure that the driver is only
considered whole when the values refer to all the values corresponding
to the parent tuple.