### PR TITLE
Fix issue with BitVector constructor

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -342,7 +342,7 @@ class Array(Type, metaclass=ArrayMeta):
         if self.iswhole(ts):
             return ts[0].name.array
 
-        return type(self)(*ts)
+        return type(self).flip()(*ts)
 
     def const(self):
         for t in self.ts:

--- a/tests/test_issues/test_562.py
+++ b/tests/test_issues/test_562.py
@@ -1,0 +1,19 @@
+import magma as m
+
+import sys
+import os
+
+TEST_SYNTAX_PATH = os.path.join(os.path.dirname(__file__), '../test_syntax')
+
+sys.path.append(TEST_SYNTAX_PATH)
+
+from test_sequential import DefineRegister, phi, compile_and_check
+
+
+def test_562():
+    BV1 = m.Bits[1]
+    @m.circuit.sequential
+    class A:
+        def __call__(self, a: m.Bit, b: m.Bits[2]) -> m.Bits[1]:
+            return a.ite(BV1(a), b[0:1])
+    compile_and_check("test_562", A, "coreir-verilog")

--- a/tests/test_syntax/gold/test_562.v
+++ b/tests/test_syntax/gold/test_562.v
@@ -1,0 +1,16 @@
+module coreir_mux #(parameter width = 1) (input [width-1:0] in0, input [width-1:0] in1, input sel, output [width-1:0] out);
+  assign out = sel ? in1 : in0;
+endmodule
+
+module A_comb (output [0:0] O, input a, input [1:0] b);
+wire [0:0] magma_Bit_ite_Out_Bits_1_inst0_out;
+coreir_mux #(.width(1)) magma_Bit_ite_Out_Bits_1_inst0(.in0(b[0]), .in1(a), .out(magma_Bit_ite_Out_Bits_1_inst0_out), .sel(a));
+assign O = magma_Bit_ite_Out_Bits_1_inst0_out;
+endmodule
+
+module A (input ASYNCRESET, input CLK, output [0:0] O, input a, input [1:0] b);
+wire [0:0] A_comb_inst0_O;
+A_comb A_comb_inst0(.O(A_comb_inst0_O), .a(a), .b(b));
+assign O = A_comb_inst0_O;
+endmodule
+


### PR DESCRIPTION
Fixes #562 

The issue was that when the Bits constructor was used with an output (converting between a Bit output to a Bits[1] output), the result doesn't preserve the directionality (so `Out(Bit)` becomes `Bits[1]`.  Now, it checks if all the children are outputs, if so, it returns `Out(Bits[n])` instead of `Bits[n]`.

We should ensure that this is consistent with all the types, (so if you convert a directed value with an undirected type, the result should preserve the direction).  The other choice is to force the user to say `Out(Bits[1])` for their type conversion.  But this would at least unblock your issue in sequential.

CC @rsetaluri and @phanrahan any thoughts on this? The issue is, if I have an output type such as
```
a = m.Out(Bit)
```
and I convert it to a `Bits[1]` using
```
b = m.Bits[1](a)
```
I'll get an instance of `m.Bits[1]` instead of `m.Out(m.Bits[1])`.  This changes the behavior to give you `m.Out(m.Bits[1])` instead.  The alternative is to use `m.bits(a, 1)` which will give you an output, but I think that syntax is not compatible with peak.  The general issue is: when using an undirected constructor with a value, should the result return a directed value?