### PR TITLE
[#476] Fix m.bits/m.uint/m.sint behavior for instances of m.Bit

### DIFF
--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -116,8 +116,12 @@ def convertbits(value, n, totype, checkbit):
     elif isinstance(value, Digital):
         if n is None:
             ts = [value]
+        elif issubclass(totype, SInt):
+            # sext
+            ts = n * [value]
         else:
-            ts = n*[value]
+            # zext
+            ts = [GND for _ in range(n - 1)] + [value]
     else:
         ts = [value[i] for i in range(len(value))]
 
@@ -231,7 +235,7 @@ def zext(value, n):
 # @check_value_is_not_input
 def sext(value, n):
     assert isinstance(value, SInt)
-    return sint(concat(array(value), array(value[-1], n)))
+    return sint(concat(array(value), array([value[-1]] * n)))
 
 
 def tuple_(value, n=None):

--- a/tests/test_type/test_conversions.py
+++ b/tests/test_type/test_conversions.py
@@ -118,10 +118,7 @@ def test_zext(type_, value):
     if type_ != sint:
         value = abs(value)
     in_ = type_(value, 16)
-    # TODO(rsetaluri): Ideally, zext(bits) should return an object of type
-    # Bits, instead it returns an object of type Array. For now, we wrap
-    # the result of zext() in bits().
-    out = type_(zext(in_, 16))
+    out = zext(in_, 16)
     assert len(out.bits()) == 32
     # If we have a negative number, then zext should not return the same (signed
     # value). It will instead return the unsigned interpretation of the original
@@ -161,3 +158,15 @@ def test_extension_no_error(op):
         op(a, 2)
     except Exception as e:
         assert False, "This should work"
+
+
+def test_bits_of_bit():
+    assert repr(m.bits(m.Bit(1), 2)) == "bits([GND, VCC])"
+
+
+def test_uint_of_bit():
+    assert repr(m.uint(m.Bit(1), 2)) == "bits([GND, VCC])"
+
+
+def test_sint_of_bit():
+    assert repr(m.sint(m.Bit(1), 2)) == "bits([VCC, VCC])"


### PR DESCRIPTION
This fixes the behavior of the conversion operators to properly zext/sext when passed an instance of m.Bit.

The discussion in #476 suggests adding an explicit conversion operator m.fill for these cases, which I think is a good idea, but we'll need to have a clearer specification for how that should work (e.g. does it take the number of bits total or number of bits to append? does it take a parameter to fill with? does it take a type to create?), so until then I think it's best that we have the existing conversion operators behave in a reasonable fashion.