### PR TITLE
sequential: fix call with state elements

### DIFF
--- a/magma/syntax/sequential.py
+++ b/magma/syntax/sequential.py
@@ -50,6 +50,8 @@ class RewriteSelfAttributes(ast.NodeTransformer):
                 return ast.Tuple([ast.Name(f"self_{attr}_{output}",
                                            ast.Load()) for output in outputs],
                                  ast.Load())
+        else:
+            self.generic_visit(node)
         return node
 
     def visit_If(self, node):

--- a/tests/test_syntax/gold/TestCall.json
+++ b/tests/test_syntax/gold/TestCall.json
@@ -1,0 +1,66 @@
+{"top":"global.TestCall",
+"namespaces":{
+  "global":{
+    "modules":{
+      "TestCall":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["CLK",["Named","coreir.clkIn"]],
+          ["ASYNCRESET",["Named","coreir.arstIn"]],
+          ["O",["Array",3,"Bit"]]
+        ]],
+        "instances":{
+          "TestCall_comb_inst0":{
+            "modref":"global.TestCall_comb"
+          },
+          "reg_PR_inst0":{
+            "genref":"coreir.reg_arst",
+            "genargs":{"width":["Int",2]},
+            "modargs":{"arst_posedge":["Bool",true], "clk_posedge":["Bool",true], "init":[["BitVector",2],"2'h0"]}
+          },
+          "reg_PR_inst1":{
+            "genref":"coreir.reg_arst",
+            "genargs":{"width":["Int",3]},
+            "modargs":{"arst_posedge":["Bool",true], "clk_posedge":["Bool",true], "init":[["BitVector",3],"3'h0"]}
+          }
+        },
+        "connections":[
+          ["self.I","TestCall_comb_inst0.I"],
+          ["reg_PR_inst0.in","TestCall_comb_inst0.O0"],
+          ["reg_PR_inst1.in","TestCall_comb_inst0.O1"],
+          ["self.O","TestCall_comb_inst0.O2"],
+          ["reg_PR_inst0.out","TestCall_comb_inst0.self_x_O"],
+          ["reg_PR_inst1.out","TestCall_comb_inst0.self_y_O"],
+          ["self.ASYNCRESET","reg_PR_inst0.arst"],
+          ["self.CLK","reg_PR_inst0.clk"],
+          ["self.ASYNCRESET","reg_PR_inst1.arst"],
+          ["self.CLK","reg_PR_inst1.clk"]
+        ]
+      },
+      "TestCall_comb":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["self_x_O",["Array",2,"BitIn"]],
+          ["self_y_O",["Array",3,"BitIn"]],
+          ["O0",["Array",2,"Bit"]],
+          ["O1",["Array",3,"Bit"]],
+          ["O2",["Array",3,"Bit"]]
+        ]],
+        "instances":{
+          "bit_const_0_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",false]}
+          }
+        },
+        "connections":[
+          ["self.O1.2","bit_const_0_None.out"],
+          ["self.O0","self.I"],
+          ["self.self_x_O.0","self.O1.0"],
+          ["self.self_x_O.1","self.O1.1"],
+          ["self.self_y_O","self.O2"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_syntax/gold/TestCall.v
+++ b/tests/test_syntax/gold/TestCall.v
@@ -1,0 +1,37 @@
+module coreir_reg_arst #(parameter width = 1, parameter arst_posedge = 1, parameter clk_posedge = 1, parameter init = 1) (input clk, input arst, input [width-1:0] in, output [width-1:0] out);
+  reg [width-1:0] outReg;
+  wire real_rst;
+  assign real_rst = arst_posedge ? arst : ~arst;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk, posedge real_rst) begin
+    if (real_rst) outReg <= init;
+    else outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module corebit_const #(parameter value = 1) (output out);
+  assign out = value;
+endmodule
+
+module TestCall_comb (input [1:0] I, output [1:0] O0, output [2:0] O1, output [2:0] O2, input [1:0] self_x_O, input [2:0] self_y_O);
+wire bit_const_0_None_out;
+corebit_const #(.value(0)) bit_const_0_None(.out(bit_const_0_None_out));
+assign O0 = I;
+assign O1 = {bit_const_0_None_out,self_x_O[1],self_x_O[0]};
+assign O2 = self_y_O;
+endmodule
+
+module TestCall (input ASYNCRESET, input CLK, input [1:0] I, output [2:0] O);
+wire [1:0] TestCall_comb_inst0_O0;
+wire [2:0] TestCall_comb_inst0_O1;
+wire [2:0] TestCall_comb_inst0_O2;
+wire [1:0] reg_PR_inst0_out;
+wire [2:0] reg_PR_inst1_out;
+TestCall_comb TestCall_comb_inst0(.I(I), .O0(TestCall_comb_inst0_O0), .O1(TestCall_comb_inst0_O1), .O2(TestCall_comb_inst0_O2), .self_x_O(reg_PR_inst0_out), .self_y_O(reg_PR_inst1_out));
+coreir_reg_arst #(.arst_posedge(1), .clk_posedge(1), .init(2'h0), .width(2)) reg_PR_inst0(.arst(ASYNCRESET), .clk(CLK), .in(TestCall_comb_inst0_O0), .out(reg_PR_inst0_out));
+coreir_reg_arst #(.arst_posedge(1), .clk_posedge(1), .init(3'h0), .width(3)) reg_PR_inst1(.arst(ASYNCRESET), .clk(CLK), .in(TestCall_comb_inst0_O1), .out(reg_PR_inst1_out));
+assign O = TestCall_comb_inst0_O2;
+endmodule
+

--- a/tests/test_syntax/test_sequential.py
+++ b/tests/test_syntax/test_sequential.py
@@ -138,6 +138,21 @@ def test_seq_simple(target, async_reset):
         """
         _run_verilator(TestBasic, directory="tests/test_syntax/build")
 
+def test_seq_call(target):
+    @m.circuit.sequential
+    class TestCall:
+        def __init__(self):
+            self.x: m.Bits[2] = m.bits(0, 2)
+            self.y: m.Bits[3] = m.bits(0, 3)
+
+        def __call__(self, I: m.Bits[2]) -> m.Bits[3]:
+            O = self.y
+            self.y = m.zext(self.x, 1)
+            self.x = I
+            return O
+
+    compile_and_check("TestCall", TestCall, target)
+
 def test_custom_env(target):
 
     _globals = globals()


### PR DESCRIPTION
sequential code can't call magma funtions with state elements. call generic_visit to convert params.

    - self_y_I_0 = m.zext(self.x, 1)
    + self_y_I_0 = m.zext(io.self_x_O, 1)
