### PR TITLE
Add unused/undriven primitives

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -26,7 +26,7 @@ def singleton(cls):
 
 # wires
 from .port import *
-from .wire import *
+from .wire import wire, Undriven, Unused
 
 # types
 from .t import *

--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -26,7 +26,7 @@ def singleton(cls):
 
 # wires
 from .port import *
-from .wire import wire, Undriven, Unused
+from .wire import wire
 
 # types
 from .t import *

--- a/magma/array.py
+++ b/magma/array.py
@@ -357,5 +357,13 @@ class Array(Type, metaclass=ArrayMeta):
     def concat(self, other) -> 'AbstractBitVector':
         return type(self)[len(self) + len(other), self.T](self.ts + other.ts)
 
+    def undriven(self):
+        for elem in self:
+            elem.undriven()
+
+    def unused(self):
+        for elem in self:
+            elem.unused()
+
 
 ArrayType = Array

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -437,6 +437,37 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def get_family(cls):
         return m.get_family()
 
+    def unused(self):
+        if not self.is_output():
+            raise TypeError("unused can only be used on output")
+        m.wire(self, DefineUnused(len(self))().I)
+
+    def undriven(self):
+        if not self.is_input():
+            raise TypeError("undriven can only be used on input")
+        m.wire(DefineUndriven(len(self))().O, self)
+
+
+def make_Define(name, port, direction):
+    def simulate(self, value_store, state_store):
+        pass
+
+    @lru_cache(maxsize=None)
+    def Define(width):
+        return m.circuit.DeclareCoreirCircuit(
+            name,
+            port, direction(Bits[width]),
+            coreir_name=name,
+            coreir_lib="coreir",
+            coreir_genargs={"width": width},
+            simulate=simulate
+        )
+    return Define
+
+
+DefineUndriven = make_Define("undriven", "O", m.Out)
+DefineUnused = make_Define("term", "I", m.In)
+
 
 BitsType = Bits
 

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 import weakref
 import magma as m
 from abc import ABCMeta
@@ -193,3 +194,33 @@ class Digital(Type, metaclass=DigitalMeta):
 
     def getgpio(self):
         return self.getinst()
+
+    def unused(self):
+        if not self.is_output():
+            raise TypeError("unused can only be used on output")
+        m.wire(self, DefineUnused()().I)
+
+    def undriven(self):
+        if not self.is_input():
+            raise TypeError("undriven can only be used on input")
+        m.wire(DefineUndriven()().O, self)
+
+
+def make_Define(name, port, direction):
+    def simulate(self, value_store, state_store):
+        pass
+
+    @lru_cache(maxsize=None)
+    def DefineCorebit():
+        return m.circuit.DeclareCoreirCircuit(
+            f"corebit_{name}",
+            port, direction(Digital),
+            coreir_name=name,
+            coreir_lib="corebit",
+            simulate=simulate
+        )
+    return DefineCorebit
+
+
+DefineUndriven = make_Define("undriven", "O", m.Out)
+DefineUnused = make_Define("term", "I", m.In)

--- a/magma/t.py
+++ b/magma/t.py
@@ -2,6 +2,7 @@ import functools
 import warnings
 import enum
 from abc import abstractmethod
+import magma as m
 from .ref import Ref, AnonRef, DefnRef, InstRef
 from .compatibility import IntegerTypes, StringTypes
 
@@ -98,13 +99,13 @@ class Type(object):
 
     def __le__(self, other):
         if not self.is_output():
-            self.wire(other)
+            m.wire(self, other)
         else:
             raise TypeError(f"Cannot use <= to assign to output: {self.debug_name} (trying to assign {other.debug_name})")
 
     def __imatmul__(self, other):
         if not self.is_output():
-            self.wire(other)
+            m.wire(self, other)
         else:
             raise TypeError(f"Cannot use @= to assign to output: {self.debug_name} (trying to assign {other.debug_name})")
         return self

--- a/magma/t.py
+++ b/magma/t.py
@@ -110,6 +110,24 @@ class Type(object):
             raise TypeError(f"Cannot use @= to assign to output: {self.debug_name} (trying to assign {other.debug_name})")
         return self
 
+    @abstractmethod
+    def unused(self):
+        # Mark value is unused by calling unused on the underlying magma
+        # elements
+        # For example, m.Bit is wired up to a coreir term primitive
+        # A general m.Array and m.Tuple will recursively call `unused` on its
+        # members
+        raise NotImplementedError()
+
+    @abstractmethod
+    def undriven(self):
+        # Mark value is undriven by calling undriven on the underlying magma
+        # elements
+        # For example, m.Bit is wired up to a coreir undriven primitive
+        # A general m.Array and m.Tuple will recursively call `undriven` on its
+        # members
+        raise NotImplementedError()
+
 
 
 class Kind(type):

--- a/magma/t.py
+++ b/magma/t.py
@@ -2,7 +2,6 @@ import functools
 import warnings
 import enum
 from abc import abstractmethod
-import magma as m
 from .ref import Ref, AnonRef, DefnRef, InstRef
 from .compatibility import IntegerTypes, StringTypes
 
@@ -99,13 +98,13 @@ class Type(object):
 
     def __le__(self, other):
         if not self.is_output():
-            m.wire(self, other)
+            self.wire(other)
         else:
             raise TypeError(f"Cannot use <= to assign to output: {self.debug_name} (trying to assign {other.debug_name})")
 
     def __imatmul__(self, other):
         if not self.is_output():
-            m.wire(self, other)
+            self.wire(other)
         else:
             raise TypeError(f"Cannot use @= to assign to output: {self.debug_name} (trying to assign {other.debug_name})")
         return self

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -290,6 +290,14 @@ class Tuple(Type, Tuple, metaclass=TupleKind):
     def items(self):
         return zip(self.keys(), self.ts)
 
+    def undriven(self):
+        for elem in self:
+            elem.undriven()
+
+    def unused(self):
+        for elem in self:
+            elem.unused()
+
 
 class ProductKind(ProductMeta, TupleKind, Kind):
     __hash__ = type.__hash__

--- a/magma/wire.py
+++ b/magma/wire.py
@@ -1,16 +1,118 @@
+import magma as m
 from .compatibility import IntegerTypes
 from .debug import debug_wire
 from .logging import root_logger
 
 
-__all__ = ['wire']
-
-
 _logger = root_logger()
 
 
+def DefineUndriven(width):
+    def simulate_undriven(self, value_store, state_store):
+        pass
+    return m.circuit.DeclareCoreirCircuit(
+        f"undriven",
+        "O", m.Out(m.Bits[width]),
+        coreir_name="undriven",
+        coreir_lib="coreir",
+        coreir_genargs={"width": width},
+        simulate=simulate_undriven
+    )
+
+
+def DefineCorebitUndriven():
+    def simulate_corebit_undriven(self, value_store, state_store):
+        pass
+    return m.circuit.DeclareCoreirCircuit(
+        f"corebit_undriven",
+        "O", m.Out(m.Bit),
+        coreir_name="undriven",
+        coreir_lib="corebit",
+        simulate=simulate_corebit_undriven
+    )
+
+
+def DefineTerm(width):
+    def simulate_term(self, value_store, state_store):
+        pass
+    return m.circuit.DeclareCoreirCircuit(
+        f"term",
+        "I", m.In(m.Bits[width]),
+        coreir_name="term",
+        coreir_lib="coreir",
+        coreir_genargs={"width": width},
+        simulate=simulate_term
+    )
+
+
+def DefineCorebitTerm():
+    def simulate_corebit_term(self, value_store, state_store):
+        pass
+    return m.circuit.DeclareCoreirCircuit(
+        f"corebit_term",
+        "I", m.In(m.Bit),
+        coreir_name="term",
+        coreir_lib="corebit",
+        simulate=simulate_corebit_term
+    )
+
+
+class Undriven:
+    pass
+
+
+def make_Unused(T):
+    if issubclass(T, m.Bit):
+        return DefineCorebitTerm()().I
+    elif issubclass(T, m.Array) and issubclass(T.T, m.Digital):
+        return DefineTerm(len(T))().I
+    elif issubclass(T, m.Array):
+        return m.array([make_Unused(T.T) for _ in range(len(T))])
+    elif issubclass(T, m.Product):
+        return m.namedtuple(
+            **{key: make_Unused(value) for key, value in T.field_dict.items()}
+        )
+    elif issubclass(T, m.Tuple):
+        return m.tuple_(
+            [make_Unused(t) for t in T.fields]
+        )
+    else:
+        raise NotImplementedError(T)
+
+
+class Unused:
+    def __imatmul__(self, other):
+        m.wire(make_Unused(type(other)), other)
+        return self
+
+
+# Singleton hack to use __imatmul__ impl
+Unused = Unused()
+
+
+def make_Undriven(T):
+    if issubclass(T, m.Bit):
+        return DefineCorebitUndriven()().O
+    elif issubclass(T, m.Array) and issubclass(T.T, m.Digital):
+        return DefineUndriven(len(T))().O
+    elif issubclass(T, m.Array):
+        return m.array([make_Undriven(T.T) for _ in range(len(T))])
+    elif issubclass(T, m.Product):
+        return m.namedtuple(
+            **{key: make_Undriven(value) for key, value in T.field_dict.items()}
+        )
+    elif issubclass(T, m.Tuple):
+        return m.tuple_(
+            [make_Undriven(t) for t in T.fields]
+        )
+    else:
+        raise NotImplementedError(T)
+
 @debug_wire
 def wire(o, i, debug_info=None):
+    if i is Undriven:
+        i = make_Undriven(type(o))
+
     # Wire(o, Circuit).
     if hasattr(i, 'interface'):
         i.wire(o, debug_info)

--- a/magma/wire.py
+++ b/magma/wire.py
@@ -2,7 +2,6 @@ import magma as m
 from .compatibility import IntegerTypes
 from .debug import debug_wire
 from .logging import root_logger
-from .t import In, Out
 
 
 _logger = root_logger()

--- a/magma/wire.py
+++ b/magma/wire.py
@@ -2,59 +2,39 @@ import magma as m
 from .compatibility import IntegerTypes
 from .debug import debug_wire
 from .logging import root_logger
+from .t import In, Out
 
 
 _logger = root_logger()
 
 
-def DefineUndriven(width):
-    def simulate_undriven(self, value_store, state_store):
+def make_Defines(name, port, direction):
+    def simulate(self, value_store, state_store):
         pass
-    return m.circuit.DeclareCoreirCircuit(
-        f"undriven",
-        "O", m.Out(m.Bits[width]),
-        coreir_name="undriven",
-        coreir_lib="coreir",
-        coreir_genargs={"width": width},
-        simulate=simulate_undriven
-    )
+
+    def Define(width):
+        return m.circuit.DeclareCoreirCircuit(
+            name,
+            port, direction(m.Bits[width]),
+            coreir_name=name,
+            coreir_lib="coreir",
+            coreir_genargs={"width": width},
+            simulate=simulate
+        )
+
+    def DefineCorebit():
+        return m.circuit.DeclareCoreirCircuit(
+            f"corebit_{name}",
+            port, direction(m.Bit),
+            coreir_name=name,
+            coreir_lib="corebit",
+            simulate=simulate
+        )
+    return Define, DefineCorebit
 
 
-def DefineCorebitUndriven():
-    def simulate_corebit_undriven(self, value_store, state_store):
-        pass
-    return m.circuit.DeclareCoreirCircuit(
-        f"corebit_undriven",
-        "O", m.Out(m.Bit),
-        coreir_name="undriven",
-        coreir_lib="corebit",
-        simulate=simulate_corebit_undriven
-    )
-
-
-def DefineTerm(width):
-    def simulate_term(self, value_store, state_store):
-        pass
-    return m.circuit.DeclareCoreirCircuit(
-        f"term",
-        "I", m.In(m.Bits[width]),
-        coreir_name="term",
-        coreir_lib="coreir",
-        coreir_genargs={"width": width},
-        simulate=simulate_term
-    )
-
-
-def DefineCorebitTerm():
-    def simulate_corebit_term(self, value_store, state_store):
-        pass
-    return m.circuit.DeclareCoreirCircuit(
-        f"corebit_term",
-        "I", m.In(m.Bit),
-        coreir_name="term",
-        coreir_lib="corebit",
-        simulate=simulate_corebit_term
-    )
+DefineUndriven, DefineCorebitUndriven = make_Defines("undriven", "O", Out)
+DefineTerm, DefineCorebitTerm = make_Defines("term", "I", In)
 
 
 def make_unused_undriven(bit_def, bits_def, attr):

--- a/tests/test_wire/gold/test_undriven.v
+++ b/tests/test_wire/gold/test_undriven.v
@@ -1,0 +1,53 @@
+module coreir_undriven #(parameter width = 1) (output [width-1:0] out);
+
+endmodule
+
+module corebit_undriven (output out);
+
+endmodule
+
+module Circuit (output O0, output [4:0] O1, output O2_B, output O2_C, output O3_0_B, output O3_0_C, output O3_1_B, output O3_1_C, output O3_2_B, output O3_2_C, output O3_3_B, output O3_3_C, output O3_4_B, output O3_4_C);
+wire corebit_undriven_inst0_out;
+wire corebit_undriven_inst1_out;
+wire corebit_undriven_inst10_out;
+wire corebit_undriven_inst11_out;
+wire corebit_undriven_inst12_out;
+wire corebit_undriven_inst2_out;
+wire corebit_undriven_inst3_out;
+wire corebit_undriven_inst4_out;
+wire corebit_undriven_inst5_out;
+wire corebit_undriven_inst6_out;
+wire corebit_undriven_inst7_out;
+wire corebit_undriven_inst8_out;
+wire corebit_undriven_inst9_out;
+wire [4:0] undriven_inst0_out;
+corebit_undriven corebit_undriven_inst0(.out(corebit_undriven_inst0_out));
+corebit_undriven corebit_undriven_inst1(.out(corebit_undriven_inst1_out));
+corebit_undriven corebit_undriven_inst10(.out(corebit_undriven_inst10_out));
+corebit_undriven corebit_undriven_inst11(.out(corebit_undriven_inst11_out));
+corebit_undriven corebit_undriven_inst12(.out(corebit_undriven_inst12_out));
+corebit_undriven corebit_undriven_inst2(.out(corebit_undriven_inst2_out));
+corebit_undriven corebit_undriven_inst3(.out(corebit_undriven_inst3_out));
+corebit_undriven corebit_undriven_inst4(.out(corebit_undriven_inst4_out));
+corebit_undriven corebit_undriven_inst5(.out(corebit_undriven_inst5_out));
+corebit_undriven corebit_undriven_inst6(.out(corebit_undriven_inst6_out));
+corebit_undriven corebit_undriven_inst7(.out(corebit_undriven_inst7_out));
+corebit_undriven corebit_undriven_inst8(.out(corebit_undriven_inst8_out));
+corebit_undriven corebit_undriven_inst9(.out(corebit_undriven_inst9_out));
+coreir_undriven #(.width(5)) undriven_inst0(.out(undriven_inst0_out));
+assign O0 = corebit_undriven_inst0_out;
+assign O1 = undriven_inst0_out;
+assign O2_B = corebit_undriven_inst1_out;
+assign O2_C = corebit_undriven_inst2_out;
+assign O3_0_B = corebit_undriven_inst3_out;
+assign O3_0_C = corebit_undriven_inst4_out;
+assign O3_1_B = corebit_undriven_inst5_out;
+assign O3_1_C = corebit_undriven_inst6_out;
+assign O3_2_B = corebit_undriven_inst7_out;
+assign O3_2_C = corebit_undriven_inst8_out;
+assign O3_3_B = corebit_undriven_inst9_out;
+assign O3_3_C = corebit_undriven_inst10_out;
+assign O3_4_B = corebit_undriven_inst11_out;
+assign O3_4_C = corebit_undriven_inst12_out;
+endmodule
+

--- a/tests/test_wire/gold/test_unused.v
+++ b/tests/test_wire/gold/test_unused.v
@@ -1,0 +1,25 @@
+module coreir_term #(parameter width = 1) (input [width-1:0] in);
+
+endmodule
+
+module corebit_term (input in);
+
+endmodule
+
+module Circuit (input I0, input [4:0] I1, input I2_B, input I2_C, input I3_0_B, input I3_0_C, input I3_1_B, input I3_1_C, input I3_2_B, input I3_2_C, input I3_3_B, input I3_3_C, input I3_4_B, input I3_4_C);
+corebit_term corebit_term_inst0(.in(I0));
+corebit_term corebit_term_inst1(.in(I2_B));
+corebit_term corebit_term_inst10(.in(I3_3_C));
+corebit_term corebit_term_inst11(.in(I3_4_B));
+corebit_term corebit_term_inst12(.in(I3_4_C));
+corebit_term corebit_term_inst2(.in(I2_C));
+corebit_term corebit_term_inst3(.in(I3_0_B));
+corebit_term corebit_term_inst4(.in(I3_0_C));
+corebit_term corebit_term_inst5(.in(I3_1_B));
+corebit_term corebit_term_inst6(.in(I3_1_C));
+corebit_term corebit_term_inst7(.in(I3_2_B));
+corebit_term corebit_term_inst8(.in(I3_2_C));
+corebit_term corebit_term_inst9(.in(I3_3_B));
+coreir_term #(.width(5)) term_inst0(.in(I1));
+endmodule
+

--- a/tests/test_wire/test_undriven.py
+++ b/tests/test_wire/test_undriven.py
@@ -17,10 +17,10 @@ def test_undriven():
 
         @classmethod
         def definition(io):
-            io.O0 @= m.Undriven
-            io.O1 @= m.Undriven
-            io.O2 @= m.Undriven
-            io.O3 @= m.Undriven
+            io.O0.undriven()
+            io.O1.undriven()
+            io.O2.undriven()
+            io.O3.undriven()
 
     m.compile("build/test_undriven", Circuit)
     assert check_files_equal(__file__, f"build/test_undriven.v",

--- a/tests/test_wire/test_undriven.py
+++ b/tests/test_wire/test_undriven.py
@@ -1,0 +1,27 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_undriven():
+    class A(m.Product):
+        B = m.Out(m.Bit)
+        C = m.Out(m.Bit)
+
+    class Circuit(m.Circuit):
+        IO = [
+            "O0", m.Out(m.Bit),
+            "O1", m.Out(m.Bits[5]),
+            "O2", A,
+            "O3", m.Out(m.Array[5, A]),
+        ]
+
+        @classmethod
+        def definition(io):
+            io.O0 @= m.Undriven
+            io.O1 @= m.Undriven
+            io.O2 @= m.Undriven
+            io.O3 @= m.Undriven
+
+    m.compile("build/test_undriven", Circuit)
+    assert check_files_equal(__file__, f"build/test_undriven.v",
+                             f"gold/test_undriven.v")

--- a/tests/test_wire/test_unused.py
+++ b/tests/test_wire/test_unused.py
@@ -1,0 +1,27 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_undriven():
+    class A(m.Product):
+        B = m.In(m.Bit)
+        C = m.In(m.Bit)
+
+    class Circuit(m.Circuit):
+        IO = [
+            "I0", m.In(m.Bit),
+            "I1", m.In(m.Bits[5]),
+            "I2", A,
+            "I3", m.In(m.Array[5, A]),
+        ]
+
+        @classmethod
+        def definition(io):
+            m.Unused @= io.I0
+            m.Unused @= io.I1
+            m.Unused @= io.I2
+            m.Unused @= io.I3
+
+    m.compile("build/test_unused", Circuit)
+    assert check_files_equal(__file__, f"build/test_unused.v",
+                             f"gold/test_unused.v")

--- a/tests/test_wire/test_unused.py
+++ b/tests/test_wire/test_unused.py
@@ -17,10 +17,10 @@ def test_undriven():
 
         @classmethod
         def definition(io):
-            m.Unused @= io.I0
-            m.Unused @= io.I1
-            m.Unused @= io.I2
-            m.Unused @= io.I3
+            io.I0.unused()
+            io.I1.unused()
+            io.I2.unused()
+            io.I3.unused()
 
     m.compile("build/test_unused", Circuit)
     assert check_files_equal(__file__, f"build/test_unused.v",


### PR DESCRIPTION
Depends on https://github.com/rdaly525/coreir/pull/834

Allows declaring undriven values, e.g.
```
            io.O0 @= m.Undriven
```
and unused values, e.g.
```
            m.Unused @= io.I0
```

Currently this works by hijacking the wiring logic/operators to dispatch on the wiring types, and if it finds the special class/object for Unused and Undriven, it inserts a reference to a generated coreir primitive module that is used to represent them (term/undriven).