### PR TITLE
Simplify base class logic for tuple

### DIFF
--- a/tests/test_type/test_tuple_performance.py
+++ b/tests/test_type/test_tuple_performance.py
@@ -2,7 +2,7 @@ import magma as m
 import os
 import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), "../test_syntax"))
-from test_sequential import DefineRegister
+from test_sequential import DefineRegister, phi
 
 
 class BigTuple(m.Product):

--- a/tests/test_type/test_tuple_performance.py
+++ b/tests/test_type/test_tuple_performance.py
@@ -1,0 +1,52 @@
+import magma as m
+
+
+class TestType(m.Product):
+    V1 = m.UInt[32]
+    V2 = m.UInt[32]
+    V3 = m.UInt[32]
+    V4 = m.UInt[32]
+    V5 = m.UInt[32]
+    V6 = m.UInt[32]
+    V7 = m.UInt[32]
+
+
+@m.circuit.sequential(async_reset=False)
+class TestLogic:
+    def __init__(self):
+        self.V1: m.UInt[32] = 0
+        self.V2: m.UInt[32] = 0
+        self.V3: m.UInt[32] = 0
+        self.V4: m.UInt[32] = 0
+        self.V5: m.UInt[32] = 0
+        self.V6: m.UInt[32] = 0
+        self.V7: m.UInt[32] = 0
+
+    def __call__(self, I: TestType, SEL: m.Bit) -> TestType:
+        t = m.namedtuple(
+            V1=self.V1,
+            V2=self.V2,
+            V3=self.V3,
+            V4=self.V4,
+            V5=self.V5,
+            V6=self.V6,
+            V7=self.V7,
+        )
+        if SEL:
+            new_t = I
+        else:
+            new_t = t
+
+        self.V1 = new_t.V1
+        self.V2 = new_t.V2
+        self.V3 = new_t.V3
+        self.V4 = new_t.V4
+        self.V5 = new_t.V5
+        self.V6 = new_t.V6
+        self.V7 = new_t.V7
+        return new_t
+
+
+def test_tuple_perf():
+    # for https://github.com/phanrahan/magma/issues/528#issuecomment-573510435
+    m.compile("build/top", TestLogic, output="coreir-verilog")

--- a/tests/test_type/test_tuple_performance.py
+++ b/tests/test_type/test_tuple_performance.py
@@ -1,7 +1,7 @@
 import magma as m
 
 
-class TestType(m.Product):
+class BigTuple(m.Product):
     V1 = m.UInt[32]
     V2 = m.UInt[32]
     V3 = m.UInt[32]
@@ -12,7 +12,7 @@ class TestType(m.Product):
 
 
 @m.circuit.sequential(async_reset=False)
-class TestLogic:
+class Top:
     def __init__(self):
         self.V1: m.UInt[32] = 0
         self.V2: m.UInt[32] = 0
@@ -22,7 +22,7 @@ class TestLogic:
         self.V6: m.UInt[32] = 0
         self.V7: m.UInt[32] = 0
 
-    def __call__(self, I: TestType, SEL: m.Bit) -> TestType:
+    def __call__(self, I: BigTuple, SEL: m.Bit) -> BigTuple:
         t = m.namedtuple(
             V1=self.V1,
             V2=self.V2,
@@ -49,4 +49,4 @@ class TestLogic:
 
 def test_tuple_perf():
     # for https://github.com/phanrahan/magma/issues/528#issuecomment-573510435
-    m.compile("build/top", TestLogic, output="coreir-verilog")
+    m.compile("build/top", Top, output="coreir-verilog")

--- a/tests/test_type/test_tuple_performance.py
+++ b/tests/test_type/test_tuple_performance.py
@@ -1,4 +1,8 @@
 import magma as m
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "../test_syntax"))
+from test_sequential import DefineRegister
 
 
 class BigTuple(m.Product):


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/528#issuecomment-573510435

Before, the base class logic for the tuple meta class was iterating over the product of the field bases.  This was used to make sure that `Tuple[Bit, Bit]` was a parent of `Tuple[In(Bit), In(Bit)`, however this general logic meant it was also checking the cross product of the possibilities, e.g. `Tuple[Bit, In(Bit)]` as candidates for a base class.

This simplifies the pipeline to simply check if any of the fields are directed.  If so, it sets the class with the undirected version of the fields as the parent.

It also removes the logic from the Product type meta class since it's able to use the Tuple meta class logic.

Finally, it updates the conversion code (tuple/namedtuple) to call the type constructors directly rather than using `type(...)` which was skipping a portion of the meta class pipeline (revealed when changing the subclass logic)