### PR TITLE
Make user defined Enums subclass a m.Enum

### DIFF
--- a/magma/enum.py
+++ b/magma/enum.py
@@ -1,28 +1,35 @@
 import magma as m
+from .bits import BitsMeta, Bits
 from enum import Enum as pyEnum
 
 
 
-class EnumMeta(type):
+class EnumMeta(BitsMeta):
     def __new__(mcs, name, bases, attrs, **kwargs):
         cls = super().__new__(mcs, name, bases, attrs, **kwargs)
-        kwargs = {}
+        fields = {}
         for key, value in attrs.items():
-            if key[:2] == "__":
+            if key[:2] == "__" or key == "_info_":
                 continue
-            kwargs[key] = value
-        if not kwargs:
+            if key == "orig_name":
+                continue
+            fields[key] = value
+        if not fields:
             return cls
-        max_value = max(value for value in kwargs.values())
+        for field in fields:
+            if field == "N":
+                # TODO: Make N unreserved
+                raise ValueError("N is a reserved name in Enum")
+        max_value = max(value for value in fields.values())
         num_bits = max(max_value.bit_length(), 1)
-        type_ = m.Bits[num_bits]
-        # TODO: Make Enum a subtype of Bits instead
+        type_ = cls[num_bits]
         type_._is_magma_enum = True
-        for key, value in kwargs.items():
+        for key, value in fields.items():
             setattr(type_, key, m.bits(value, num_bits))
         return type_
 
-class Enum(metaclass=EnumMeta):
+
+class Enum(Bits, metaclass=EnumMeta):
     pass
 
 

--- a/tests/test_type/test_enum.py
+++ b/tests/test_type/test_enum.py
@@ -1,3 +1,4 @@
+import pytest
 import magma as m
 from magma.testing import check_files_equal
 
@@ -7,6 +8,8 @@ def test_enum():
         zero = 0
         one = 1
         two = 2
+
+    assert issubclass(State, m.Enum)
 
     circuit = m.DefineCircuit('enum_test', "I", m.In(State),
                               "O", m.Out(m.Array[2, State]))
@@ -30,3 +33,10 @@ def test_enum_max_value():
     m.EndDefine()
     m.compile("build/test_enum_max_value", circuit, output="coreir-verilog")
     assert check_files_equal(__file__, "build/test_enum_max_value.v", "gold/test_enum_max_value.v")
+
+
+def test_reserved():
+    with pytest.raises(ValueError):
+        class MyEnum(m.Enum):
+            a = 0
+            N = 2


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/548 and https://github.com/phanrahan/magma/issues/500 (for now we just raise an error for `N`, in the future we can make this unreserved, but right now a lot of internal code unrelated to enums (arrays) use this attribute).