### PR TITLE
Fix handling of asyncreset cast in coreir backend

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -182,6 +182,10 @@ class Array(Type, metaclass=ArrayKind):
         for k in range(len(i)):
             i[k].wire(o[k], debug_info)
 
+    def unwire(i, o):
+        for k in range(len(i)):
+            i[k].unwire(o[k])
+
     def driven(self):
         for t in self.ts:
             if not t.driven():

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -14,7 +14,7 @@ from ..logging import error
 import coreir
 from ..ref import ArrayRef, DefnRef, TupleRef, InstRef
 from ..passes import InstanceGraphPass
-from ..t import In
+from ..t import In, Kind
 import logging
 from .util import make_relative, get_codegen_debug_info
 from ..interface import InterfaceKind
@@ -227,10 +227,16 @@ class CoreIRBackend:
             config_args = self.context.new_values(config_args)
             gen_args = {}
             for name, value in type(instance).coreir_genargs.items():
-                if isinstance(value, (AsyncResetKind, AsyncResetNKind)):
-                    value = self.context.named_types["coreir", "arst"]
-                elif isinstance(value, ClockKind):
-                    value = self.context.named_types["coreir", "clk"]
+                if isinstance(value, ClockKind):
+                    if value.isinput():
+                        value = self.context.named_types[("coreir", "clkIn")]
+                    else:
+                        value = self.context.named_types[("coreir", "clk")]
+                elif isinstance(value, (AsyncResetKind, AsyncResetNKind)):
+                    if value.isinput():
+                        value = self.context.named_types[("coreir", "arstIn")]
+                    else:
+                        value = self.context.named_types[("coreir", "arst")]
                 gen_args[name] = value
             gen_args = self.context.new_values(gen_args)
             return module_definition.add_generator_instance(instance.name,
@@ -501,30 +507,53 @@ class CoreIRBackend:
 
 
 class InsertWrapCasts(DefinitionPass):
-    def define_wrap(self, type_, in_type):
-        def sim_wrap(self, value_store, state_store):
-            input_val = value_store.get_value(getattr(self, "in"))
-            value_store.set_value(self.out, input_val)
+    def sim(self, value_store, state_store):
+        input_val = value_store.get_value(getattr(self, "in"))
+        value_store.set_value(self.out, input_val)
 
+    def define_wrap(self, wrap_type, in_type, out_type):
         return m.DeclareCircuit(
-            f'coreir_wrap{type_.__name__}',
-            "in", m.In(in_type), "out", m.Out(type_),
-            coreir_genargs={"type": type_},
+            f'coreir_wrap{wrap_type}'.replace("(", "").replace(")", ""),
+            "in", m.In(in_type), "out", m.Out(out_type),
+            coreir_genargs={"type": wrap_type},
             coreir_name="wrap",
             coreir_lib="coreir",
-            simulate=sim_wrap
+            simulate=self.sim
         )
 
-    def __call__(self, definition):
-        for name, port in definition.interface.ports.items():
-            if isinstance(port, (AsyncResetType, AsyncResetNType)):
+    def wrap_if_arst(self, port, definition):
+        if isinstance(port, (ArrayType, TupleType)):
+            for t in port:
+                self.wrap_if_arst(t, definition)
+        elif port.isinput():
+            if isinstance(port, (AsyncResetType, AsyncResetNType)) or \
+                    isinstance(port.value(), (AsyncResetType, AsyncResetNType)):
                 value = port.value()
-                if value is not None and not isinstance(value, type(port)):
+                print(port, value)
+                if value is not None and not isinstance(type(value),
+                                                        type(type(port))):
                     port.unwire(value)
-                    wrap_inst = self.define_wrap(type(port), type(value))()
-                    definition.place(wrap_inst)
-                    getattr(wrap_inst, "in") <= value
-                    m.wire(wrap_inst.out, port)
+                    if isinstance(port, (AsyncResetType, AsyncResetNType)):
+                        inst = self.define_wrap(type(port).flip(), type(port),
+                                                type(value))()
+                    else:
+                        inst = self.define_wrap(type(value).flip(), type(port),
+                                                type(value))()
+                    definition.place(inst)
+                    getattr(inst, "in") <= value
+                    m.wire(inst.out, port)
+
+    def __call__(self, definition):
+        # copy, because wrapping might add instances
+        instances = definition.instances[:]
+        for instance in definition.instances:
+            if type(instance).coreir_name == "wrap" or \
+                    type(instance).coreir_name == "unwrap":
+                continue
+            for port in instance.interface.ports.values():
+                self.wrap_if_arst(port, definition)
+        for port in definition.interface.ports.values():
+            self.wrap_if_arst(port, definition)
 
 
 def compile(main, file_name=None, context=None, check_context_is_default=True):

--- a/magma/bit.py
+++ b/magma/bit.py
@@ -46,6 +46,8 @@ class _BitType(Type):
         i.port.wire(o.port, debug_info)
         i.debug_info = debug_info
         o.debug_info = debug_info
+    def unwire(i, o):
+        i.port.unwire(o.port)
 
     def driven(self):
         return self.port.driven()

--- a/magma/bit.py
+++ b/magma/bit.py
@@ -46,6 +46,7 @@ class _BitType(Type):
         i.port.wire(o.port, debug_info)
         i.debug_info = debug_info
         o.debug_info = debug_info
+
     def unwire(i, o):
         i.port.unwire(o.port)
 

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -5,6 +5,7 @@ import subprocess
 
 from .passes import DefinitionPass, InstanceGraphPass
 from .backend import verilog, blif, firrtl, dot
+from .backend.coreir_ import InsertWrapCasts
 from .config import get_compile_dir
 from .logging import warning
 from .uniquification import uniquification_pass, UniquificationMode
@@ -24,6 +25,7 @@ def __compile_to_coreir(main, file_name, opts):
     # package.
     from .frontend import coreir_
     backend = coreir_.GetCoreIRBackend()
+    InsertWrapCasts(main).run()
     backend.compile(main)
     passes = opts.get("passes", [])
     if "markdirty" not in passes:

--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -6,6 +6,7 @@ from .bit import _BitKind, _BitType, Bit, BitType, VCC, GND
 from .clock import ClockType, Clock, \
     Reset, ResetType, \
     AsyncReset, AsyncResetType, \
+    AsyncResetN, AsyncResetNType, \
     Enable, EnableType
 from .array import ArrayType, Array, ArrayKind
 from .bits import BitsType, Bits, UIntType, UInt, SIntType, SInt, UIntKind, \
@@ -16,7 +17,7 @@ import magma as m
 import hwtypes
 
 __all__ = ['bit']
-__all__ += ['clock', 'reset', 'enable', 'asyncreset']
+__all__ += ['clock', 'reset', 'enable', 'asyncreset', 'asyncresetn']
 
 __all__ += ['array']
 __all__ += ['bits', 'uint', 'sint']
@@ -84,6 +85,10 @@ def reset(value):
 
 def asyncreset(value):
     return convertbit(value, AsyncResetType, AsyncReset)
+
+
+def asyncresetn(value):
+    return convertbit(value, AsyncResetNType, AsyncResetN)
 
 
 def enable(value):

--- a/magma/port.py
+++ b/magma/port.py
@@ -86,6 +86,9 @@ class Wire:
     def __init__(self):
         self.inputs = []
         self.outputs = []
+    def disconnect( self, o, i):
+        self.outputs.remove(o)
+        self.inputs.remove(i)
 
     def connect( self, o, i , debug_info):
         """
@@ -161,6 +164,10 @@ class Port:
     def anon(self):
         return self.bit.anon()
 
+    def unwire(i, o):
+        o.wires.disconnect(o, i)
+
+    # wire a port to a port
     def wire(i, o, debug_info):
         """
         Wire a port to a port.

--- a/magma/port.py
+++ b/magma/port.py
@@ -86,7 +86,8 @@ class Wire:
     def __init__(self):
         self.inputs = []
         self.outputs = []
-    def disconnect( self, o, i):
+
+    def disconnect(self, o, i):
         self.outputs.remove(o)
         self.inputs.remove(i)
 

--- a/magma/port.py
+++ b/magma/port.py
@@ -88,7 +88,6 @@ class Wire:
         self.outputs = []
 
     def disconnect(self, o, i):
-        self.outputs.remove(o)
         self.inputs.remove(i)
 
     def connect( self, o, i , debug_info):
@@ -167,6 +166,8 @@ class Port:
 
     def unwire(i, o):
         o.wires.disconnect(o, i)
+        # Wire can only have one output, so we start with a fresh wire
+        i.wires = Wire()
 
     # wire a port to a port
     def wire(i, o, debug_info):
@@ -221,6 +222,7 @@ class Port:
         if self in self.wires.inputs:
             if len(self.wires.outputs) < 1:
                 return None
+            assert len(self.wires.outputs) == 1
             return self.wires.outputs[0]
 
         return None

--- a/magma/port.py
+++ b/magma/port.py
@@ -222,7 +222,6 @@ class Port:
         if self in self.wires.inputs:
             if len(self.wires.outputs) < 1:
                 return None
-            assert len(self.wires.outputs) == 1
             return self.wires.outputs[0]
 
         return None

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -95,6 +95,13 @@ class TupleType(Type):
             else:
                 i_elem.wire(o_elem, debug_info)
 
+    def unwire(i, o):
+        for i_elem, o_elem in zip(i, o):
+            if o_elem.isinput():
+                o_elem.unwire(i_elem, debug_info)
+            else:
+                i_elem.unwire(o_elem, debug_info)
+
     def driven(self):
         for t in self.ts:
             if not t.driven():

--- a/tests/test_type/gold/test_AsyncResetN_cast.v
+++ b/tests/test_type/gold/test_AsyncResetN_cast.v
@@ -2,9 +2,30 @@ module coreir_wrap (input in, output out);
   assign out = in;
 endmodule
 
-module AsyncResetTest (input I, output O);
-wire coreir_wrapAsyncResetN_inst0_out;
-coreir_wrap coreir_wrapAsyncResetN_inst0(.in(I), .out(coreir_wrapAsyncResetN_inst0_out));
-assign O = coreir_wrapAsyncResetN_inst0_out;
+module AsyncResetTest (output [2:0] Bit_Arr_out, output Bit_out, input I, input [2:0] I_Arr, output O, output [1:0] O_Arr, output O_Tuple_B, output O_Tuple_R, input [1:0] T_Arr_in, input T_Tuple_in_T, input T_in);
+wire coreir_wrapInAsyncResetN_inst0_out;
+wire coreir_wrapInAsyncResetN_inst1_out;
+wire coreir_wrapInAsyncResetN_inst2_out;
+wire coreir_wrapInAsyncResetN_inst3_out;
+wire coreir_wrapInAsyncResetN_inst4_out;
+wire coreir_wrapOutAsyncResetN_inst0_out;
+wire coreir_wrapOutAsyncResetN_inst1_out;
+wire coreir_wrapOutAsyncResetN_inst2_out;
+wire coreir_wrapOutAsyncResetN_inst3_out;
+coreir_wrap coreir_wrapInAsyncResetN_inst0(.in(T_Tuple_in_T), .out(coreir_wrapInAsyncResetN_inst0_out));
+coreir_wrap coreir_wrapInAsyncResetN_inst1(.in(T_in), .out(coreir_wrapInAsyncResetN_inst1_out));
+coreir_wrap coreir_wrapInAsyncResetN_inst2(.in(T_Arr_in[0]), .out(coreir_wrapInAsyncResetN_inst2_out));
+coreir_wrap coreir_wrapInAsyncResetN_inst3(.in(T_Arr_in[1]), .out(coreir_wrapInAsyncResetN_inst3_out));
+coreir_wrap coreir_wrapInAsyncResetN_inst4(.in(T_Arr_in[0]), .out(coreir_wrapInAsyncResetN_inst4_out));
+coreir_wrap coreir_wrapOutAsyncResetN_inst0(.in(I), .out(coreir_wrapOutAsyncResetN_inst0_out));
+coreir_wrap coreir_wrapOutAsyncResetN_inst1(.in(I_Arr[0]), .out(coreir_wrapOutAsyncResetN_inst1_out));
+coreir_wrap coreir_wrapOutAsyncResetN_inst2(.in(I_Arr[1]), .out(coreir_wrapOutAsyncResetN_inst2_out));
+coreir_wrap coreir_wrapOutAsyncResetN_inst3(.in(I_Arr[2]), .out(coreir_wrapOutAsyncResetN_inst3_out));
+assign Bit_Arr_out = {coreir_wrapInAsyncResetN_inst4_out,coreir_wrapInAsyncResetN_inst3_out,coreir_wrapInAsyncResetN_inst2_out};
+assign Bit_out = coreir_wrapInAsyncResetN_inst1_out;
+assign O = coreir_wrapOutAsyncResetN_inst0_out;
+assign O_Arr = {coreir_wrapOutAsyncResetN_inst3_out,coreir_wrapOutAsyncResetN_inst2_out};
+assign O_Tuple_B = coreir_wrapInAsyncResetN_inst0_out;
+assign O_Tuple_R = coreir_wrapOutAsyncResetN_inst1_out;
 endmodule
 

--- a/tests/test_type/gold/test_AsyncResetN_cast.v
+++ b/tests/test_type/gold/test_AsyncResetN_cast.v
@@ -1,31 +1,38 @@
+// Module `Inst` defined externally
 module coreir_wrap (input in, output out);
   assign out = in;
 endmodule
 
-module AsyncResetTest (output [2:0] Bit_Arr_out, output Bit_out, input I, input [2:0] I_Arr, output O, output [1:0] O_Arr, output O_Tuple_B, output O_Tuple_R, input [1:0] T_Arr_in, input T_Tuple_in_T, input T_in);
+module AsyncResetTest (output [3:0] Bit_Arr_out, output Bit_out, input I, input [2:0] I_Arr, output O, output [1:0] O_Arr, output O_Tuple_B, output O_Tuple_R, input [1:0] T_Arr_in, input T_Tuple_in_T, input T_in);
+wire Inst_inst0_O;
 wire coreir_wrapInAsyncResetN_inst0_out;
 wire coreir_wrapInAsyncResetN_inst1_out;
 wire coreir_wrapInAsyncResetN_inst2_out;
 wire coreir_wrapInAsyncResetN_inst3_out;
 wire coreir_wrapInAsyncResetN_inst4_out;
+wire coreir_wrapInAsyncResetN_inst5_out;
 wire coreir_wrapOutAsyncResetN_inst0_out;
 wire coreir_wrapOutAsyncResetN_inst1_out;
 wire coreir_wrapOutAsyncResetN_inst2_out;
 wire coreir_wrapOutAsyncResetN_inst3_out;
+wire coreir_wrapOutAsyncResetN_inst4_out;
+Inst Inst_inst0(.I(coreir_wrapOutAsyncResetN_inst0_out), .O(Inst_inst0_O));
 coreir_wrap coreir_wrapInAsyncResetN_inst0(.in(T_Tuple_in_T), .out(coreir_wrapInAsyncResetN_inst0_out));
 coreir_wrap coreir_wrapInAsyncResetN_inst1(.in(T_in), .out(coreir_wrapInAsyncResetN_inst1_out));
 coreir_wrap coreir_wrapInAsyncResetN_inst2(.in(T_Arr_in[0]), .out(coreir_wrapInAsyncResetN_inst2_out));
 coreir_wrap coreir_wrapInAsyncResetN_inst3(.in(T_Arr_in[1]), .out(coreir_wrapInAsyncResetN_inst3_out));
 coreir_wrap coreir_wrapInAsyncResetN_inst4(.in(T_Arr_in[0]), .out(coreir_wrapInAsyncResetN_inst4_out));
-coreir_wrap coreir_wrapOutAsyncResetN_inst0(.in(I), .out(coreir_wrapOutAsyncResetN_inst0_out));
-coreir_wrap coreir_wrapOutAsyncResetN_inst1(.in(I_Arr[0]), .out(coreir_wrapOutAsyncResetN_inst1_out));
-coreir_wrap coreir_wrapOutAsyncResetN_inst2(.in(I_Arr[1]), .out(coreir_wrapOutAsyncResetN_inst2_out));
-coreir_wrap coreir_wrapOutAsyncResetN_inst3(.in(I_Arr[2]), .out(coreir_wrapOutAsyncResetN_inst3_out));
-assign Bit_Arr_out = {coreir_wrapInAsyncResetN_inst4_out,coreir_wrapInAsyncResetN_inst3_out,coreir_wrapInAsyncResetN_inst2_out};
+coreir_wrap coreir_wrapInAsyncResetN_inst5(.in(Inst_inst0_O), .out(coreir_wrapInAsyncResetN_inst5_out));
+coreir_wrap coreir_wrapOutAsyncResetN_inst0(.in(I_Arr[2]), .out(coreir_wrapOutAsyncResetN_inst0_out));
+coreir_wrap coreir_wrapOutAsyncResetN_inst1(.in(I), .out(coreir_wrapOutAsyncResetN_inst1_out));
+coreir_wrap coreir_wrapOutAsyncResetN_inst2(.in(I_Arr[0]), .out(coreir_wrapOutAsyncResetN_inst2_out));
+coreir_wrap coreir_wrapOutAsyncResetN_inst3(.in(I_Arr[1]), .out(coreir_wrapOutAsyncResetN_inst3_out));
+coreir_wrap coreir_wrapOutAsyncResetN_inst4(.in(I_Arr[2]), .out(coreir_wrapOutAsyncResetN_inst4_out));
+assign Bit_Arr_out = {coreir_wrapInAsyncResetN_inst5_out,coreir_wrapInAsyncResetN_inst4_out,coreir_wrapInAsyncResetN_inst3_out,coreir_wrapInAsyncResetN_inst2_out};
 assign Bit_out = coreir_wrapInAsyncResetN_inst1_out;
-assign O = coreir_wrapOutAsyncResetN_inst0_out;
-assign O_Arr = {coreir_wrapOutAsyncResetN_inst3_out,coreir_wrapOutAsyncResetN_inst2_out};
+assign O = coreir_wrapOutAsyncResetN_inst1_out;
+assign O_Arr = {coreir_wrapOutAsyncResetN_inst4_out,coreir_wrapOutAsyncResetN_inst3_out};
 assign O_Tuple_B = coreir_wrapInAsyncResetN_inst0_out;
-assign O_Tuple_R = coreir_wrapOutAsyncResetN_inst1_out;
+assign O_Tuple_R = coreir_wrapOutAsyncResetN_inst2_out;
 endmodule
 

--- a/tests/test_type/gold/test_AsyncResetN_cast.v
+++ b/tests/test_type/gold/test_AsyncResetN_cast.v
@@ -1,0 +1,10 @@
+module coreir_wrap (input in, output out);
+  assign out = in;
+endmodule
+
+module AsyncResetTest (input I, output O);
+wire coreir_wrapAsyncResetN_inst0_out;
+coreir_wrap coreir_wrapAsyncResetN_inst0(.in(I), .out(coreir_wrapAsyncResetN_inst0_out));
+assign O = coreir_wrapAsyncResetN_inst0_out;
+endmodule
+

--- a/tests/test_type/gold/test_AsyncReset_cast.v
+++ b/tests/test_type/gold/test_AsyncReset_cast.v
@@ -1,31 +1,38 @@
+// Module `Inst` defined externally
 module coreir_wrap (input in, output out);
   assign out = in;
 endmodule
 
-module AsyncResetTest (output [2:0] Bit_Arr_out, output Bit_out, input I, input [2:0] I_Arr, output O, output [1:0] O_Arr, output O_Tuple_B, output O_Tuple_R, input [1:0] T_Arr_in, input T_Tuple_in_T, input T_in);
+module AsyncResetTest (output [3:0] Bit_Arr_out, output Bit_out, input I, input [2:0] I_Arr, output O, output [1:0] O_Arr, output O_Tuple_B, output O_Tuple_R, input [1:0] T_Arr_in, input T_Tuple_in_T, input T_in);
+wire Inst_inst0_O;
 wire coreir_wrapInAsyncReset_inst0_out;
 wire coreir_wrapInAsyncReset_inst1_out;
 wire coreir_wrapInAsyncReset_inst2_out;
 wire coreir_wrapInAsyncReset_inst3_out;
 wire coreir_wrapInAsyncReset_inst4_out;
+wire coreir_wrapInAsyncReset_inst5_out;
 wire coreir_wrapOutAsyncReset_inst0_out;
 wire coreir_wrapOutAsyncReset_inst1_out;
 wire coreir_wrapOutAsyncReset_inst2_out;
 wire coreir_wrapOutAsyncReset_inst3_out;
+wire coreir_wrapOutAsyncReset_inst4_out;
+Inst Inst_inst0(.I(coreir_wrapOutAsyncReset_inst0_out), .O(Inst_inst0_O));
 coreir_wrap coreir_wrapInAsyncReset_inst0(.in(T_Tuple_in_T), .out(coreir_wrapInAsyncReset_inst0_out));
 coreir_wrap coreir_wrapInAsyncReset_inst1(.in(T_in), .out(coreir_wrapInAsyncReset_inst1_out));
 coreir_wrap coreir_wrapInAsyncReset_inst2(.in(T_Arr_in[0]), .out(coreir_wrapInAsyncReset_inst2_out));
 coreir_wrap coreir_wrapInAsyncReset_inst3(.in(T_Arr_in[1]), .out(coreir_wrapInAsyncReset_inst3_out));
 coreir_wrap coreir_wrapInAsyncReset_inst4(.in(T_Arr_in[0]), .out(coreir_wrapInAsyncReset_inst4_out));
-coreir_wrap coreir_wrapOutAsyncReset_inst0(.in(I), .out(coreir_wrapOutAsyncReset_inst0_out));
-coreir_wrap coreir_wrapOutAsyncReset_inst1(.in(I_Arr[0]), .out(coreir_wrapOutAsyncReset_inst1_out));
-coreir_wrap coreir_wrapOutAsyncReset_inst2(.in(I_Arr[1]), .out(coreir_wrapOutAsyncReset_inst2_out));
-coreir_wrap coreir_wrapOutAsyncReset_inst3(.in(I_Arr[2]), .out(coreir_wrapOutAsyncReset_inst3_out));
-assign Bit_Arr_out = {coreir_wrapInAsyncReset_inst4_out,coreir_wrapInAsyncReset_inst3_out,coreir_wrapInAsyncReset_inst2_out};
+coreir_wrap coreir_wrapInAsyncReset_inst5(.in(Inst_inst0_O), .out(coreir_wrapInAsyncReset_inst5_out));
+coreir_wrap coreir_wrapOutAsyncReset_inst0(.in(I_Arr[2]), .out(coreir_wrapOutAsyncReset_inst0_out));
+coreir_wrap coreir_wrapOutAsyncReset_inst1(.in(I), .out(coreir_wrapOutAsyncReset_inst1_out));
+coreir_wrap coreir_wrapOutAsyncReset_inst2(.in(I_Arr[0]), .out(coreir_wrapOutAsyncReset_inst2_out));
+coreir_wrap coreir_wrapOutAsyncReset_inst3(.in(I_Arr[1]), .out(coreir_wrapOutAsyncReset_inst3_out));
+coreir_wrap coreir_wrapOutAsyncReset_inst4(.in(I_Arr[2]), .out(coreir_wrapOutAsyncReset_inst4_out));
+assign Bit_Arr_out = {coreir_wrapInAsyncReset_inst5_out,coreir_wrapInAsyncReset_inst4_out,coreir_wrapInAsyncReset_inst3_out,coreir_wrapInAsyncReset_inst2_out};
 assign Bit_out = coreir_wrapInAsyncReset_inst1_out;
-assign O = coreir_wrapOutAsyncReset_inst0_out;
-assign O_Arr = {coreir_wrapOutAsyncReset_inst3_out,coreir_wrapOutAsyncReset_inst2_out};
+assign O = coreir_wrapOutAsyncReset_inst1_out;
+assign O_Arr = {coreir_wrapOutAsyncReset_inst4_out,coreir_wrapOutAsyncReset_inst3_out};
 assign O_Tuple_B = coreir_wrapInAsyncReset_inst0_out;
-assign O_Tuple_R = coreir_wrapOutAsyncReset_inst1_out;
+assign O_Tuple_R = coreir_wrapOutAsyncReset_inst2_out;
 endmodule
 

--- a/tests/test_type/gold/test_AsyncReset_cast.v
+++ b/tests/test_type/gold/test_AsyncReset_cast.v
@@ -2,9 +2,30 @@ module coreir_wrap (input in, output out);
   assign out = in;
 endmodule
 
-module AsyncResetTest (input I, output O);
-wire coreir_wrapAsyncReset_inst0_out;
-coreir_wrap coreir_wrapAsyncReset_inst0(.in(I), .out(coreir_wrapAsyncReset_inst0_out));
-assign O = coreir_wrapAsyncReset_inst0_out;
+module AsyncResetTest (output [2:0] Bit_Arr_out, output Bit_out, input I, input [2:0] I_Arr, output O, output [1:0] O_Arr, output O_Tuple_B, output O_Tuple_R, input [1:0] T_Arr_in, input T_Tuple_in_T, input T_in);
+wire coreir_wrapInAsyncReset_inst0_out;
+wire coreir_wrapInAsyncReset_inst1_out;
+wire coreir_wrapInAsyncReset_inst2_out;
+wire coreir_wrapInAsyncReset_inst3_out;
+wire coreir_wrapInAsyncReset_inst4_out;
+wire coreir_wrapOutAsyncReset_inst0_out;
+wire coreir_wrapOutAsyncReset_inst1_out;
+wire coreir_wrapOutAsyncReset_inst2_out;
+wire coreir_wrapOutAsyncReset_inst3_out;
+coreir_wrap coreir_wrapInAsyncReset_inst0(.in(T_Tuple_in_T), .out(coreir_wrapInAsyncReset_inst0_out));
+coreir_wrap coreir_wrapInAsyncReset_inst1(.in(T_in), .out(coreir_wrapInAsyncReset_inst1_out));
+coreir_wrap coreir_wrapInAsyncReset_inst2(.in(T_Arr_in[0]), .out(coreir_wrapInAsyncReset_inst2_out));
+coreir_wrap coreir_wrapInAsyncReset_inst3(.in(T_Arr_in[1]), .out(coreir_wrapInAsyncReset_inst3_out));
+coreir_wrap coreir_wrapInAsyncReset_inst4(.in(T_Arr_in[0]), .out(coreir_wrapInAsyncReset_inst4_out));
+coreir_wrap coreir_wrapOutAsyncReset_inst0(.in(I), .out(coreir_wrapOutAsyncReset_inst0_out));
+coreir_wrap coreir_wrapOutAsyncReset_inst1(.in(I_Arr[0]), .out(coreir_wrapOutAsyncReset_inst1_out));
+coreir_wrap coreir_wrapOutAsyncReset_inst2(.in(I_Arr[1]), .out(coreir_wrapOutAsyncReset_inst2_out));
+coreir_wrap coreir_wrapOutAsyncReset_inst3(.in(I_Arr[2]), .out(coreir_wrapOutAsyncReset_inst3_out));
+assign Bit_Arr_out = {coreir_wrapInAsyncReset_inst4_out,coreir_wrapInAsyncReset_inst3_out,coreir_wrapInAsyncReset_inst2_out};
+assign Bit_out = coreir_wrapInAsyncReset_inst1_out;
+assign O = coreir_wrapOutAsyncReset_inst0_out;
+assign O_Arr = {coreir_wrapOutAsyncReset_inst3_out,coreir_wrapOutAsyncReset_inst2_out};
+assign O_Tuple_B = coreir_wrapInAsyncReset_inst0_out;
+assign O_Tuple_R = coreir_wrapOutAsyncReset_inst1_out;
 endmodule
 

--- a/tests/test_type/gold/test_AsyncReset_cast.v
+++ b/tests/test_type/gold/test_AsyncReset_cast.v
@@ -1,0 +1,10 @@
+module coreir_wrap (input in, output out);
+  assign out = in;
+endmodule
+
+module AsyncResetTest (input I, output O);
+wire coreir_wrapAsyncReset_inst0_out;
+coreir_wrap coreir_wrapAsyncReset_inst0(.in(I), .out(coreir_wrapAsyncReset_inst0_out));
+assign O = coreir_wrapAsyncReset_inst0_out;
+endmodule
+

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -1,5 +1,7 @@
 import pytest
 import tempfile
+import magma as m
+from magma.testing import check_files_equal
 from magma import In, Out, Flip, \
     Clock, ClockType, ClockKind, \
     Reset, ResetType, ResetKind, reset, \
@@ -174,3 +176,17 @@ def test_const_wire(T, t):
     expected_filename = f"tests/test_type/test_const_wire_golden.json"
     expected = open(expected_filename).read()
     assert got == expected
+
+
+@pytest.mark.parametrize("T,convert", [(m.AsyncResetOut, m.asyncreset),
+                                       (m.AsyncResetNOut, m.asyncresetn)])
+def test_asyncreset_cast(T, convert):
+    class AsyncResetTest(m.Circuit):
+        IO = ['I', m.BitIn, 'O', T]
+
+        @classmethod
+        def definition(io):
+            io.O <= convert(io.I)
+    m.compile(f"build/test_{T.__name__}_cast", AsyncResetTest)
+    assert check_files_equal(__file__, f"build/test_{T.__name__}_cast.v",
+                             f"gold/test_{T.__name__}_cast.v")

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -182,11 +182,27 @@ def test_const_wire(T, t):
                                        (m.AsyncResetNOut, m.asyncresetn)])
 def test_asyncreset_cast(T, convert):
     class AsyncResetTest(m.Circuit):
-        IO = ['I', m.BitIn, 'O', T]
+        IO = ['I', m.BitIn, 'I_Arr', m.In(m.Array[3, Bit]),
+              'O', T, "O_Tuple", m.Tuple(R=T, B=Out(Bit)),
+              "O_Arr", m.Array[2, T],
+              'T_in', In(T), 'Bit_out', Out(Bit),
+              'T_Arr_in', In(m.Array[2, T]),
+              'Bit_Arr_out', Out(m.Array[3, Bit]),
+              'T_Tuple_in', In(m.Tuple(T=T)),
+              'Bit_Arr_out', Out(m.Array[3, Bit])]
 
         @classmethod
         def definition(io):
             io.O <= convert(io.I)
+            io.O_Tuple.R <= convert(io.I_Arr[0])
+            io.O_Arr[0] <= convert(io.I_Arr[1])
+            io.O_Arr[1] <= convert(io.I_Arr[2])
+            io.Bit_out <= m.bit(io.T_in)
+            io.O_Tuple.B <= m.bit(io.T_Tuple_in.T)
+            io.Bit_Arr_out[0] <= m.bit(io.T_Arr_in[0])
+            io.Bit_Arr_out[1] <= m.bit(io.T_Arr_in[1])
+            io.Bit_Arr_out[2] <= m.bit(io.T_Arr_in[0])
+
     m.compile(f"build/test_{T.__name__}_cast", AsyncResetTest)
     assert check_files_equal(__file__, f"build/test_{T.__name__}_cast.v",
                              f"gold/test_{T.__name__}_cast.v")

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -181,6 +181,9 @@ def test_const_wire(T, t):
 @pytest.mark.parametrize("T,convert", [(m.AsyncResetOut, m.asyncreset),
                                        (m.AsyncResetNOut, m.asyncresetn)])
 def test_asyncreset_cast(T, convert):
+    class Inst(m.Circuit):
+        IO = ['O', T, 'I', m.In(T)]
+
     class AsyncResetTest(m.Circuit):
         IO = ['I', m.BitIn, 'I_Arr', m.In(m.Array[3, Bit]),
               'O', T, "O_Tuple", m.Tuple(R=T, B=Out(Bit)),
@@ -189,19 +192,22 @@ def test_asyncreset_cast(T, convert):
               'T_Arr_in', In(m.Array[2, T]),
               'Bit_Arr_out', Out(m.Array[3, Bit]),
               'T_Tuple_in', In(m.Tuple(T=T)),
-              'Bit_Arr_out', Out(m.Array[3, Bit])]
+              'Bit_Arr_out', Out(m.Array[4, Bit])]
 
         @classmethod
         def definition(io):
+            inst = Inst()
             io.O <= convert(io.I)
             io.O_Tuple.R <= convert(io.I_Arr[0])
             io.O_Arr[0] <= convert(io.I_Arr[1])
             io.O_Arr[1] <= convert(io.I_Arr[2])
+            inst.I <= convert(io.I_Arr[2])
             io.Bit_out <= m.bit(io.T_in)
             io.O_Tuple.B <= m.bit(io.T_Tuple_in.T)
             io.Bit_Arr_out[0] <= m.bit(io.T_Arr_in[0])
             io.Bit_Arr_out[1] <= m.bit(io.T_Arr_in[1])
             io.Bit_Arr_out[2] <= m.bit(io.T_Arr_in[0])
+            io.Bit_Arr_out[3] <= m.bit(inst.O)
 
     m.compile(f"build/test_{T.__name__}_cast", AsyncResetTest)
     assert check_files_equal(__file__, f"build/test_{T.__name__}_cast.v",


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/492

Coreir uses a special named type to distinguish async reset, the only way to wire up a bit to this type is to insert a `wrap` module that converts from the bit to the named type (effectively an explicit cast using an instance of a special primitive).  Magma, on the other hand, handles the cast by just wiring up the underlying values (so there's no explicit instance between them).

These changes introduce a pass that is run before compilation that insert the coreir wrap primitive instances to handle the conversion to the named type.  For now it only handles AsyncRest and AsyncResetN, but we could generalize this later to handle arbitrary named types that need this logic.

In order to do this pass, I needed to include logic to allow unwiring a port (so I could unwire a bit connected to an asyncreset, then rewire them to the intermediate wrap instance).

TODO: Generalize support for nested types (right now the pass only works on ports that are asyncreset(n), but not if they're nested inside a tuple or array)

Depends on https://github.com/rdaly525/coreir/pull/816