### PR TITLE
Fix new circuit errors

### DIFF
--- a/magma/placer.py
+++ b/magma/placer.py
@@ -4,6 +4,7 @@ from collections import Counter
 import inspect
 import textwrap
 from .config import get_debug_mode
+from .ref import LazyCircuit
 from .view import InstView
 
 
@@ -124,6 +125,7 @@ class StagedPlacer(ABC):
 
     def place(self, inst):
         self._instances.append(inst)
+        inst.defn = LazyCircuit
 
     def finalize(self, defn):
         if self._finalized:

--- a/magma/ref.py
+++ b/magma/ref.py
@@ -2,7 +2,8 @@ from .compatibility import IntegerTypes
 
 
 __all__ = ['AnonRef', 'InstRef', 'DefnRef', 'ArrayRef', 'TupleRef']
-__all__ += ['LazyDefnRef']
+__all__ += ['LazyDefnRef', 'LazyCircuit']
+
 
 class Ref:
     def __str__(self):
@@ -61,10 +62,11 @@ class DefnRef(Ref):
         return False
 
 
-class LazyDefnRef(DefnRef):
-    class _LazyCircuit:
-        name = ""
+class LazyCircuit:
+    name = ""
 
+
+class LazyDefnRef(DefnRef):
     def __init__(self, name):
         self.name = name
         self._defn = None
@@ -73,7 +75,7 @@ class LazyDefnRef(DefnRef):
     def defn(self):
         if self._defn is not None:
             return self._defn
-        return LazyDefnRef._LazyCircuit
+        return LazyCircuit
 
     def qualifiedname(self, sep="."):
         return super().qualifiedname(sep)


### PR DESCRIPTION
See the tests in the PR diff for what this fixes.

Previously you'd get `AttributeError: 'NoneType' object has no attribute 'name'`