### PR TITLE
Support bit width promotion in Bits constructor

### DIFF
--- a/magma/bits.py
+++ b/magma/bits.py
@@ -66,6 +66,17 @@ class BitsMeta(AbstractBitVectorMeta, ArrayMeta):
 class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     __hash__ = Array.__hash__
 
+    def __init__(self, *args, **kwargs):
+        if args and len(args) == 1 and isinstance(args[0], m.Array) and \
+                len(self) > 1 and len(args[0]) <= len(self):
+            self.ts = args[0].ts[:]
+            # zext for promoting width
+            for i in range(len(self) - len(args[0])):
+                self.ts.append(m.VCC)
+            Type.__init__(self, **kwargs)
+        else:
+            Array.__init__(self, *args, **kwargs)
+
     def __repr__(self):
         if not isinstance(self.name, AnonRef):
             return repr(self.name)

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -72,7 +72,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             self.ts = args[0].ts[:]
             # zext for promoting width
             for i in range(len(self) - len(args[0])):
-                self.ts.append(m.VCC)
+                self.ts.append(m.GND)
             Type.__init__(self, **kwargs)
         else:
             Array.__init__(self, *args, **kwargs)

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -498,6 +498,17 @@ class UInt(Bits):
 
 
 class SInt(Bits):
+    def __init__(self, *args, **kwargs):
+        if args and len(args) == 1 and isinstance(args[0], m.Array) and \
+                len(self) > 1 and len(args[0]) <= len(self):
+            self.ts = args[0].ts[:]
+            # zext for promoting width
+            for i in range(len(self) - len(args[0])):
+                self.ts.append(args[0].ts[-1])
+            Type.__init__(self, **kwargs)
+        else:
+            Array.__init__(self, *args, **kwargs)
+
     @bits_cast
     def bvslt(self, other) -> AbstractBit:
         return self.declare_compare_op("slt")()(self, other)

--- a/tests/test_type/test_bits.py
+++ b/tests/test_type/test_bits.py
@@ -96,6 +96,7 @@ def test_construct():
 
     # test promote
     assert isinstance(m.Bits[16](a_1), m.Bits)
+    assert repr(m.Bits[16](a_1)) == "bits([VCC, VCC, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND])"
 
 
 def test_const():

--- a/tests/test_type/test_bits.py
+++ b/tests/test_type/test_bits.py
@@ -94,6 +94,9 @@ def test_construct():
     print(type(a_1))
     assert isinstance(a_1, m.BitsType)
 
+    # test promote
+    assert isinstance(m.Bits[16](a_1), m.Bits)
+
 
 def test_const():
     """

--- a/tests/test_type/test_sint.py
+++ b/tests/test_type/test_sint.py
@@ -77,6 +77,7 @@ def test_construct():
     assert not isinstance(a1, UInt)
 
     assert isinstance(SInt[15](a1), SInt)
+    assert repr(m.SInt[16](a1)) == "bits([VCC, VCC, VCC, VCC, VCC, VCC, VCC, VCC, VCC, VCC, VCC, VCC, VCC, VCC, VCC, VCC])"
 
     # Test explicit conversion
     assert isinstance(uint(a1), UInt)

--- a/tests/test_type/test_sint.py
+++ b/tests/test_type/test_sint.py
@@ -76,6 +76,8 @@ def test_construct():
     assert isinstance(a1, Bits)
     assert not isinstance(a1, UInt)
 
+    assert isinstance(SInt[15](a1), SInt)
+
     # Test explicit conversion
     assert isinstance(uint(a1), UInt)
     assert not isinstance(uint(a1), SInt)

--- a/tests/test_type/test_uint.py
+++ b/tests/test_type/test_uint.py
@@ -76,6 +76,8 @@ def test_construct():
     assert isinstance(a1, Bits)
     assert not isinstance(a1, SInt)
 
+    assert isinstance(UInt[15](a1), UInt)
+
     # Test explicit conversion
     assert isinstance(sint(a1), SInt)
     assert not isinstance(sint(a1), UInt)

--- a/tests/test_type/test_uint.py
+++ b/tests/test_type/test_uint.py
@@ -77,6 +77,7 @@ def test_construct():
     assert not isinstance(a1, SInt)
 
     assert isinstance(UInt[15](a1), UInt)
+    assert repr(m.UInt[16](a1)) == "bits([VCC, VCC, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND, GND])"
 
     # Test explicit conversion
     assert isinstance(sint(a1), SInt)


### PR DESCRIPTION
Fixes issue in lassen where the Bits constructor (or it's children) cannot be used to promote the width of the input value (e.g. `Bits[16](Bits[1](1))`).  This adds the corresponding code and tests