### PR TITLE
Fix wire regression with tuple

### DIFF
--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -266,7 +266,7 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
         if len(ts) == len(self) and self.iswhole(ts):
             return ts[0].name.tuple
 
-        return tuple_(dict(zip(self.keys(),ts)))
+        return type(self).flip()(*ts)
 
     def value(self):
         ts = [t.value() for t in self.ts]
@@ -278,7 +278,7 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
         if len(ts) == len(self) and self.iswhole(ts):
             return ts[0].name.tuple
 
-        return tuple_(dict(zip(self.keys(),ts)))
+        return type(self).flip()(*ts)
 
     def flatten(self):
         return sum([t.flatten() for t in self.ts], [])


### PR DESCRIPTION
This hotfixes an issue with compiling the FB design.

The Array value/trace logic was updated as a part of https://github.com/phanrahan/magma/commit/0faae41b1cd5dbd635aed8257a08bcf8096ef222#diff-835ddd87e75de5f378b2918908f1c13fR342 and https://github.com/phanrahan/magma/commit/ac17a2f6dc11d5ddc7df9de2bce8d391362f250b

Specifically the use of `type(self).flip()` here: https://github.com/phanrahan/magma/commit/0faae41b1cd5dbd635aed8257a08bcf8096ef222#diff-835ddd87e75de5f378b2918908f1c13fR342

This updates the tuple logic to match.  We should add a test for this, but want to get this code out asap to unblock their version upgrade.
