### PR TITLE
Refactor kratos backend

### DIFF
--- a/magma/syntax/sequential.py
+++ b/magma/syntax/sequential.py
@@ -133,12 +133,6 @@ def get_initial_value_map(init_func, defn_env):
         # TODO: Should we deal with multiple assignments? For now we take the
         # last one
         m.DefineCircuit("tmp")
-
-        # this is a fix when python is loaded with a third-party debugging
-        # tool such as pydev debugger, 'm' is not defined
-        import magma as __m
-        defn_env["m"] = __m
-        defn_env["__main__"] = __m
         eval_type = eval(astor.to_source(stmt.annotation).rstrip(), defn_env)
         eval_value = eval(astor.to_source(stmt.value).rstrip(), defn_env)
         m.EndCircuit()

--- a/magma/syntax/sequential.py
+++ b/magma/syntax/sequential.py
@@ -133,6 +133,12 @@ def get_initial_value_map(init_func, defn_env):
         # TODO: Should we deal with multiple assignments? For now we take the
         # last one
         m.DefineCircuit("tmp")
+
+        # this is a fix when python is loaded with a third-party debugging
+        # tool such as pydev debugger, 'm' is not defined
+        import magma as __m
+        defn_env["m"] = __m
+        defn_env["__main__"] = __m
         eval_type = eval(astor.to_source(stmt.annotation).rstrip(), defn_env)
         eval_value = eval(astor.to_source(stmt.value).rstrip(), defn_env)
         m.EndCircuit()

--- a/tests/test_syntax/gold/TestBasicToVerilog.v
+++ b/tests/test_syntax/gold/TestBasicToVerilog.v
@@ -10,6 +10,12 @@ logic [1:0] self_x_I;
 logic [1:0] self_x_O;
 logic [1:0] self_y_I;
 logic [1:0] self_y_O;
+always_comb begin
+  _O = self_y_O;
+  self_y_I = self_x_O;
+  self_x_I = I;
+  O = _O;
+end
 
 always_ff @(posedge CLK, posedge ASYNCRESET) begin
   if (ASYNCRESET) begin
@@ -20,12 +26,6 @@ always_ff @(posedge CLK, posedge ASYNCRESET) begin
     self_x_O <= self_x_I;
     self_y_O <= self_y_I;
   end
-end
-always_comb begin
-  _O = self_y_O;
-  self_y_I = self_x_O;
-  self_x_I = I;
-  O = _O;
 end
 endmodule   // TestBasic
 

--- a/tests/test_syntax/test_to_verilog.py
+++ b/tests/test_syntax/test_to_verilog.py
@@ -129,6 +129,14 @@ def test_seq_simple():
                 tester.circuit.O.expect(0)
             tester.step(2)
         directory = f"{os.path.abspath(os.path.dirname(__file__))}/build/"
+        target = "verilator"
+        if target == "verilator":
+            top_module_name = "TOP"
+        else:
+            top_module_name = "dut"
+        # TODO automatically obtain the kratos-based circuit
+        generators = [TestBasic.kratos]
+        kratos.debug.dump_external_database(generators, top_module_name, f"{directory}debug.db")
         tester.compile_and_run(target,
                                directory=directory,
                                flags=["-Wno-fatal"], magma_output="verilog")


### PR DESCRIPTION
What:
- Passing in ast nodes directly into the code gen backend instead of dump it into a text file and load back. This also allows comments and other multi-line coding style as long as during the pre-processing the `lineno` is preserved (added in this PR)
- Refactor the code to reuse both combinational and sequential logics.
- Construct proper reset logic instead of string generation

Discussion:
1. For now I assume everything is posedge reset, this may not be the case for ASIC design and it would be better to have an option.
2. There is no clock gating/chip enable signal to the sequential block., It would be great if we can have the port so that the sequential logic can be properly clock gated.

Some hacks on debugging:
- If you look at how I dump debug information for testing sequential logic, the generators are not collected automatically. I'm not sure if the code used for combinational works here.