### PR TITLE
Remove unnec. rename in uniq. pass

### DIFF
--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -36,8 +36,7 @@ def _hash(definition):
 
 class UniquificationPass(DefinitionPass):
     def __init__(self, main, mode):
-        super(UniquificationPass, self).__init__(main)
-        self.definitions = {}
+        super().__init__(main)
         self.mode = mode
         self.seen = {}
         self.original_names = {}
@@ -46,17 +45,19 @@ class UniquificationPass(DefinitionPass):
         name = definition.name
         key = _hash(definition)
 
-        if name not in self.seen:
-            self.seen[name] = {}
-        if key not in self.seen[name]:
-            if self.mode is UniquificationMode.UNIQUIFY and len(self.seen[name]) > 0:
-                new_name = name + "_unq" + str(len(self.seen[name]))
+        seen = self.seen.setdefault(name, {})
+        if key not in seen:
+            if self.mode is UniquificationMode.UNIQUIFY and len(seen) > 0:
+                new_name = name + "_unq" + str(len(seen))
                 type(definition).rename(definition, new_name)
-            self.seen[name][key] = [definition]
+            seen[key] = [definition]
         else:
             if self.mode is not UniquificationMode.UNIQUIFY:
-                assert self.seen[name][key][0].name == definition.name
-            self.seen[name][key].append(definition)
+                assert seen[key][0].name == name
+            elif name != seen[key][0].name:
+                new_name = seen[key][0].name
+                type(definition).rename(definition, new_name)
+            seen[key].append(definition)
 
     def run(self):
         super().run()

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -56,27 +56,10 @@ class UniquificationPass(DefinitionPass):
         else:
             if self.mode is not UniquificationMode.UNIQUIFY:
                 assert self.seen[name][key][0].name == definition.name
-            else:
-                type(definition).rename(definition, self.seen[name][key][0].name)
             self.seen[name][key].append(definition)
 
-    def _run(self, definition):
-        if not isdefinition(definition):
-            return
-
-        for instance in definition.instances:
-            instancedefinition = type(instance)
-            if isdefinition(instancedefinition):
-                self._run( instancedefinition )
-
-        id_ = id(definition)
-        if id_ in self.definitions:
-            return
-        self.definitions[id_] = definition
-        self(definition)
-
     def run(self):
-        super(UniquificationPass, self).run()
+        super().run()
         duplicated = []
         for name, definitions in self.seen.items():
             if len(definitions) > 1:

--- a/tests/gold/uniquify_multiple_rename.json
+++ b/tests/gold/uniquify_multiple_rename.json
@@ -1,0 +1,55 @@
+{"top":"global._Top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Foo":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["O",["Array",2,"Bit"]]
+        ]],
+        "connections":[
+          ["self.O","self.I"]
+        ]
+      },
+      "Foo_unq1":{
+        "type":["Record",[
+          ["I",["Array",3,"BitIn"]],
+          ["O",["Array",3,"Bit"]]
+        ]],
+        "connections":[
+          ["self.O","self.I"]
+        ]
+      },
+      "_Top":{
+        "type":["Record",[
+          ["I0",["Array",2,"BitIn"]],
+          ["I1",["Array",3,"BitIn"]],
+          ["I2",["Array",3,"BitIn"]],
+          ["O0",["Array",2,"Bit"]],
+          ["O1",["Array",3,"Bit"]],
+          ["O2",["Array",3,"Bit"]]
+        ]],
+        "instances":{
+          "Foo_inst0":{
+            "modref":"global.Foo"
+          },
+          "Foo_inst1":{
+            "modref":"global.Foo_unq1"
+          },
+          "Foo_inst2":{
+            "modref":"global.Foo_unq1"
+          }
+        },
+        "connections":[
+          ["self.I0","Foo_inst0.I"],
+          ["self.O0","Foo_inst0.O"],
+          ["self.I1","Foo_inst1.I"],
+          ["self.O1","Foo_inst1.O"],
+          ["self.I2","Foo_inst2.I"],
+          ["self.O2","Foo_inst2.O"]
+        ]
+      }
+    }
+  }
+}
+}


### PR DESCRIPTION
Previously we were calling rename with the same name (i.e. an
unnecessary rename). For normal magma circuits this wasn't an issue,
since the rename was a no-op, but it was surfacing when doing so for
verilog-wrapped circuits, since they can't be renamed.

Added a test for this issue.