### PR TITLE
Add ability to do a dynamic slice with a constant width

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -84,3 +84,5 @@ def get_family():
 
 from .generator import Generator
 from .monitor import MonitorIO, MonitorGenerator
+import magma.operators
+from .operators import slice

--- a/magma/array.py
+++ b/magma/array.py
@@ -210,7 +210,13 @@ class Array(Type, metaclass=ArrayMeta):
     def flat_length(cls):
         return cls.N * cls.T.flat_length()
 
+    def dynamic_mux_select(self, key):
+        return m.operators.Mux(len(self), self.T)(*self.ts, key)
+
     def __getitem__(self, key):
+        if isinstance(key, Type):
+            # indexed using a dynamic magma value, generate mux circuit
+            return self.dynamic_mux_select(key)
         if isinstance(key, ArrayType) and all(t in {VCC, GND} for t in key.ts):
             key = seq2int([0 if t is GND else 1 for t in key.ts])
         if isinstance(key, slice):

--- a/magma/operators.py
+++ b/magma/operators.py
@@ -1,0 +1,76 @@
+from .circuit import Circuit, DeclareCoreirCircuit
+from .array import Array
+from .bits import Bits
+from .conversions import array
+from .t import Type, In, Out
+from .tuple import Product
+from .bitutils import clog2
+from .generator import Generator
+from .frontend.coreir_ import DefineCircuitFromGeneratorWrapper, GetCoreIRBackend
+from .wire import wire
+
+
+class CoreIRCommonLibMuxN(Generator):
+    @staticmethod
+    def generate(N: int, width: int):
+        return DeclareCoreirCircuit(f"coreir_commonlib_mux{N}x{width}",
+            *["I", In(Product.from_fields("anon",
+                                          dict(data=Array[N, Bits[width]],
+                                               sel=Bits[clog2(N)]))),
+              "O", Out(Bits[width])],
+            coreir_name="muxn",
+            coreir_lib="commonlib",
+            coreir_genargs={"width": width, "N": N}
+        )
+
+class Mux(Generator):
+    @staticmethod
+    def generate(height: int, T: Type):
+        # TODO: Type must be hashable so we can cache
+        N = T.flat_length()
+        class Mux(Circuit):
+            IO = []
+            for i in range(height):
+                IO += [f"I{i}", In(T)]
+            IO += ["S", In(Bits[clog2(height)])]
+            IO += ["O", Out(T)]
+            @classmethod
+            def definition(io):
+                mux = CoreIRCommonLibMuxN(height, N)
+                wire(mux.I.data, array(
+                    [Bits[N](getattr(io, f"I{i}").flatten()) 
+                     for i in range(height)]
+                ))
+                wire(mux.I.sel, io.S)
+                wire(mux.O, io.O)
+        return Mux
+
+
+def slice(value: Bits, start: Bits, width: int):
+    """
+    Dynamic slice based off the value of `start` with constant `width`
+
+    Example:
+    ```
+    class TestSlice(m.Circuit):
+        # Slice a 6 bit window of I using x as the start index
+        IO = [
+            "I", m.In(m.Bits[10]), 
+            "x", m.In(m.Bits[2]), 
+            "O", m.Out(m.Bits[6])
+        ]
+
+        @classmethod
+        def definition(io):
+            io.O @= m.slice(io.I, start=io.x, width=6)
+    ```
+
+    Notes:
+    * For now we only support slicing bits with bits index
+    * We could add support for slicing Arrays
+    * We could restrict index to be a UInt
+    """
+    # Construct an array where the index `i` is the slice of bits from `i` to
+    # `i+width`, index into this array using `start`
+    return array([value[i:i+width] for i in range(len(value) - width
+)])[start]

--- a/magma/operators.py
+++ b/magma/operators.py
@@ -72,5 +72,4 @@ def slice(value: Bits, start: Bits, width: int):
     """
     # Construct an array where the index `i` is the slice of bits from `i` to
     # `i+width`, index into this array using `start`
-    return array([value[i:i+width] for i in range(len(value) - width
-)])[start]
+    return array([value[i:i+width] for i in range(len(value) - width)])[start]

--- a/tests/test_operators/build/.gitignore
+++ b/tests/test_operators/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_operators/gold/TestSlice.v
+++ b/tests/test_operators/gold/TestSlice.v
@@ -1,0 +1,40 @@
+module coreir_slice #(parameter hi = 1, parameter lo = 0, parameter width = 1) (input [width-1:0] in, output [hi-lo-1:0] out);
+  assign out = in[hi-1:lo];
+endmodule
+
+module coreir_mux #(parameter width = 1) (input [width-1:0] in0, input [width-1:0] in1, input sel, output [width-1:0] out);
+  assign out = sel ? in1 : in0;
+endmodule
+
+module commonlib_muxn__N2__width6 (input [5:0] in_data_0, input [5:0] in_data_1, input [0:0] in_sel, output [5:0] out);
+wire [5:0] _join_out;
+coreir_mux #(.width(6)) _join(.in0(in_data_0), .in1(in_data_1), .out(_join_out), .sel(in_sel[0]));
+assign out = _join_out;
+endmodule
+
+module commonlib_muxn__N4__width6 (input [5:0] in_data_0, input [5:0] in_data_1, input [5:0] in_data_2, input [5:0] in_data_3, input [1:0] in_sel, output [5:0] out);
+wire [5:0] _join_out;
+wire [5:0] muxN_0_out;
+wire [5:0] muxN_1_out;
+wire [0:0] sel_slice0_out;
+wire [0:0] sel_slice1_out;
+coreir_mux #(.width(6)) _join(.in0(muxN_0_out), .in1(muxN_1_out), .out(_join_out), .sel(in_sel[1]));
+commonlib_muxn__N2__width6 muxN_0(.in_data_0(in_data_0), .in_data_1(in_data_1), .in_sel(sel_slice0_out), .out(muxN_0_out));
+commonlib_muxn__N2__width6 muxN_1(.in_data_0(in_data_2), .in_data_1(in_data_3), .in_sel(sel_slice1_out), .out(muxN_1_out));
+coreir_slice #(.hi(1), .lo(0), .width(2)) sel_slice0(.in(in_sel), .out(sel_slice0_out));
+coreir_slice #(.hi(1), .lo(0), .width(2)) sel_slice1(.in(in_sel), .out(sel_slice1_out));
+assign out = _join_out;
+endmodule
+
+module Mux (input [5:0] I0, input [5:0] I1, input [5:0] I2, input [5:0] I3, output [5:0] O, input [1:0] S);
+wire [5:0] coreir_commonlib_mux4x6_inst0_out;
+commonlib_muxn__N4__width6 coreir_commonlib_mux4x6_inst0(.in_data_0(I0), .in_data_1(I1), .in_data_2(I2), .in_data_3(I3), .in_sel(S), .out(coreir_commonlib_mux4x6_inst0_out));
+assign O = coreir_commonlib_mux4x6_inst0_out;
+endmodule
+
+module TestSlice (input [9:0] I, output [5:0] O, input [1:0] x);
+wire [5:0] Mux_inst0_O;
+Mux Mux_inst0(.I0({I[5],I[4],I[3],I[2],I[1],I[0]}), .I1({I[6],I[5],I[4],I[3],I[2],I[1]}), .I2({I[7],I[6],I[5],I[4],I[3],I[2]}), .I3({I[8],I[7],I[6],I[5],I[4],I[3]}), .O(Mux_inst0_O), .S(x));
+assign O = Mux_inst0_O;
+endmodule
+

--- a/tests/test_operators/test_slice.py
+++ b/tests/test_operators/test_slice.py
@@ -1,0 +1,20 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_slice_fixed_range():
+	class TestSlice(m.Circuit):
+		IO = [
+			"I", m.In(m.Bits[10]), 
+			"x", m.In(m.Bits[2]), 
+			"O", m.Out(m.Bits[6])
+		]
+
+		@classmethod
+		def definition(io):
+			io.O @= m.slice(io.I, start=io.x, width=6)
+
+	m.compile("build/TestSlice", TestSlice)
+	assert check_files_equal(__file__,
+                             "build/TestSlice.v",
+                             "gold/TestSlice.v")

--- a/tests/test_operators/test_slice.py
+++ b/tests/test_operators/test_slice.py
@@ -1,20 +1,40 @@
 import magma as m
 from magma.testing import check_files_equal
+from hwtypes import BitVector
 
 
 def test_slice_fixed_range():
-	class TestSlice(m.Circuit):
-		IO = [
-			"I", m.In(m.Bits[10]), 
-			"x", m.In(m.Bits[2]), 
-			"O", m.Out(m.Bits[6])
-		]
+    class TestSlice(m.Circuit):
+        IO = [
+            "I", m.In(m.Bits[10]), 
+            "x", m.In(m.Bits[2]), 
+            "O", m.Out(m.Bits[6])
+        ]
 
-		@classmethod
-		def definition(io):
-			io.O @= m.slice(io.I, start=io.x, width=6)
+        @classmethod
+        def definition(io):
+            io.O @= m.slice(io.I, start=io.x, width=6)
 
-	m.compile("build/TestSlice", TestSlice)
-	assert check_files_equal(__file__,
+    m.compile("build/TestSlice", TestSlice)
+    assert check_files_equal(__file__,
                              "build/TestSlice.v",
                              "gold/TestSlice.v")
+
+    try:
+        import fault
+        tester = fault.Tester(TestSlice)
+        I = BitVector[10](0x2DE)
+        tester.circuit.I = I
+        for x in range(0, 4):
+            tester.circuit.x = x
+            tester.eval()
+            tester.circuit.O.expect(I[x:x+6])
+        import os
+        build_dir = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            "build"
+        )
+        tester.compile_and_run("verilator", skip_compile=True, directory=build_dir,
+                               flags=["-Wno-unused"])
+    except ImportError:
+        pass


### PR DESCRIPTION
(CC @priyanka-raina and @kong0329)

Adds the ability to do a constant width slice, but using a dynamic offset value.

We currently don't support a truly dynamic slice such as `x[y:z]` where `y` and `z` are magma values, since this would require the notion of a value with a variable width (depending on the dynamic value of `y` and `z`).  However, this adds support for the simpler case of `x[y:y+OFFSET]` where `OFFSET` is a constant value.  This essential selects a constant slice of values, with a dynamic start offset (`x`).

The initial implementation uses a functional style operator `m.slice(value: Bits, start: Bits, width: int` since this would be easier to implement then the general slice syntax (e.g. `value[start:start+width]` we'd have to determine that the top of the slice was a constant offset, but that could be tricky in general, for example if you had `(1 << N)` instead of `width`.  Using a functional style operator requires the user to perform any computation and realize it as a constant value before passing it to the operator.