### PR TITLE
Support 2d array to verilog

### DIFF
--- a/magma/backend/verilog.py
+++ b/magma/backend/verilog.py
@@ -1,4 +1,3 @@
-import warnings
 import os
 import types
 import operator

--- a/tests/test_verilog/gold/2d_array_from_verilog.v
+++ b/tests/test_verilog/gold/2d_array_from_verilog.v
@@ -1,0 +1,29 @@
+module transpose_buffer (
+  input logic clk,
+  output logic [2:0] index_inner,
+  output logic [2:0] index_outer,
+  input logic [3:0] input_data [63:0],
+  input logic [2:0] range_inner,
+  input logic [2:0] range_outer,
+  input logic rst_n,
+  input logic [2:0] stride
+);
+
+
+always_ff @(posedge clk, negedge rst_n) begin
+  if (~rst_n) begin
+    index_outer <= 3'h0;
+    index_inner <= 3'h0;
+  end
+  else begin
+    if (index_outer == (range_outer - 3'h1)) begin
+      index_outer <= 3'h0;
+    end
+    else index_outer <= index_outer + 3'h1;
+    if (index_inner == (range_inner - 3'h1)) begin
+      index_inner <= 3'h0;
+    end
+    else index_inner <= index_inner + 3'h1;
+  end
+end
+endmodule   // transpose_buffer

--- a/tests/test_verilog/test_2d_array.py
+++ b/tests/test_verilog/test_2d_array.py
@@ -1,0 +1,40 @@
+import magma as m
+import magma.testing
+
+
+def test_2d_array_from_verilog():
+    main = m.DefineFromVerilog(f"""
+module transpose_buffer (
+  input logic clk,
+  output logic [2:0] index_inner,
+  output logic [2:0] index_outer,
+  input logic [3:0] input_data [63:0],
+  input logic [2:0] range_inner,
+  input logic [2:0] range_outer,
+  input logic rst_n,
+  input logic [2:0] stride
+);
+
+
+always_ff @(posedge clk, negedge rst_n) begin
+  if (~rst_n) begin
+    index_outer <= 3'h0;
+    index_inner <= 3'h0;
+  end
+  else begin
+    if (index_outer == (range_outer - 3'h1)) begin
+      index_outer <= 3'h0;
+    end
+    else index_outer <= index_outer + 3'h1;
+    if (index_inner == (range_inner - 3'h1)) begin
+      index_inner <= 3'h0;
+    end
+    else index_inner <= index_inner + 3'h1;
+  end
+end
+endmodule   // transpose_buffer
+""")[0]
+    m.compile("build/2d_array_from_verilog", main, output="verilog")
+    assert m.testing.check_files_equal(__file__,
+                                       f"build/2d_array_from_verilog.v",
+                                       f"gold/2d_array_from_verilog.v")


### PR DESCRIPTION
We support importing verilog with 2d arrays, but we can't compile them out using the verilog backend.

This simply moves up the logic to emit a module defined by a pure verilog string to emit the string before the type safety check of the interface.

The current use case is using imported verilog with fault (which may have n-d arrays) but compiling through the verilog backend.

Adding support for these modules to coreir is more involved since we'll need to handle the n-d arrays as non-flattened types which will touch a lot of code (right now everything assumes that types including n-d arrays are flattened out before the coreir verilog backend code generation)