### PR TITLE
Use _qualify_magma_

### DIFF
--- a/magma/t.py
+++ b/magma/t.py
@@ -1,7 +1,7 @@
 import functools
 import warnings
 import enum
-from abc import abstractmethod, ABCMeta
+from abc import abstractmethod
 from .common import deprecated
 from .ref import Ref, AnonRef, DefnRef, InstRef
 from .compatibility import IntegerTypes, StringTypes
@@ -158,7 +158,7 @@ def Flip(T):
     return T.flip()
 
 
-class MagmaProtocolMeta(ABCMeta):
+class MagmaProtocolMeta(type):
     @abstractmethod
     def _to_magma_(cls):
         # Need way to retrieve underlying magma type

--- a/magma/t.py
+++ b/magma/t.py
@@ -170,6 +170,12 @@ class MagmaProtocolMeta(ABCMeta):
         # underlying type qualified to be an input)
         raise NotImplementedError()
 
+    @abstractmethod
+    def _flip_magma_(cls):
+        # Need way to flip underlying type (e.g. give me a Foo with the
+        # underlying type flipped)
+        raise NotImplementedError()
+
     def qualify(cls, direction: Direction):
         return cls._qualify_magma_(direction)
 
@@ -179,12 +185,7 @@ class MagmaProtocolMeta(ABCMeta):
         raise NotImplementedError()
 
     def flip(cls):
-        T = cls._to_magma_()
-        if T.is_input():
-            return cls._qualify_magma_(Direction.Out)
-        elif T.is_output():
-            return cls._qualify_magma_(Direction.In)
-        return cls
+        return cls._flip_magma_()
 
 
 class MagmaProtocol(metaclass=MagmaProtocolMeta):

--- a/tests/test_type/test_magma_protocol.py
+++ b/tests/test_type/test_magma_protocol.py
@@ -23,6 +23,11 @@ def test_foo_type_magma_protocol():
             # underlying type qualified to be an input)
             return cls[cls.T.qualify(direction)]
 
+        def _flip_magma_(cls):
+            # Need way to create a new version (e.g. give me a Foo with the
+            # underlying type qualified to be an input)
+            return cls[cls.T.flip()]
+
         def _from_magma_value_(cls, val: m.Type):
             # Need a way to create an instance of Foo from a value, this just
             # dispatches to the __init__ logic, but you could define any

--- a/tests/test_type/test_magma_protocol.py
+++ b/tests/test_type/test_magma_protocol.py
@@ -18,16 +18,16 @@ def test_foo_type_magma_protocol():
             # Need way to retrieve underlying magma type
             return cls.T
 
-        def _from_magma_(cls, T: m.Kind):
+        def _qualify_magma_(cls, direction: m.Direction):
             # Need way to create a new version (e.g. give me a Foo with the
             # underlying type qualified to be an input)
-            return cls[T]
+            return cls[cls.T.qualify(direction)]
 
         def _from_magma_value_(cls, val: m.Type):
             # Need a way to create an instance of Foo from a value, this just
             # dispatches to the __init__ logic, but you could define any
             # custom behavior here
-            return cls._from_magma_(type(val))(val)
+            return cls(val)
 
         def __getitem__(cls, T):
             return type(cls)(f"Foo{T}", (cls, ), {"T": T})


### PR DESCRIPTION
As requested by @cdonovick change the protocol to use `_qualify_magma_` to specifically handle type qualifiers, rather than supporting a general `_from_magma_` function.