### PR TITLE
Allow setting verilog importer at runtime

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -51,7 +51,8 @@ from .braid import *
 from .frontend.verilog import (declare_from_verilog, declare_from_verilog_file,
                                define_from_verilog, define_from_verilog_file,
                                DeclareFromVerilog, DeclareFromVerilogFile,
-                               DefineFromVerilog, DefineFromVerilogFile)
+                               DefineFromVerilog, DefineFromVerilogFile,
+                               set_verilog_importer)
 from .backend.verilog import *
 
 # compile


### PR DESCRIPTION
Exposes a runtime config variable for setting the verilog importer.

Also exposes a convenience function 'set_verilog_importer'.

This change is in prepration for allowing it easier to specify
custom verilog importers.