### PR TITLE
Add primitive python simulation methods and tuple hotfix

### DIFF
--- a/magma/bit.py
+++ b/magma/bit.py
@@ -3,9 +3,12 @@ Definition of magma's Bit type
 * Subtype of the Digital type
 * Implementation of hwtypes.AbstractBit
 """
+import keyword
+import operator
 import typing as tp
 import functools
 from functools import lru_cache
+import hwtypes as ht
 import magma as m
 from hwtypes.bit_vector_abc import AbstractBit, TypeFamily
 from .t import Direction
@@ -36,25 +39,52 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
     @classmethod
     @lru_cache(maxsize=None)
     def declare_unary_op(cls, op):
+        assert op == "not", f"simulate not implemented for {op}"
+
+        def simulate(self, value_store, state_store):
+            I = ht.Bit(value_store.get_value(self.I))
+            O = int(~I)
+            value_store.set_value(self.O, O)
+
         return m.circuit.DeclareCoreirCircuit(f"magma_Bit_{op}",
                                               "I", m.In(m.Bit),
                                               "O", m.Out(m.Bit),
+                                              simulate=simulate,
                                               coreir_name=op,
                                               coreir_lib="corebit")
 
     @classmethod
     @lru_cache(maxsize=None)
     def declare_binary_op(cls, op):
+        python_op_name = op
+        if op in keyword.kwlist:
+            python_op_name += "_"
+        python_op = getattr(operator, python_op_name)
+
+        def simulate(self, value_store, state_store):
+            I0 = ht.Bit(value_store.get_value(self.I0))
+            I1 = ht.Bit(value_store.get_value(self.I1))
+            O = int(python_op(I0, I1))
+            value_store.set_value(self.O, O)
         return m.circuit.DeclareCoreirCircuit(f"magma_Bit_{op}",
                                               "I0", m.In(m.Bit),
                                               "I1", m.In(m.Bit),
                                               "O", m.Out(m.Bit),
+                                              simulate=simulate,
                                               coreir_name=op,
                                               coreir_lib="corebit")
 
     @classmethod
     @lru_cache(maxsize=None)
     def declare_ite(cls, T):
+
+        def simulate(self, value_store, state_store):
+            I0 = ht.Bit(value_store.get_value(self.I0))
+            I1 = ht.Bit(value_store.get_value(self.I1))
+            S = ht.Bit(value_store.get_value(self.S))
+            O = I1 if S else I0
+            value_store.set_value(self.O, O)
+
         t_str = str(T)
         # Sanitize
         t_str = t_str.replace("(", "_")
@@ -67,6 +97,7 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
                                                   "I1", m.In(T),
                                                   "S", m.In(m.Bit),
                                                   "O", m.Out(T),
+                                                  simulate=simulate,
                                                   coreir_name="mux",
                                                   coreir_lib="corebit")
         assert issubclass(T, m.Bits)
@@ -76,6 +107,7 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
                                               "S", m.In(m.Bit),
                                               "O", m.Out(T),
                                               coreir_genargs={"width": len(T)},
+                                              simulate=simulate,
                                               coreir_name="mux",
                                               coreir_lib="coreir")
 

--- a/magma/bit.py
+++ b/magma/bit.py
@@ -13,6 +13,7 @@ import magma as m
 from hwtypes.bit_vector_abc import AbstractBit, TypeFamily
 from .t import Direction
 from .digital import Digital, DigitalMeta
+from .util import primitive_to_python_operator_name_map
 
 
 def bit_cast(fn: tp.Callable[['Bit', 'Bit'], 'Bit']) -> \
@@ -56,9 +57,7 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
     @classmethod
     @lru_cache(maxsize=None)
     def declare_binary_op(cls, op):
-        python_op_name = op
-        if op in keyword.kwlist:
-            python_op_name += "_"
+        python_op_name = primitive_to_python_operator_name_map.get(op, op)
         python_op = getattr(operator, python_op_name)
 
         def simulate(self, value_store, state_store):

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -137,11 +137,12 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     @lru_cache(maxsize=None)
     def declare_unary_op(cls, op):
         N = len(cls)
-        assert op == "not", f"simulate not implemented for {op}"
+        if op == "not":
+            python_op_name = "invert"
 
         def simulate(self, value_store, state_store):
             I = ht.BitVector[N](value_store.get_value(self.I))
-            O = int(~I)
+            O = int(getattr(operatr, python_op_name)(I))
             value_store.set_value(self.O, O)
         return m.circuit.DeclareCoreirCircuit(f"magma_Bits_{N}_{op}",
                                               "I", m.In(cls),
@@ -160,8 +161,12 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             python_op_name += "_"
         if op == "shl":
             python_op_name = "lshift"
-        if op == "lshr":
+        if op in ["lshr", "ashr"]:
             python_op_name = "rshift"
+        if op in ["urem", "srem"]:
+            python_op_name = "mod"
+        if op in ["udiv", "sdiv"]:
+            python_op_name = "floordiv"
         python_op = getattr(operator, python_op_name)
 
         def simulate(self, value_store, state_store):

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -18,6 +18,7 @@ from .bit import Bit, VCC, GND
 from .array import Array, ArrayMeta
 from .debug import debug_wire
 from .t import Type, Direction
+from .util import primitive_to_python_operator_name_map
 
 
 def _coerce(T: tp.Type['Bits'], val: tp.Any) -> 'Bits':
@@ -137,10 +138,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     @lru_cache(maxsize=None)
     def declare_unary_op(cls, op):
         N = len(cls)
-        if op == "not":
-            python_op_name = "invert"
-        else:
-            python_op_name = op
+        python_op_name = primitive_to_python_operator_name_map.get(op, op)
 
         def simulate(self, value_store, state_store):
             I = cls.hwtypes_T[N](value_store.get_value(self.I))
@@ -158,18 +156,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     @lru_cache(maxsize=None)
     def declare_binary_op(cls, op):
         N = len(cls)
-        python_op_name = {
-            "and": "and_",
-            "or": "or_",
-            "xor": "xor",
-            "shl": "lshift",
-            "lshr": "rshift",
-            "ashr": "rshift",
-            "urem": "mod",
-            "srem": "mod",
-            "udiv": "floordiv",
-            "sdiv": "floordiv",
-        }.get(op, op)
+        python_op_name = primitive_to_python_operator_name_map.get(op, op)
         python_op = getattr(operator, python_op_name)
 
         def simulate(self, value_store, state_store):
@@ -190,16 +177,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     @lru_cache(maxsize=None)
     def declare_compare_op(cls, op):
         N = len(cls)
-        python_op_name = {
-            "ule": "le",
-            "ult": "lt",
-            "uge": "ge",
-            "ugt": "gt",
-            "sle": "le",
-            "slt": "lt",
-            "sge": "ge",
-            "sgt": "gt"
-        }.get(op, op)
+        python_op_name = primitive_to_python_operator_name_map.get(op, op)
 
         def simulate(self, value_store, state_store):
             I0 = cls.hwtypes_T[N](value_store.get_value(self.I0))

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -159,8 +159,8 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def declare_binary_op(cls, op):
         N = len(cls)
         python_op_name = {
-            "and_": "and",
-            "or_": "or",
+            "and": "and_",
+            "or": "or_",
             "xor": "xor",
             "shl": "lshift",
             "lshr": "rshift",

--- a/magma/simulator/python_simulator.py
+++ b/magma/simulator/python_simulator.py
@@ -168,7 +168,7 @@ class PythonSimulator(CircuitSimulator):
         return wrapped
 
     def initialize(self, bit):
-        if isinstance(bit, Array):
+        if isinstance(bit, (Array, Tuple)):
             for b in bit:
                 self.initialize(b)
         else:

--- a/magma/simulator/python_simulator.py
+++ b/magma/simulator/python_simulator.py
@@ -13,6 +13,7 @@ from ..circuit import *
 from ..scope import *
 from ..bit import VCC, GND, Bit, Digital
 from ..array import Array
+from ..tuple import Tuple
 from ..bits import SInt, Bits, UInt
 from hwtypes import BitVector
 import hwtypes
@@ -93,7 +94,7 @@ class ValueStore:
         self.value_map = {}
 
     def value_initialized(self, bit):
-        if isinstance(bit, Array):
+        if isinstance(bit, (Array, Tuple)):
             for b in bit:
                 if not self.value_initialized(b):
                     return False

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -29,7 +29,6 @@ class TransformedCircuit:
 
     def get_new_bit(self, orig_bit, scope):
         assert isinstance(scope, Scope), "Second argument to get_new_bit should be an instance of Scope"
-        print(self.orig_to_new)
         if isinstance(orig_bit, Array):
             arr = []
             for o in orig_bit:

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -29,6 +29,7 @@ class TransformedCircuit:
 
     def get_new_bit(self, orig_bit, scope):
         assert isinstance(scope, Scope), "Second argument to get_new_bit should be an instance of Scope"
+        print(self.orig_to_new)
         if isinstance(orig_bit, Array):
             arr = []
             for o in orig_bit:

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -6,9 +6,10 @@ from .digital import Digital
 from .bit import *
 from .clock import Clock, Enable, Reset, AsyncReset, wiredefaultclock
 from .array import *
+from .tuple import Tuple
 from .wire import wire
-from .conversions import array
-from .ref import DefnRef, InstRef, ArrayRef
+from .conversions import array, tuple_
+from .ref import DefnRef, InstRef, ArrayRef, TupleRef
 from .scope import *
 
 __all__ = ['TransformedCircuit', 'flatten', 'setup_clocks', 'get_uniq_circuits']
@@ -109,9 +110,12 @@ def get_new_source(source_qual, primitive_map, old_circuit, new_circuit):
 
     bitref = old_source.name
     idxs = []
-    while isinstance(bitref, ArrayRef):
+    while isinstance(bitref, (ArrayRef, TupleRef)):
         idxs.append(bitref.index)
-        bitref = bitref.array.name
+        if isinstance(bitref, ArrayRef):
+            bitref = bitref.array.name
+        else:
+            bitref = bitref.tuple.name
 
     if isinstance(bitref, InstRef):
         # Get the primitive outbit is attached to,
@@ -124,17 +128,19 @@ def get_new_source(source_qual, primitive_map, old_circuit, new_circuit):
         defn = bitref.defn.name
         assert defn == old_circuit.name, f"Collapsed bit to circuit other than outermost, {defn} {old_circuit.name}"
         newsource = get_renamed_port(new_circuit, bitref.name)
-    elif isinstance(old_source, Array):
+    elif isinstance(old_source, (Array, Tuple)):
         # Must not be a whole array
         assert bitref.anon()
 
-        new_source_array = []
+        new_src = []
         for s in old_source:
             partial_qual = QualifiedBit(bit=s, scope=scope)
             ns = get_new_source(partial_qual, primitive_map, old_circuit, new_circuit)
-            new_source_array.append(ns)
+            new_src.append(ns)
 
-        return array(new_source_array)
+        if isinstance(old_source, Array):
+            return array(new_src)
+        return tuple_(new_src)
     else:
         assert False, f"Failed to collapse bit {bitref}"
 
@@ -145,8 +151,8 @@ def get_new_source(source_qual, primitive_map, old_circuit, new_circuit):
     return newsource
 
 def wire_new_bit(origbit, newbit, cur_scope, primitive_map, bit_map, old_circuit, flattened_circuit):
-    if isinstance(origbit, Array):
-        assert isinstance(newbit, Array)
+    if isinstance(origbit, (Array, Tuple)):
+        assert isinstance(newbit, type(origbit))
         for x, y in zip(origbit, newbit):
             wire_new_bit(x, y, cur_scope, primitive_map, bit_map, old_circuit, flattened_circuit)
         return

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -46,9 +46,9 @@ class TransformedCircuit:
                 raise MagmaTransformException("Could not find bit in transform mapping. bit={}, scope={}".format(orig_bit, scope))
 
     def set_new_bit(self, orig_bit, orig_scope, new_bit):
-        assert isinstance(new_bit, (Digital, Array)), type(new_bit)
+        assert isinstance(new_bit, (Digital, Array, Tuple)), type(new_bit)
 
-        if isinstance(orig_bit, Array):
+        if isinstance(orig_bit, (Array, Tuple)):
             # Map the individual bits
             for o, n in zip(orig_bit, new_bit):
                 self.orig_to_new[QualifiedBit(bit=o, scope=orig_scope)] = n

--- a/magma/util.py
+++ b/magma/util.py
@@ -1,6 +1,29 @@
 import magma as m
 
 
+primitive_to_python_operator_name_map = {
+    "and": "and_",
+    "or": "or_",
+    "xor": "xor",
+    "shl": "lshift",
+    "lshr": "rshift",
+    "ashr": "rshift",
+    "urem": "mod",
+    "srem": "mod",
+    "udiv": "floordiv",
+    "sdiv": "floordiv",
+    "ule": "le",
+    "ult": "lt",
+    "uge": "ge",
+    "ugt": "gt",
+    "sle": "le",
+    "slt": "lt",
+    "sge": "ge",
+    "sgt": "gt",
+    "not": "invert"
+}
+
+
 def BitOrBits(width):
     if width is None:
         return m.Bit

--- a/tests/test_simulator/test_mux_tuple.py
+++ b/tests/test_simulator/test_mux_tuple.py
@@ -1,0 +1,45 @@
+import magma as m
+from magma.circuit import DeclareCircuit
+from magma.bitutils import clog2
+from hwtypes import BitVector
+from magma.simulator import PythonSimulator
+
+
+def _declare_muxn(height, width):
+    def simulate(self, value_store, state_store):
+        sel = BitVector[clog2(height)](value_store.get_value(self.I.sel))
+        out = BitVector[width](value_store.get_value(self.I.data[int(sel)]))
+        value_store.set_value(self.O, out)
+
+    I_fields = dict(data=m.Array[height, m.Bits[width]],
+                    sel=m.Bits[clog2(height)])
+
+    return DeclareCircuit(f"mux{height}x{width}",
+                          "I", m.In(m.Product.from_fields("anon",
+                                                          I_fields)),
+                          "O", m.Out(m.Bits[width]),
+                          simulate=simulate)
+
+
+def test_muxn():
+    class Main(m.Circuit):
+        IO = ["I0", m.In(m.Bits[5]),
+              "I1", m.In(m.Bits[5]),
+              "S", m.In(m.Bits[1]),
+              "O", m.Out(m.Bits[5])]
+
+        @classmethod
+        def definition(io):
+            in_ = m.namedtuple(data=m.array([io.I0, io.I1]), sel=io.S)
+            io.O @= _declare_muxn(2, 5)()(in_)
+
+    sim = PythonSimulator(Main)
+    for i in range(5):
+        I0 = BitVector.random(5)
+        I1 = BitVector.random(5)
+        S = BitVector.random(1)
+        sim.set_value(Main.I0, I0)
+        sim.set_value(Main.I1, I1)
+        sim.set_value(Main.S, S)
+        sim.evaluate()
+        assert sim.get_value(Main.O) == (I1 if S else I0)

--- a/tests/test_simulator/test_product.py
+++ b/tests/test_simulator/test_product.py
@@ -1,0 +1,23 @@
+import magma as m
+from magma.simulator import PythonSimulator
+
+
+def test_product_python_sim_basic():
+    class T(m.Product):
+        a = m.Bits[4]
+        b = m.Bits[4]
+
+    class Main(m.Circuit):
+        IO = ["I", m.In(T), "O", m.Out(T)]
+
+        @classmethod
+        def definition(io):
+            io.O @= io.I
+
+
+    simulator = PythonSimulator(Main)
+    simulator.set_value(Main.I.a, 5)
+    simulator.set_value(Main.I.b, 11)
+    simulator.evaluate()
+    assert simulator.get_value(Main.I.a) == 5
+    assert simulator.get_value(Main.I.b) == 11

--- a/tests/test_type/test_bit.py
+++ b/tests/test_type/test_bit.py
@@ -3,6 +3,7 @@ import magma as m
 from magma import In, Out, Flip
 from magma.testing import check_files_equal
 from magma.bit import Bit, VCC, GND, Digital
+from magma.simulator import PythonSimulator
 import operator
 BitIn = In(Bit)
 BitOut = Out(Bit)
@@ -262,6 +263,12 @@ EndCircuit()\
     assert check_files_equal(__file__, f"build/TestBitInvert.v",
                              f"gold/TestBitInvert.v")
 
+    sim = PythonSimulator(TestInvert)
+    for I in [0, 1]:
+        sim.set_value(TestInvert.I, I)
+        sim.evaluate()
+        assert sim.get_value(TestInvert.O) == (0 if I else 1)
+
 
 @pytest.mark.parametrize("op", ["and_", "or_", "xor"])
 def test_binary(op):
@@ -284,6 +291,13 @@ EndCircuit()\
     m.compile(f"build/TestBit{clean_op}", TestBinary, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/TestBit{clean_op}.v",
                              f"gold/TestBit{clean_op}.v")
+
+    sim = PythonSimulator(TestBinary)
+    for I0, I1 in zip([0, 1], [0, 1]):
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == getattr(operator, op)(I0, I1)
 
 
 def test_eq():
@@ -309,6 +323,13 @@ EndCircuit()\
     assert check_files_equal(__file__, f"build/TestBiteq.v",
                              f"gold/TestBiteq.v")
 
+    sim = PythonSimulator(TestBinary)
+    for I0, I1 in zip([0, 1], [0, 1]):
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == (I0 == I1)
+
 
 def test_ne():
     class TestBinary(m.Circuit):
@@ -330,6 +351,13 @@ EndCircuit()\
     m.compile(f"build/TestBitne", TestBinary, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/TestBitne.v",
                              f"gold/TestBitne.v")
+
+    sim = PythonSimulator(TestBinary)
+    for I0, I1 in zip([0, 1], [0, 1]):
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == (I0 != I1)
 
 
 def test_ite():
@@ -353,6 +381,14 @@ EndCircuit()\
     m.compile(f"build/TestBitite", TestITE, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/TestBitite.v",
                              f"gold/TestBitite.v")
+
+    sim = PythonSimulator(TestITE)
+    for I0, I1, S in zip([0, 1], [0, 1], [0, 1]):
+        sim.set_value(TestITE.I0, I0)
+        sim.set_value(TestITE.I1, I1)
+        sim.set_value(TestITE.S, S)
+        sim.evaluate()
+        assert sim.get_value(TestITE.O) == (I1 if S else I0)
 
 
 @pytest.mark.parametrize("op", [int, bool])

--- a/tests/test_type/test_bits.py
+++ b/tests/test_type/test_bits.py
@@ -7,6 +7,8 @@ import pytest
 import magma as m
 from magma import Bits
 from magma.testing import check_files_equal
+from magma.simulator import PythonSimulator
+from hwtypes import BitVector
 
 ARRAY2 = m.Array[2, m.Bit]
 ARRAY4 = m.Array[4, m.Bit]
@@ -189,6 +191,13 @@ EndCircuit()\
     assert check_files_equal(__file__, f"build/TestBits{n}Invert.v",
                              f"gold/TestBits{n}Invert.v")
 
+    sim = PythonSimulator(TestInvert)
+    for _ in range(2):
+        I = BitVector.random(n)
+        sim.set_value(TestInvert.I, I)
+        sim.evaluate()
+        assert sim.get_value(TestInvert.O) == ~I
+
 
 @pytest.mark.parametrize("n", [1, 3])
 @pytest.mark.parametrize("op", ["and_", "or_", "xor", "lshift", "rshift"])
@@ -214,6 +223,15 @@ EndCircuit()\
     m.compile(f"build/TestBits{n}{magma_op}", TestBinary, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/TestBits{n}{magma_op}.v",
                              f"gold/TestBits{n}{magma_op}.v")
+
+    sim = PythonSimulator(TestBinary)
+    for _ in range(2):
+        I0 = BitVector.random(n)
+        I1 = BitVector.random(n)
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == getattr(operator, op)(I0, I1)
 
 
 @pytest.mark.parametrize("n", [1, 3])
@@ -244,6 +262,16 @@ EndCircuit()\
     assert check_files_equal(__file__, f"build/TestBits{n}ITE.v",
                              f"gold/TestBits{n}ITE.v")
 
+    sim = PythonSimulator(TestITE)
+    for S in [0, 1]:
+        I0 = BitVector.random(n)
+        I1 = BitVector.random(n)
+        sim.set_value(TestITE.I0, I0)
+        sim.set_value(TestITE.I1, I1)
+        sim.set_value(TestITE.S, S)
+        sim.evaluate()
+        assert sim.get_value(TestITE.O) == (I1 if S else I0)
+
 
 @pytest.mark.parametrize("n", [1, 3])
 def test_eq(n):
@@ -265,6 +293,15 @@ EndCircuit()\
     m.compile(f"build/TestBits{n}eq", TestBinary, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/TestBits{n}eq.v",
                              f"gold/TestBits{n}eq.v")
+
+    sim = PythonSimulator(TestBinary)
+    for i in range(2):
+        I0 = BitVector.random(n)
+        I1 = BitVector.random(n)
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == (I0 == I1)
 
 
 @pytest.mark.parametrize("n", [1, 3])
@@ -288,6 +325,13 @@ EndCircuit()\
     assert check_files_equal(__file__, f"build/TestBits{n}ext.v",
                              f"gold/TestBits{n}ext.v")
 
+    sim = PythonSimulator(TestExt)
+    for i in range(2):
+        I = BitVector.random(n)
+        sim.set_value(TestExt.I, I)
+        sim.evaluate()
+        assert sim.get_value(TestExt.O) == I.zext(3)
+
 
 @pytest.mark.parametrize("n", [1, 3])
 def test_bvcomp(n):
@@ -310,6 +354,15 @@ EndCircuit()\
     assert check_files_equal(__file__, f"build/TestBits{n}bvcomp.v",
                              f"gold/TestBits{n}bvcomp.v")
 
+    sim = PythonSimulator(TestBinary)
+    for i in range(2):
+        I0 = BitVector.random(n)
+        I1 = BitVector.random(n)
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == (I0 == I1)
+
 
 @pytest.mark.parametrize("n", [1, 3])
 @pytest.mark.parametrize("x", [4, 7])
@@ -330,3 +383,10 @@ EndCircuit()\
     m.compile(f"build/TestBits{n}x{x}Repeat", TestRepeat, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/TestBits{n}x{x}Repeat.v",
                              f"gold/TestBits{n}x{x}Repeat.v")
+
+    sim = PythonSimulator(TestRepeat)
+    for i in range(2):
+        I = BitVector.random(n)
+        sim.set_value(TestRepeat.I, I)
+        sim.evaluate()
+        assert sim.get_value(TestRepeat.O) == I.repeat(x)

--- a/tests/test_type/test_sint.py
+++ b/tests/test_type/test_sint.py
@@ -139,6 +139,9 @@ def test_binary(n, op):
     for _ in range(2):
         I0 = SIntVector.random(n)
         I1 = SIntVector.random(n)
+        if op in ["floordiv", "mod"]:
+            while I1 == 0:
+                I1 = SIntVector.random(n)
         sim.set_value(TestBinary.I0, I0)
         sim.set_value(TestBinary.I1, I1)
         sim.evaluate()

--- a/tests/test_type/test_sint.py
+++ b/tests/test_type/test_sint.py
@@ -2,6 +2,8 @@ import operator
 import pytest
 from magma.testing import check_files_equal
 from magma import *
+from magma.simulator import PythonSimulator
+from hwtypes import SIntVector
 
 Array2 = Array[2,Bit]
 Array4 = Array[4,Bit]
@@ -95,6 +97,15 @@ def test_compare(n, op):
         def definition(io):
             io.O <= getattr(operator, op)(io.I0, io.I1)
 
+    sim = PythonSimulator(TestBinary)
+    for _ in range(2):
+        I0 = SIntVector.random(n)
+        I1 = SIntVector.random(n)
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == getattr(operator, op)(I0, I1)
+
     op = {
         "eq": "eq",
         "le": "sle",
@@ -123,6 +134,15 @@ def test_binary(n, op):
         @classmethod
         def definition(io):
             io.O <= getattr(operator, op)(io.I0, io.I1)
+
+    sim = PythonSimulator(TestBinary)
+    for _ in range(2):
+        I0 = SIntVector.random(n)
+        I1 = SIntVector.random(n)
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == getattr(operator, op)(I0, I1)
 
     if op == "floordiv":
         op = "sdiv"
@@ -183,6 +203,16 @@ EndCircuit()\
     assert check_files_equal(__file__, f"build/TestSInt{n}adc.v",
                              f"gold/TestSInt{n}adc.v")
 
+    sim = PythonSimulator(TestBinary)
+    for _ in range(2):
+        I0 = SIntVector.random(n)
+        I1 = SIntVector.random(n)
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == I0 + I1
+        assert sim.get_value(TestBinary.COUT) == (I0.sext(1) + I1.sext(1))[-1]
+
 
 @pytest.mark.parametrize("n", [7, 3])
 def test_negate(n):
@@ -202,3 +232,10 @@ EndCircuit()\
     m.compile(f"build/TestSInt{n}neg", TestNegate, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/TestSInt{n}neg.v",
                              f"gold/TestSInt{n}neg.v")
+
+    sim = PythonSimulator(TestNegate)
+    for _ in range(2):
+        I = SIntVector.random(n)
+        sim.set_value(TestNegate.I, I)
+        sim.evaluate()
+        assert sim.get_value(TestNegate.O) == -I

--- a/tests/test_type/test_uint.py
+++ b/tests/test_type/test_uint.py
@@ -3,7 +3,7 @@ import operator
 import pytest
 from magma import *
 from magma.simulator import PythonSimulator
-from hwtypes import BitVector
+from hwtypes import UIntVector
 
 Array2 = Array[2,Bit]
 Array4 = Array[4,Bit]
@@ -99,8 +99,8 @@ def test_compare(n, op):
 
     sim = PythonSimulator(TestBinary)
     for _ in range(2):
-        I0 = BitVector.random(n)
-        I1 = BitVector.random(n)
+        I0 = UIntVector.random(n)
+        I1 = UIntVector.random(n)
         sim.set_value(TestBinary.I0, I0)
         sim.set_value(TestBinary.I1, I1)
         sim.evaluate()
@@ -137,8 +137,8 @@ def test_binary(n, op):
 
     sim = PythonSimulator(TestBinary)
     for _ in range(2):
-        I0 = BitVector.random(n)
-        I1 = BitVector.random(n)
+        I0 = UIntVector.random(n)
+        I1 = UIntVector.random(n)
         sim.set_value(TestBinary.I0, I0)
         sim.set_value(TestBinary.I1, I1)
         sim.evaluate()
@@ -203,8 +203,8 @@ EndCircuit()\
 
     sim = PythonSimulator(TestBinary)
     for _ in range(2):
-        I0 = BitVector.random(n)
-        I1 = BitVector.random(n)
+        I0 = UIntVector.random(n)
+        I1 = UIntVector.random(n)
         sim.set_value(TestBinary.I0, I0)
         sim.set_value(TestBinary.I1, I1)
         sim.evaluate()

--- a/tests/test_type/test_uint.py
+++ b/tests/test_type/test_uint.py
@@ -139,6 +139,9 @@ def test_binary(n, op):
     for _ in range(2):
         I0 = UIntVector.random(n)
         I1 = UIntVector.random(n)
+        if op in ["floordiv", "mod"]:
+            while I1 == 0:
+                I1 = UIntVector.random(n)
         sim.set_value(TestBinary.I0, I0)
         sim.set_value(TestBinary.I1, I1)
         sim.evaluate()

--- a/tests/test_type/test_uint.py
+++ b/tests/test_type/test_uint.py
@@ -2,6 +2,8 @@ from magma.testing import check_files_equal
 import operator
 import pytest
 from magma import *
+from magma.simulator import PythonSimulator
+from hwtypes import BitVector
 
 Array2 = Array[2,Bit]
 Array4 = Array[4,Bit]
@@ -95,6 +97,15 @@ def test_compare(n, op):
         def definition(io):
             io.O <= getattr(operator, op)(io.I0, io.I1)
 
+    sim = PythonSimulator(TestBinary)
+    for _ in range(2):
+        I0 = BitVector.random(n)
+        I1 = BitVector.random(n)
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == getattr(operator, op)(I0, I1)
+
     op = {
         "eq": "eq",
         "le": "ule",
@@ -123,6 +134,15 @@ def test_binary(n, op):
         @classmethod
         def definition(io):
             io.O <= getattr(operator, op)(io.I0, io.I1)
+
+    sim = PythonSimulator(TestBinary)
+    for _ in range(2):
+        I0 = BitVector.random(n)
+        I1 = BitVector.random(n)
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == getattr(operator, op)(I0, I1)
 
     if op == "floordiv":
         op = "udiv"
@@ -180,3 +200,13 @@ EndCircuit()\
     m.compile(f"build/TestUInt{n}adc", TestBinary, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/TestUInt{n}adc.v",
                              f"gold/TestUInt{n}adc.v")
+
+    sim = PythonSimulator(TestBinary)
+    for _ in range(2):
+        I0 = BitVector.random(n)
+        I1 = BitVector.random(n)
+        sim.set_value(TestBinary.I0, I0)
+        sim.set_value(TestBinary.I1, I1)
+        sim.evaluate()
+        assert sim.get_value(TestBinary.O) == I0 + I1
+        assert sim.get_value(TestBinary.COUT) == (I0.zext(1) + I1.zext(1))[-1]


### PR DESCRIPTION
Adds support for Bit primitives in python simulator, it would be nice if we didn't have to cast to/from the `hwtypes` Bit (i.e. the Python simulator used that internally).  That would vastly simplify this code.  Also the use of `value_store` and `state_store` is a bit cumbersome, ideally it would give us our IO and state values directly (perhaps we could register these up front then just refer to them as simulation method arguments).