### PR TITLE
Fix zext bug

### DIFF
--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -213,7 +213,7 @@ def check_value_is_not_input(fn):
 # @check_value_is_not_input
 def zext(value, n):
     assert isinstance(value, (UInt, SInt, Bits)) or \
-        isinstance(value, Array) and isinstance(value.T, Digital)
+        isinstance(value, Array) and issubclass(value.T, Digital)
     if isinstance(value, UInt):
         zeros = uint(0, n)
     elif isinstance(value, SInt):

--- a/tests/test_zext.py
+++ b/tests/test_zext.py
@@ -1,0 +1,9 @@
+import magma as m
+from hwtypes import BitVector
+
+
+def test_zext():
+    result = m.zext(m.concat(m.bits(4), m.bits(5)), 3)
+    assert m.bits(result).bits() == \
+        BitVector[3](4).concat(BitVector[3](5))\
+                       .concat(BitVector[3](0)).bits()


### PR DESCRIPTION
Fixes
```python
>>> m.zext(m.concat(m.bits(4), m.bits(5)), 3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "magma/conversions.py", line 212, in zext
    isinstance(value, Array) and isinstance(value.T, Digital)
AssertionError
```