### PR TITLE
Make key N error in Product

### DIFF
--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -330,6 +330,9 @@ class ProductKind(ProductMeta, TupleKind, Kind):
         # add properties to namespace
         # build properties
         for field_name, field_type in fields.items():
+            if field_name == "N":
+                # TODO: Make N unreserved
+                raise ValueError("N is a reserved name in Product")
             assert field_name not in ns
             idx = idx_table[field_name]
             ns[field_name] = _make_prop(field_type, idx)


### PR DESCRIPTION
`N` key causes massive internal calls like this.

             1066227879 function calls (986191464 primitive calls) in 253.551 seconds

       Ordered by: call count

       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    122233100   32.698    0.000   60.016    0.000 _collections_abc.py:742(__iter__)
     81614892    5.927    0.000    5.927    0.000 digital.py:122(__eq__)
     81602044   18.373    0.000   56.118    0.000 {built-in method builtins.getattr}
    81557305/40846086   10.308    0.000   26.451    0.000 {built-in method builtins.len}
     81514069    4.354    0.000    4.354    0.000 {method '__getitem__' of 'dict' objects}
     81514068   14.468    0.000   18.822    0.000 util.py:12(__getitem__)
     81437145    7.657    0.000    7.657    0.000 adt_meta.py:263(fields)
    41989990/3039010    2.778    0.000  238.619    0.000 {built-in method builtins.isinstance}
     40795005    5.307    0.000    5.308    0.000 util.py:92(__get__)
     40734812    8.531    0.000    8.531    0.000 adt_meta.py:409(field_dict)
     40734035    4.377    0.000    4.377    0.000 _collections_abc.py:698(__init__)
     40728765    8.500    0.000    8.500    0.000 util.py:15(__iter__)
     40726088    7.579    0.000   11.240    0.000 adt_meta.py:272(is_bound)
     40725635   10.681    0.000   15.058    0.000 _collections_abc.py:676(items)
     40725632   10.137    0.000   25.194    0.000 {method 'items' of 'mappingproxy' objects}
     40725202   73.433    0.000  243.190    0.000 tuple.py:376(__eq__)
     40708164    6.001    0.000   32.437    0.000 tuple.py:109(N)
     40708164   12.144    0.000   19.277    0.000 tuple.py:389(__len__)
    633796/633778    0.097    0.000    0.100    0.000 {built-in method builtins.hasattr}
       611622    0.080    0.000    0.110    0.000 inspect.py:63(ismodule)

Just renaming `N` key fixes the issue (253 seconds -> 4 seconds)

             7747966 function calls (7431001 primitive calls) in 4.057 seconds

       Ordered by: call count

       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    1271150/1149818    0.114    0.000    0.547    0.000 {built-in method builtins.isinstance}
    633796/633778    0.094    0.000    0.096    0.000 {built-in method builtins.hasattr}
       611622    0.081    0.000    0.111    0.000 inspect.py:63(ismodule)

Make `N` key error for the time being, same as 1ea25c297da68d4737bd8a245eec4d167168faf5