### PR TITLE
Patch travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,35 +23,33 @@ install:
 - pip install python-coveralls
 - pip install pytest-cov pytest-codestyle fault
 - pip install -e .
+script:
+- py.test --cov magma -v --cov-report term-missing tests
+- pycodestyle magma/
 after_success:
 - coveralls
-jobs:
-  include:
-  - stage: test
-    script:
-    - py.test --cov magma -v --cov-report term-missing tests
-    - pycodestyle magma/
-  - stage: trigger downstream
-    script: |
-      # See https://github.com/mernst/plume-lib/blob/master/bin/trigger-travis.sh for documentation
-      echo "TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
-      if [[ ($TRAVIS_BRANCH == master) &&
-            ($TRAVIS_PULL_REQUEST == false) ]] ; then
-        curl -LO --retry 3 https://raw.github.com/mernst/plume-lib/master/bin/trigger-travis.sh
-        sh trigger-travis.sh --pro David-Durst aetherling $TRAVIS_ACCESS_TOKEN
-        sh trigger-travis.sh --pro StanfordAHA garnet $TRAVIS_ACCESS_TOKEN
-        sh trigger-travis.sh phanrahan mantle $TRAVIS_ORG_ACCESS_TOKEN
-        sh trigger-travis.sh --pro cdonovick peak $TRAVIS_ACCESS_TOKEN
-      fi
-  - stage: docs
-    script: curl -X POST -d "token=$READ_THE_DOCS_TOKEN" https://readthedocs.org/api/v2/webhook/magma/55300/
-  - stage: deploy
-    if: tag IS present
-    script: skip
-    deploy: 
-      provider: script
-      script: /bin/bash .travis/deploy.sh
-      skip_cleanup: true
-      on:
-        tags: true
-        branch: master
+# Build docs
+- |
+  if [[ ($TRAVIS_BRANCH == master) && ($TRAVIS_PULL_REQUEST == false) ]] ; then
+    curl -X POST -d "token=$READ_THE_DOCS_TOKEN" https://readthedocs.org/api/v2/webhook/magma/55300/
+  fi
+# Trigger downstream repo builds
+- |
+  # See https://github.com/mernst/plume-lib/blob/master/bin/trigger-travis.sh for documentation
+  echo "TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
+  if [[ ($TRAVIS_BRANCH == master) &&
+        ($TRAVIS_PULL_REQUEST == false) ]] ; then
+    curl -LO --retry 3 https://raw.github.com/mernst/plume-lib/master/bin/trigger-travis.sh
+    sh trigger-travis.sh --pro David-Durst aetherling $TRAVIS_ACCESS_TOKEN
+    sh trigger-travis.sh --pro StanfordAHA garnet $TRAVIS_ACCESS_TOKEN
+    sh trigger-travis.sh phanrahan mantle $TRAVIS_ORG_ACCESS_TOKEN
+    sh trigger-travis.sh --pro cdonovick peak $TRAVIS_ACCESS_TOKEN
+  fi
+
+deploy: 
+  provider: script
+  script: /bin/bash .travis/deploy.sh
+  skip_cleanup: true
+  on:
+    tags: true
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,22 +12,13 @@ addons:
 
 install:
 # install conda for py 3.7
-- wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+- wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 - chmod +x miniconda.sh
 - ./miniconda.sh -b -p $TRAVIS_BUILD_DIR/miniconda
 - export PATH=$TRAVIS_BUILD_DIR/miniconda/bin:$PATH
 - hash -r
 - conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda create -q -n test-env python=3.7
-- source activate test-env
-- conda install pip
 # End install conda
-- curl -s -L https://github.com/rdaly525/coreir/releases/latest | grep "href.*coreir-${TRAVIS_OS_NAME}.tar.gz" | cut -d \" -f 2 | xargs -I {} wget https://github.com"{}"
-- mkdir coreir_release;
-- tar -xf coreir-${TRAVIS_OS_NAME}.tar.gz -C coreir_release --strip-components 1;
-- cd coreir_release && sudo make install && cd ..
-
 - pip install twine
 - pip install python-coveralls
 - pip install pytest-cov pytest-codestyle fault


### PR DESCRIPTION
This improves the travis flow to reduce build time down to two minutes from 7.

It installs python3 directly using miniconda3 instead of using Miniconda (python2) and setting up a python 3 environment.

It also removes the separate build stages (for docs/deploy/downstream triggers) since each of these runs in a fresh environment (and thus has to redownload/install the dependencies) and instead runs them in the after_success (guarded to only run on the master branch)