### PR TITLE
Add missing guard for setattrs

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -74,7 +74,8 @@ class _DefinitionBlock:
 
 def _setattrs(obj, dct):
     for k, v in dct.items():
-        setattr(obj, k, v)
+        if isinstance(k, str):
+            setattr(obj, k, v)
 
 
 class CircuitKind(type):


### PR DESCRIPTION
This guard was removed in the recent refactor changes (https://github.com/phanrahan/magma/commit/07a0baf922077677bdc7828bfd2e8cb9ded66017#diff-6b17d570b43c15049f981d307cbd23fdL77) but it causes an error in mantle: https://travis-ci.org/phanrahan/mantle/builds/623001886

We should add a magma test for this case, but this should fix the mantle build.