### PR TITLE
Enforce Unique Names

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -596,8 +596,12 @@ def DefineCircuit(name, *decl, **args):
     currentDefinition = DefineCircuitKind( name, (Circuit,), dct)
     return currentDefinition
 
+__seenCircuitNames = {}
 def EndDefine():
     if currentDefinition:
+        if currentDefinition.name in __seenCircuitNames:
+            raise Exception(f"The circuit name '{currentDefinition.name}' was already used. Module names must be unique!")
+        __seenCircuitNames[currentDefinition.name] = 1
         debug_info = get_callee_frame_info()
         currentDefinition.end_circuit_filename = debug_info[0]
         currentDefinition.end_circuit_lineno   = debug_info[1]

--- a/magma/syntax/combinational.py
+++ b/magma/syntax/combinational.py
@@ -275,7 +275,6 @@ def combinational(
     else:
         wrapped_combinational = ast_utils.inspect_enclosing_env(
                 _combinational,
-                decorators=[combinational],
-                st=env
+                decorators=[combinational]
         )
         return wrapped_combinational(fn)

--- a/tests/test_circuit/test_define.py
+++ b/tests/test_circuit/test_define.py
@@ -54,7 +54,7 @@ def test_for_loop_def(target, suffix):
     And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                             "O", m.Out(m.Bit))
 
-    main = m.DefineCircuit("main", "I", m.In(m.Bits[2]), "O", m.Out(m.Bit))
+    main = m.DefineCircuit("main2", "I", m.In(m.Bits[2]), "O", m.Out(m.Bit))
 
     and2_prev = None
     for i in range(0, 4):
@@ -86,7 +86,7 @@ def test_interleaved_instance_wiring(target, suffix):
     And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                             "O", m.Out(m.Bit))
 
-    main = m.DefineCircuit("main", "I", m.In(m.Bits[2]), "O", m.Out(m.Bit))
+    main = m.DefineCircuit("main3", "I", m.In(m.Bits[2]), "O", m.Out(m.Bit))
 
     and2_0 = And2()
     and2_1 = And2()
@@ -115,7 +115,7 @@ def test_unwired_ports_warnings(caplog):
     And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                             "O", m.Out(m.Bit))
 
-    main = m.DefineCircuit("main", "I", m.In(m.Bits[2]), "O", m.Out(m.Bit))
+    main = m.DefineCircuit("main4", "I", m.In(m.Bits[2]), "O", m.Out(m.Bit))
 
     and2 = And2()
 
@@ -134,7 +134,7 @@ def test_2d_array_error(caplog):
     And2 = m.DeclareCircuit('And2', "I0", m.In(m.Bit), "I1", m.In(m.Bit),
                             "O", m.Out(m.Bit))
 
-    main = m.DefineCircuit("main", "I", m.In(m.Array[2, m.Array[3, m.Bit]]),
+    main = m.DefineCircuit("main5", "I", m.In(m.Array[2, m.Array[3, m.Bit]]),
                            "O", m.Out(m.Bit))
 
     and2 = And2()
@@ -157,7 +157,7 @@ def test_anon_value(target, suffix, T):
     And2 = m.DeclareCircuit('And2', "I0", m.In(T), "I1", m.In(T),
                             "O", m.Out(T))
 
-    main = m.DefineCircuit("main", "I0", m.In(T), "I1", m.In(T),
+    main = m.DefineCircuit(f"main6_{target}_{suffix}_{T}", "I0", m.In(T), "I1", m.In(T),
                            "O", m.Out(T))
 
     and2 = And2()


### PR DESCRIPTION
I suggest we change magma to enforce that module names are unique at definition time. Currently, if the user forgets to memoize a generator, their code will create thousands of duplicate module definitions, which the compiler will silently accept. This is causing us to have hour long compile times, and it's not possible to debug this if we don't raise an error.

I added a quick fix to enforce this behavior, but (if we agree this is the behavior we want), I will need help squashing all the duplicate name bugs. It looks like a large number of generators in the repo that are not being memoized.