### PR TITLE
Make pycodestyle run by defualt for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,10 @@ max-line-length = 80
 # We ignore this because I and O is currently idiomatic magma for port names
 ignore = E741
 
+# Start with all files blacklisted from pycodestyle.
+exclude = tests/*,magma/port.py,magma/waveform.py,magma/logging.py,magma/transforms.py,magma/bits.py,magma/tuple.py,magma/compatibility.py,magma/circuit.py,magma/config.py,magma/frontend/coreir.py,magma/frontend/__init__.py,magma/frontend/coreir_.py,magma/util.py,magma/conversions.py,magma/clock.py,magma/interface.py,magma/passes/tsort.py,magma/passes/clock.py,magma/passes/debug_name.py,magma/passes/__init__.py,magma/passes/ir.py,magma/passes/passes.py,magma/bitutils.py,magma/__init__.py,magma/backend/util.py,magma/backend/__init__.py,magma/backend/firrtl.py,magma/backend/verilog.py,magma/backend/coreir_.py,magma/backend/dot.py,magma/backend/blif.py,magma/ir.py,magma/wire.py,magma/testing/__init__.py,magma/testing/coroutine.py,magma/testing/utils.py,magma/testing/compile.py,magma/generator.py,magma/ssa/__init__.py,magma/ssa/ssa.py,magma/is_primitive.py,magma/simulator/__init__.py,magma/simulator/coreir_simulator.py,magma/simulator/simulator.py,magma/simulator/python_simulator.py,magma/simulator/mdb.py,magma/debug.py,magma/ast_utils.py,magma/compile.py,magma/ref.py,magma/bit.py,magma/product.py,magma/math.py,magma/braid.py,magma/enum.py,magma/fromverilog.py,magma/operators.py,magma/array.py,magma/syntax/util.py,magma/syntax/combinational.py,magma/syntax/__init__.py,magma/syntax/sequential.py,magma/uniquification.py,magma/is_definition.py,magma/scope.py,magma/t.py
+
 [tool:pytest]
+addopts = --pycodestyle magma
 codestyle_max_line_length = 80
 codestyle_ignore = E741


### PR DESCRIPTION
Through setup.cfg, by default (i.e. unless over-ridden) all calls to
pytest will invoke pycodestyle. Note that currently all files are
blacklisted such that no errors are raised. All new files should be
linted before being checked in.