### PR TITLE
Add separate debug option in *_to_verilog functions

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -67,6 +67,7 @@ def set_mantle_target(t):
 from .backend.util import set_codegen_debug_info
 from .enum import Enum
 import magma.util
+import magma.syntax
 
 from .is_primitive import isprimitive
 from .is_definition import isdefinition

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -23,7 +23,8 @@ from magma.syntax.combinational import combinational
 from magma.syntax.sequential import sequential
 from magma.syntax.combinational import combinational
 from magma.syntax.sequential import sequential
-from magma.syntax.verilog import combinational_to_verilog, sequential_to_verilog
+from magma.syntax.verilog import combinational_to_verilog, \
+    sequential_to_verilog, build_kratos_debug_info
 if sys.version_info > (3, 0):
     from functools import reduce
 

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -24,7 +24,7 @@ from magma.syntax.sequential import sequential
 from magma.syntax.combinational import combinational
 from magma.syntax.sequential import sequential
 from magma.syntax.verilog import combinational_to_verilog, \
-    sequential_to_verilog, build_kratos_debug_info
+    sequential_to_verilog
 if sys.version_info > (3, 0):
     from functools import reduce
 

--- a/magma/syntax/__init__.py
+++ b/magma/syntax/__init__.py
@@ -1,1 +1,2 @@
 from magma.syntax.combinational import combinational
+from magma.syntax.verilog import build_kratos_debug_info

--- a/tests/test_syntax/test_to_verilog.py
+++ b/tests/test_syntax/test_to_verilog.py
@@ -11,8 +11,7 @@ class SimpleALU(m.Circuit):
     IO = ["a", m.In(m.UInt[16]), "b", m.In(m.UInt[16]), "c",
           m.Out(m.UInt[16]), "config_", m.In(m.Bits[2])]
 
-    m.config.set_debug_mode(False)
-    @m.circuit.combinational_to_verilog
+    @m.circuit.combinational_to_verilog(debug=False)
     def execute_alu(a: m.UInt[16], b: m.UInt[16], config_: m.Bits[2]) -> \
             m.UInt[16]:
         if config_ == m.bits(0, 2):
@@ -30,26 +29,8 @@ class SimpleALU(m.Circuit):
         io.c <= io.execute_alu(io.a, io.b, io.config_)
 
 
-def build_kratos_debug_info(circuit, is_top):
-    inst_to_defn_map = {}
-    for instance in circuit.instances:
-        instance_inst_to_defn_map = \
-            build_kratos_debug_info(type(instance), is_top=False)
-        for k, v in instance_inst_to_defn_map.values():
-            key = instance.name + "." + k
-            if is_top:
-                key = circuit.name + "." + key
-            inst_to_defn_map[key] = v
-        inst_name = instance.name
-        if is_top:
-            inst_name = circuit.name + "." + instance.name
-        if instance.kratos is not None:
-            inst_to_defn_map[inst_name] = instance.kratos
-    return inst_to_defn_map
-
-
 def test_simple_alu():
-    inst_to_defn_map = build_kratos_debug_info(SimpleALU, is_top=True)
+    inst_to_defn_map = m.circuit.build_kratos_debug_info(SimpleALU, is_top=True)
     assert "SimpleALU.execute_alu_inst0" in inst_to_defn_map
     generators = []
     for instance_name, mod in inst_to_defn_map.items():
@@ -92,7 +73,7 @@ def test_simple_alu():
 
 
 def test_seq_simple():
-    @m.circuit.sequential_to_verilog(async_reset=True)
+    @m.circuit.sequential_to_verilog(async_reset=True, debug=False)
     class TestBasic:
         def __init__(self):
             self.x: m.Bits[2] = m.bits(0, 2)

--- a/tests/test_syntax/test_to_verilog.py
+++ b/tests/test_syntax/test_to_verilog.py
@@ -30,7 +30,7 @@ class SimpleALU(m.Circuit):
 
 
 def test_simple_alu():
-    inst_to_defn_map = m.circuit.build_kratos_debug_info(SimpleALU, is_top=True)
+    inst_to_defn_map = m.syntax.build_kratos_debug_info(SimpleALU, is_top=True)
     assert "SimpleALU.execute_alu_inst0" in inst_to_defn_map
     generators = []
     for instance_name, mod in inst_to_defn_map.items():


### PR DESCRIPTION
This additional parameter `debug` allows users to only debug on the circuit they're interested in, instead of the entire design. It will also speed up the debugging performance.

Also refactor the debug information extraction code to the magma package so that fault can use it to generate correct debugging logic.