### PR TITLE
Revert VCC/GND back to Bit

### DIFF
--- a/magma/bit.py
+++ b/magma/bit.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 import magma as m
 from hwtypes.bit_vector_abc import AbstractBit, TypeFamily
 from .t import Direction
-from .digital import Digital, DigitalMeta, VCC, GND
+from .digital import Digital, DigitalMeta
 
 
 def bit_cast(fn: tp.Callable[['Bit', 'Bit'], 'Bit']) -> \
@@ -139,13 +139,12 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
     def __int__(self) -> int:
         raise NotImplementedError("Converting magma bit to int not supported")
 
-    def __repr__(self):
-        if self is VCC:
-            return '1'
-        if self is GND:
-            return '0'
 
-        return super().__repr__()
+VCC = Bit[Direction.Out](name="VCC")
+GND = Bit[Direction.Out](name="GND")
+
+HIGH = VCC
+LOW = GND
 
 
 BitIn = Bit[Direction.In]

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -1,4 +1,5 @@
 import weakref
+import magma as m
 from abc import ABCMeta
 from .t import Kind, Direction, Type
 from .debug import debug_wire, get_callee_frame_info
@@ -71,7 +72,7 @@ class DigitalMeta(ABCMeta, Kind):
     def __call__(cls, value=None, *args, **kwargs):
         if value is not None:
             if isinstance(value, (bool, IntegerTypes)):
-                return VCC if value else GND
+                return m.VCC if value else m.GND
         result = super().__call__(*args, **kwargs)
         if value is not None:
             assert isinstance(value, Digital), type(value)
@@ -136,7 +137,7 @@ class Digital(Type, metaclass=DigitalMeta):
         i = self
         # promote integer types to LOW/HIGH
         if isinstance(o, IntegerTypes):
-            o = HIGH if o else LOW
+            o = m.HIGH if o else m.LOW
 
         if not isinstance(o, Digital):
             report_wiring_error(f'Cannot wire {i.debug_name} (type={type(i)}) '
@@ -172,7 +173,7 @@ class Digital(Type, metaclass=DigitalMeta):
         return [self]
 
     def const(self):
-        return self is VCC or self is GND
+        return self is m.VCC or self is m.GND
 
     def unwire(i, o):
         i.port.unwire(o.port)
@@ -188,10 +189,3 @@ class Digital(Type, metaclass=DigitalMeta):
 
     def getgpio(self):
         return self.getinst()
-
-
-VCC = Digital[Direction.Out](name="VCC")
-GND = Digital[Direction.Out](name="GND")
-
-HIGH = VCC
-LOW = GND

--- a/tests/test_syntax/gold/custom_env0.json
+++ b/tests/test_syntax/gold/custom_env0.json
@@ -2,7 +2,7 @@
 "namespaces":{
   "global":{
     "modules":{
-      "Mux2xOutDigital":{
+      "Mux2xOutBit":{
         "type":["Record",[
           ["I0","BitIn"],
           ["I1","BitIn"],
@@ -17,8 +17,8 @@
           ["O","Bit"]
         ]],
         "instances":{
-          "Mux2xOutDigital_inst0":{
-            "modref":"global.Mux2xOutDigital"
+          "Mux2xOutBit_inst0":{
+            "modref":"global.Mux2xOutBit"
           },
           "bit_const_0_None":{
             "modref":"corebit.const",
@@ -26,10 +26,10 @@
           }
         },
         "connections":[
-          ["bit_const_0_None.out","Mux2xOutDigital_inst0.I0"],
-          ["self.I","Mux2xOutDigital_inst0.I1"],
-          ["self.O","Mux2xOutDigital_inst0.O"],
-          ["self.S","Mux2xOutDigital_inst0.S"]
+          ["bit_const_0_None.out","Mux2xOutBit_inst0.I0"],
+          ["self.I","Mux2xOutBit_inst0.I1"],
+          ["self.O","Mux2xOutBit_inst0.O"],
+          ["self.S","Mux2xOutBit_inst0.S"]
         ]
       }
     }

--- a/tests/test_syntax/gold/custom_env0.v
+++ b/tests/test_syntax/gold/custom_env0.v
@@ -1,6 +1,6 @@
 module basic_fun (input  I, input  S, output  O);
-wire  Mux2xOutDigital_inst0_O;
-Mux2xOutDigital Mux2xOutDigital_inst0 (.I0(1'b0), .I1(I), .S(S), .O(Mux2xOutDigital_inst0_O));
-assign O = Mux2xOutDigital_inst0_O;
+wire  Mux2xOutBit_inst0_O;
+Mux2xOutBit Mux2xOutBit_inst0 (.I0(1'b0), .I1(I), .S(S), .O(Mux2xOutBit_inst0_O));
+assign O = Mux2xOutBit_inst0_O;
 endmodule
 

--- a/tests/test_syntax/gold/custom_env1.json
+++ b/tests/test_syntax/gold/custom_env1.json
@@ -2,7 +2,7 @@
 "namespaces":{
   "global":{
     "modules":{
-      "Mux2xOutDigital":{
+      "Mux2xOutBit":{
         "type":["Record",[
           ["I0","BitIn"],
           ["I1","BitIn"],
@@ -17,8 +17,8 @@
           ["O","Bit"]
         ]],
         "instances":{
-          "Mux2xOutDigital_inst0":{
-            "modref":"global.Mux2xOutDigital"
+          "Mux2xOutBit_inst0":{
+            "modref":"global.Mux2xOutBit"
           },
           "bit_const_1_None":{
             "modref":"corebit.const",
@@ -26,10 +26,10 @@
           }
         },
         "connections":[
-          ["bit_const_1_None.out","Mux2xOutDigital_inst0.I0"],
-          ["self.I","Mux2xOutDigital_inst0.I1"],
-          ["self.O","Mux2xOutDigital_inst0.O"],
-          ["self.S","Mux2xOutDigital_inst0.S"]
+          ["bit_const_1_None.out","Mux2xOutBit_inst0.I0"],
+          ["self.I","Mux2xOutBit_inst0.I1"],
+          ["self.O","Mux2xOutBit_inst0.O"],
+          ["self.S","Mux2xOutBit_inst0.S"]
         ]
       }
     }

--- a/tests/test_syntax/gold/custom_env1.v
+++ b/tests/test_syntax/gold/custom_env1.v
@@ -1,6 +1,6 @@
 module basic_fun (input  I, input  S, output  O);
-wire  Mux2xOutDigital_inst0_O;
-Mux2xOutDigital Mux2xOutDigital_inst0 (.I0(1'b1), .I1(I), .S(S), .O(Mux2xOutDigital_inst0_O));
-assign O = Mux2xOutDigital_inst0_O;
+wire  Mux2xOutBit_inst0_O;
+Mux2xOutBit Mux2xOutBit_inst0 (.I0(1'b1), .I1(I), .S(S), .O(Mux2xOutBit_inst0_O));
+assign O = Mux2xOutBit_inst0_O;
 endmodule
 


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/499

hwtypes2 changed VCC/GND to be instances of Digital instead of Bit.  This reverts the change to be consistent with the old naming scheme.  In the future, we may decide to have a similar const name for Digital that is different than Bit (e.g. VCC/GND and HIGH/LOW). See the issue for more discussion