### PR TITLE
Replace non-ascii in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [pycodestyle]
 max-line-length = 80
 
-# E741: do not use variables named ‘l’, ‘O’, or ‘I’
+# E741: do not use variables named 'l', 'O', or 'I'
 # We ignore this because I and O is currently idiomatic magma for port names
 ignore = E741
 


### PR DESCRIPTION
(probably better to update Python itself but) To fix pip install with Python 3.6

    $ pip3 install -e .
    Obtaining file:///...
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
    ...
          File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
            return codecs.ascii_decode(input, self.errors)[0]
        UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 71: ordinal not in range(128)

        ----------------------------------------
    Command "python setup.py egg_info" failed with error code 1 in .../magma/