### PR TITLE
[Proposal] AnonProduct

### DIFF
--- a/docs/inline_verilog.md
+++ b/docs/inline_verilog.md
@@ -62,9 +62,9 @@ attribute syntax.  Here's a more complex example that shows various examples of
 referring to complex (Tuple) types and child instances.
 
 ```python
-RVDATAIN = m.Array[2, m.Product.from_fields("", dict(data=m.In(m.Bits[5]),
-                                                     valid=m.In(m.Bit),
-                                                     ready=m.Out(m.Bit)))]
+RVDATAIN = m.Array[2, m.AnonProduct[dict(data=m.In(m.Bits[5]),
+                                         valid=m.In(m.Bit),
+                                         ready=m.Out(m.Bit))]]
 
 class InnerInnerDelayUnit(m.Circuit):
     name = "InnerInnerDelayUnit"

--- a/tests/test_syntax/gold/return_anon_product.json
+++ b/tests/test_syntax/gold/return_anon_product.json
@@ -1,0 +1,18 @@
+{"top":"global.return_anon_product",
+"namespaces":{
+  "global":{
+    "modules":{
+      "return_anon_product":{
+        "type":["Record",[
+          ["I",["Array",2,"BitIn"]],
+          ["O",["Record",[["x","Bit"],["y","Bit"]]]]
+        ]],
+        "connections":[
+          ["self.O.x","self.I.0"],
+          ["self.O.y","self.I.1"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_syntax/test_combinational.py
+++ b/tests/test_syntax/test_combinational.py
@@ -129,6 +129,13 @@ def test_return_magma_named_tuple(target):
                       return_magma_named_tuple.circuit_definition, target)
 
 
+def test_return_anon_product(target):
+    @m.circuit.combinational
+    def return_anon_product(I: m.Bits[2]) -> m.AnonProduct[dict(x=m.Bit, y=m.Bit)]:
+        return m.namedtuple(x=I[0], y=I[1])
+    compile_and_check("return_anon_product", return_anon_product.circuit_definition, target)
+
+
 def test_simple_circuit_1(target):
     class EQ(m.Circuit):
         name = "eq"

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -367,12 +367,11 @@ def test_asyncreset_cast(T, convert):
 
     class AsyncResetTest(m.Circuit):
         io = m.IO(I=m.BitIn, I_Arr=m.In(m.Array[3, Bit]),
-                  O=T, O_Tuple=m.Product.from_fields(
-                      "anon", {"R": T, "B": Out(Bit)}),
+                  O=T, O_Tuple=m.AnonProduct[dict(R=T, B=Out(Bit))],
                   O_Arr=m.Array[2, T],
                   T_in=In(T), Bit_out=Out(Bit),
                   T_Arr_in=In(m.Array[2, T]),
-                  T_Tuple_in=In(m.Product.from_fields("anon", {"T": T})),
+                  T_Tuple_in=In(m.AnonProduct[dict(T=T)]),
                   Bit_Arr_out=Out(m.Array[4, Bit]))
 
         inst = Inst()

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -267,3 +267,19 @@ def test_tuple_nested_tuple_value():
 def test_flat_length():
     a = m.Product.from_fields("anon", dict(x=m.Bits[5], y=m.Bits[3], z=m.Bit))
     assert a.flat_length() == 9
+
+
+def test_anon_product():
+    product = m.Product.from_fields("anon", dict(x=m.Bits[5], y=m.Bits[3], z=m.Bit))
+    assert isinstance(product, AnonymousProductMeta)
+    assert isinstance(product, ProductMeta)
+
+    anon_product = m.AnonProduct[dict(x=m.Bits[5], y=m.Bits[3], z=m.Bit)]
+    assert isinstance(anon_product, AnonymousProductMeta)
+    assert not isinstance(anon_product, ProductMeta)
+    assert anon_product.flat_length() == product.flat_length()
+    assert anon_product.x == product.x
+    assert anon_product.y == product.y
+    assert anon_product.z == product.z
+    assert anon_product == product
+    assert not anon_product is product

--- a/tests/test_verilog/test_inline.py
+++ b/tests/test_verilog/test_inline.py
@@ -32,9 +32,9 @@ assert property (@(posedge CLK) {io.arr[0]} |-> ##1 {io.arr[1]});
 
 def test_inline_tuple():
 
-    RVDATAIN = m.Array[2, m.Product.from_fields("", dict(data=m.In(m.Bits[5]),
-                                                         valid=m.In(m.Bit),
-                                                         ready=m.Out(m.Bit)))]
+    RVDATAIN = m.Array[2, m.AnonProduct[dict(data=m.In(m.Bits[5]),
+                                             valid=m.In(m.Bit),
+                                             ready=m.Out(m.Bit))]]
 
     class InnerInnerDelayUnit(m.Circuit):
         name = "InnerInnerDelayUnit"


### PR DESCRIPTION
I really miss old `Tuple` for declaring return type.

    def test(I: m.Bits[2]) -> m.Tuple(x=m.Bit, y=m.Bit):

Current options are, 1. use `from_fields` (too long to write)

    def test(I: m.Bits[2]) -> m.Product.from_fields("anon", dict(x=m.Bit, y=m.Bit)):

Or, 2. declare `Product` type beforehand (not convenient)

    class Out(m.Product)
        x = m.Bit
        y = m.Bit

    def test(I: m.Bits[2]) -> Out:

Can we introduce `AnonProduct`? just alias for `from_fields("anon", dict(`
since magma already has `AnonRef`

    def test(I: m.Bits[2]) -> m.AnonProduct(x=m.Bit, y=m.Bit):
