### PR TITLE
Add logic to invoke combinational function in Python

### DIFF
--- a/magma/syntax/combinational.py
+++ b/magma/syntax/combinational.py
@@ -13,7 +13,7 @@ import types
 from magma.debug import debug_info
 from magma.ssa import convert_tree_to_ssa
 from magma.config import get_debug_mode
-from ..t import Type
+from ..t import Type, MagmaProtocol
 import itertools
 import typing
 from ast_tools.stack import _SKIP_FRAME_DEBUG_STMT, SymbolTable
@@ -239,11 +239,11 @@ def _combinational(defn_env: dict, fn: types.FunctionType):
     @functools.wraps(fn)
     def func(*args, **kwargs):
         if (len(args) + len(kwargs) and
-                not any(isinstance(x, Type) for x in args) and
-                not any(isinstance(x, Type) for x in kwargs.values())):
-            # If not called with at least one magma value, use the Python
-            # implementation
-            return fn(*args, **kwargs)
+            not any(isinstance(x, (Type, MagmaProtocol)) for x in args +
+                    list(kwargs.values()))):
+                # If not called with at least one magma value, use the Python
+                # implementation
+                return fn(*args, **kwargs)
         return circuit_def()(*args, **kwargs)
     func.__name__ = fn.__name__
     func.__qualname__ = fn.__name__

--- a/magma/syntax/combinational.py
+++ b/magma/syntax/combinational.py
@@ -13,6 +13,7 @@ import types
 from magma.debug import debug_info
 from magma.ssa import convert_tree_to_ssa
 from magma.config import get_debug_mode
+from ..t import Type
 import itertools
 import typing
 from ast_tools.stack import _SKIP_FRAME_DEBUG_STMT, SymbolTable
@@ -237,6 +238,11 @@ def _combinational(defn_env: dict, fn: types.FunctionType):
 
     @functools.wraps(fn)
     def func(*args, **kwargs):
+        if (not any(isinstance(x, Type) for x in args) and not
+                any(isinstance(x, Type) for x in kwargs.values())):
+            # If not called with at least one magma value, use the Python
+            # implementation
+            return fn(*args, **kwargs)
         return circuit_def()(*args, **kwargs)
     func.__name__ = fn.__name__
     func.__qualname__ = fn.__name__

--- a/magma/syntax/combinational.py
+++ b/magma/syntax/combinational.py
@@ -240,7 +240,7 @@ def _combinational(defn_env: dict, fn: types.FunctionType):
     def func(*args, **kwargs):
         if (len(args) + len(kwargs) and
             not any(isinstance(x, (Type, MagmaProtocol)) for x in args +
-                    list(kwargs.values()))):
+                    tuple(kwargs.values()))):
                 # If not called with at least one magma value, use the Python
                 # implementation
                 return fn(*args, **kwargs)

--- a/magma/syntax/combinational.py
+++ b/magma/syntax/combinational.py
@@ -238,8 +238,9 @@ def _combinational(defn_env: dict, fn: types.FunctionType):
 
     @functools.wraps(fn)
     def func(*args, **kwargs):
-        if (not any(isinstance(x, Type) for x in args) and not
-                any(isinstance(x, Type) for x in kwargs.values())):
+        if (len(args) + len(kwargs) and
+                not any(isinstance(x, Type) for x in args) and
+                not any(isinstance(x, Type) for x in kwargs.values())):
             # If not called with at least one magma value, use the Python
             # implementation
             return fn(*args, **kwargs)


### PR DESCRIPTION
This adds logic to dispatch on the arguments of a combinational function.  If no magma values are found, it will use the underlying python code to execute (allows for polymorphism over python versus magma values).

Since magma circuits can sometimes mix python constants with magma values, if any magma values are found, it will use the magma logic.