### PR TITLE
Init coroutine syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
 - pip install twine
 - pip install python-coveralls
 - pip install pytest-cov pytest-codestyle fault
+- pip install -r requirements.txt
 - pip install -e .
 script:
 - py.test --cov magma -v --cov-report term-missing tests

--- a/magma/ssa/ssa.py
+++ b/magma/ssa/ssa.py
@@ -140,7 +140,7 @@ def convert_tree_to_ssa(tree: ast.AST, defn_env: dict, phi_name: str = "phi"):
         else:
             cond = conds[-1]
             for c in conds[:-1]:
-                c = ast.BinOp(cond, ast.BitAnd(), c)
+                cond = ast.BinOp(cond, ast.BitAnd(), c)
             if isinstance(tree.returns, ast.Tuple):
                 for i in range(len(tree.returns.elts)):
                     tree.body.append(ast.Assign(
@@ -152,14 +152,14 @@ def convert_tree_to_ssa(tree: ast.AST, defn_env: dict, phi_name: str = "phi"):
                                               ast.Index(ast.Num(i)),
                                               ast.Load())
                             ], ast.Load()),
-                            c], []))
+                            cond], []))
                     )
             else:
                 tree.body.append(ast.Assign(
                     [ast.Name("O", ast.Store())],
                     ast.Call(ast.Name(phi_name, ast.Load()), [
                         ast.List([ast.Name("O", ast.Load()), ast.Name(name, ast.Load())],
-                                 ast.Load()), c], []))
+                                 ast.Load()), cond], []))
                 )
     return tree, ssa_visitor.args
 

--- a/magma/ssa/ssa.py
+++ b/magma/ssa/ssa.py
@@ -140,7 +140,7 @@ def convert_tree_to_ssa(tree: ast.AST, defn_env: dict, phi_name: str = "phi"):
         else:
             cond = conds[-1]
             for c in conds[:-1]:
-                c = ast.BinOp(cond, ast.And(), c)
+                c = ast.BinOp(cond, ast.BitAnd(), c)
             if isinstance(tree.returns, ast.Tuple):
                 for i in range(len(tree.returns.elts)):
                     tree.body.append(ast.Assign(
@@ -152,14 +152,14 @@ def convert_tree_to_ssa(tree: ast.AST, defn_env: dict, phi_name: str = "phi"):
                                               ast.Index(ast.Num(i)),
                                               ast.Load())
                             ], ast.Load()),
-                            cond], []))
+                            c], []))
                     )
             else:
                 tree.body.append(ast.Assign(
                     [ast.Name("O", ast.Store())],
                     ast.Call(ast.Name(phi_name, ast.Load()), [
                         ast.List([ast.Name("O", ast.Load()), ast.Name(name, ast.Load())],
-                                 ast.Load()), cond], []))
+                                 ast.Load()), c], []))
                 )
     return tree, ssa_visitor.args
 

--- a/magma/ssa/ssa.py
+++ b/magma/ssa/ssa.py
@@ -66,12 +66,8 @@ class SSAVisitor(ast.NodeTransformer):
 
         if node.orelse:
             self.last_name = false_name
-            # Using explicit Not because invert is not defined during magma
-            # tests
-            # self.cond_stack[-1] = ast.UnaryOp(ast.Invert(),
-            #                                   self.cond_stack[-1])
-            self.cond_stack[-1] = ast.parse(
-                f"Not()({astor.to_source(self.cond_stack[-1]).rstrip()})")
+            self.cond_stack[-1] = ast.UnaryOp(ast.Invert(),
+                                              self.cond_stack[-1])
             result += flatten([self.visit(s) for s in node.orelse])
             false_name = dict(self.last_name)
 

--- a/magma/syntax/__init__.py
+++ b/magma/syntax/__init__.py
@@ -1,2 +1,3 @@
 from magma.syntax.combinational import combinational
 from magma.syntax.verilog import build_kratos_debug_info
+from .coroutine import coroutine

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -1,7 +1,45 @@
+import ast
+import copy
+
 import astor
 from staticfg import CFGBuilder
-import ast
+from staticfg.builder import invert
+
 from ..ast_utils import get_ast
+from ..bitutils import clog2
+
+
+class RemoveIfTrues(ast.NodeTransformer):
+    def visit_If(self, node):
+        if isinstance(node.test, ast.NameConstant) and node.test.value is True:
+            return node.body
+        return self.generic_visit(node)
+
+
+class MergeInverseIf(ast.NodeTransformer):
+    def visit(self, node):
+        if hasattr(node, 'body'):
+            node.body = self.visit_body(node.body)
+        return self.generic_visit(node)
+
+    def visit_body(self, body):
+        new_body = []
+        skip_next = False
+        for i, node in enumerate(body):
+            if skip_next:
+                continue
+            new_body.append(node)
+            if i == len(body) - 1:
+                break
+            if (isinstance(node, ast.If) and isinstance(body[i + 1], ast.If)
+                    and ast.dump(invert(node.test)) ==
+                        ast.dump(body[i + 1].test)):
+                node.orelse = body[i + 1].body
+                skip_next = True
+            else:
+                skip_next = False
+        return new_body
+
 
 
 def is_yield(statement):
@@ -12,24 +50,76 @@ def is_yield(statement):
 def collect_paths_to_yield(start_idx, block):
     path = []
     for statement in block.statements[start_idx:]:
+        path.append(statement)
         if is_yield(statement):
-            return path
-        else:
-            path.append(statement)
-    return sum(path + p for p in  collect_paths_to_yield(0, exit.target) for
-               exit in block.exits)
+            return [path]
+    paths = []
+    for exit in block.exits:
+        _path = path
+        if exit.exitcase is not None:
+            assert len(_path) == 1
+            _path = _path.copy()
+            _path[0] = copy.copy(_path[0])
+            _path[0].exitcase = exit.exitcase
+        paths.extend(_path + p for p in collect_paths_to_yield(0, exit.target))
+    return paths
 
 
 def coroutine(fn):
     tree = get_ast(fn).body[0]
+    assert (isinstance(tree.body[0], ast.FunctionDef) and
+            tree.body[0].name == "__init__")
+    assert (isinstance(tree.body[1], ast.FunctionDef) and
+            tree.body[1].name == "__call__")
     call_method = tree.body[1]
+    # insert while true
+    call_method.body = [ast.While(ast.NameConstant(True), call_method.body, [])]
     cfg = CFGBuilder().build(call_method.name, call_method)
     # cfg.build_visual(tree.name, 'pdf')
-    paths = {}
+    yield_paths = {}
+    yield_id_map = {}
     for block in cfg:
         for i, statement in enumerate(block.statements):
             if is_yield(statement):
+                yield_id_map[statement] = len(yield_id_map)
                 paths = collect_paths_to_yield(i + 1, block)
-                print(paths)
+                yield_paths[statement] = paths
+    tree.body[0].body.append(ast.parse(
+        f"self.yield_state: m.Bits[{clog2(len(yield_id_map))}] = 0"
+    ).body[0])
+    call_method.body = []
+    for i, (yield_, paths) in enumerate(yield_paths.items()):
+        test = ast.parse(
+            f"self.yield_state == {yield_id_map[yield_]}"
+        ).body[0].value
+        if i == 0:
+            curr_body = []
+            call_method.body.append(ast.If(test, curr_body, []))
+            prev_if = call_method.body[0]
+        elif i == len(yield_paths) - 1:
+            curr_body = prev_if.orelse
+        else:
+            curr_body = []
+            prev_if.orelse.append(ast.If(test, curr_body, []))
+            prev_if = prev_if.orelse[-1]
+        for path in paths:
+            body = curr_body
+            end_yield = path[-1]
+            for statement in path[:-1]:
+                body.append(copy.deepcopy(statement))
+                if isinstance(statement, ast.While):
+                    body[-1] = ast.If(body[-1].test, body[-1].body, [])
+                    body[-1].exitcase = statement.exitcase
+                if isinstance(statement, (ast.If, ast.While)):
+                    body[-1].test = body[-1].exitcase
+                    body[-1].body = []
+                    body = body[-1].body
+            body.append(ast.parse(
+                f"self.yield_state = {yield_id_map[end_yield]}"
+            ).body[0])
+            body.append(ast.Return(end_yield.value.value))
+    call_method = RemoveIfTrues().visit(call_method)
+    call_method = MergeInverseIf().visit(call_method)
+    tree.decorator_list = [ast.parse(f"m.circuit.sequential").body[0].value]
+    print(astor.to_source(tree))
     raise Exception()
-

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -197,7 +197,9 @@ def _coroutine(defn_env, fn):
     call_method = MergeInverseIf().visit(call_method)
 
     # Sequential stage
-    tree.decorator_list = [ast.parse(f"m.circuit.sequential").body[0].value]
+    tree.decorator_list = [ast.parse(
+        f"m.circuit.sequential(async_reset=True)"
+    ).body[0].value]
 
     # print(astor.to_source(tree))
     circuit = compile_function_to_file(tree, tree.name, defn_env)

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -59,21 +59,19 @@ class MergeInverseIf(ast.NodeTransformer):
             if i == len(body) - 1:
                 break
             if (isinstance(node, ast.If) and isinstance(body[i + 1], ast.If)
-                    and ast.dump(invert(node.test)) ==
-                        ast.dump(body[i + 1].test)):
-                node.orelse = body[i + 1].body
-                skip_next = True
+                and ast.dump(invert(node.test)) == ast.dump(body[i + 1].test)):
+                    node.orelse = body[i + 1].body
+                    skip_next = True
             else:
                 skip_next = False
         return new_body
-
 
 
 def is_yield(statement):
     """
     Is this a statement of the form `yield <expr>`
     """
-    return (isinstance(statement, ast.Expr) and \
+    return (isinstance(statement, ast.Expr) and
             isinstance(statement.value, ast.Yield))
 
 
@@ -96,8 +94,9 @@ def collect_paths_to_yield(start_idx, block):
     for exit in block.exits:
         _path = path
         if exit.exitcase is not None:
-            assert (len(_path) == 1 and
-                    isinstance(_path[0], (ast.If, ast.While))), "Expect branch"
+            assert (len(_path) == 1
+                    and isinstance(_path[0], (ast.If, ast.While))), \
+                "Expect branch"
             _path = _path.copy()
             _path[0] = copy.copy(_path[0])
             _path[0].test = exit.exitcase
@@ -109,10 +108,10 @@ def _coroutine(defn_env, fn):
     tree = get_ast(fn).body[0]
 
     # validate assumptions on program format
-    assert (isinstance(tree.body[0], ast.FunctionDef) and
-            tree.body[0].name == "__init__")
-    assert (isinstance(tree.body[1], ast.FunctionDef) and
-            tree.body[1].name == "__call__")
+    assert (isinstance(tree.body[0], ast.FunctionDef)
+            and tree.body[0].name == "__init__")
+    assert (isinstance(tree.body[1], ast.FunctionDef)
+            and tree.body[1].name == "__call__")
     call_method = tree.body[1]
 
     # insert while true to simplify CFG construction
@@ -185,7 +184,7 @@ def _coroutine(defn_env, fn):
             # of the path
             body.append(ast.parse(
                 f"self.yield_state = m.bits({yield_id_map[end_yield]}, "
-                                          f"{yield_state_width})"
+                f"{yield_state_width})"
             ).body[0])
 
             # Return the value of the original end yield

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -1,0 +1,35 @@
+import astor
+from staticfg import CFGBuilder
+import ast
+from ..ast_utils import get_ast
+
+
+def is_yield(statement):
+    return (isinstance(statement, ast.Expr) and \
+            isinstance(statement.value, ast.Yield))
+
+
+def collect_paths_to_yield(start_idx, block):
+    path = []
+    for statement in block.statements[start_idx:]:
+        if is_yield(statement):
+            return path
+        else:
+            path.append(statement)
+    return sum(path + p for p in  collect_paths_to_yield(0, exit.target) for
+               exit in block.exits)
+
+
+def coroutine(fn):
+    tree = get_ast(fn).body[0]
+    call_method = tree.body[1]
+    cfg = CFGBuilder().build(call_method.name, call_method)
+    # cfg.build_visual(tree.name, 'pdf')
+    paths = {}
+    for block in cfg:
+        for i, statement in enumerate(block.statements):
+            if is_yield(statement):
+                paths = collect_paths_to_yield(i + 1, block)
+                print(paths)
+    raise Exception()
+

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -59,9 +59,10 @@ class MergeInverseIf(ast.NodeTransformer):
             if i == len(body) - 1:
                 break
             if (isinstance(node, ast.If) and isinstance(body[i + 1], ast.If)
-                and ast.dump(invert(node.test)) == ast.dump(body[i + 1].test)):
-                    node.orelse = body[i + 1].body
-                    skip_next = True
+                    and ast.dump(invert(node.test))
+                    == ast.dump(body[i + 1].test)):
+                node.orelse = body[i + 1].body
+                skip_next = True
             else:
                 skip_next = False
         return new_body
@@ -71,8 +72,8 @@ def is_yield(statement):
     """
     Is this a statement of the form `yield <expr>`
     """
-    return (isinstance(statement, ast.Expr) and
-            isinstance(statement.value, ast.Yield))
+    return (isinstance(statement, ast.Expr)
+            and isinstance(statement.value, ast.Yield))
 
 
 def collect_paths_to_yield(start_idx, block):

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -115,9 +115,6 @@ def _coroutine(defn_env, fn):
             and tree.body[1].name == "__call__")
     call_method = tree.body[1]
 
-    # insert while true to simplify CFG construction
-    call_method.body = [ast.While(ast.NameConstant(True), call_method.body, [])]
-
     # build cfg
     cfg = CFGBuilder().build(call_method.name, call_method)
     # debug cfg visualizer

--- a/magma/syntax/sequential.py
+++ b/magma/syntax/sequential.py
@@ -48,7 +48,8 @@ class RewriteSelfAttributes(ast.NodeTransformer):
                 return ast.Tuple([ast.Name(f"self_{attr}_{output}",
                                            ast.Load()) for output in outputs],
                                  ast.Load())
-        elif (isinstance(node.func.value, ast.Attribute) and
+        elif (isinstance(node.func, ast.Attribute) and
+                isinstance(node.func.value, ast.Attribute) and
                 isinstance(node.func.value.value, ast.Name) and
                 node.func.value.value.id == "self" and
                 node.func.attr == "prev"):

--- a/magma/syntax/sequential.py
+++ b/magma/syntax/sequential.py
@@ -48,6 +48,11 @@ class RewriteSelfAttributes(ast.NodeTransformer):
                 return ast.Tuple([ast.Name(f"self_{attr}_{output}",
                                            ast.Load()) for output in outputs],
                                  ast.Load())
+        elif (isinstance(node.func.value, ast.Attribute) and
+                isinstance(node.func.value.value, ast.Name) and
+                node.func.value.value.id == "self" and
+                node.func.attr == "prev"):
+            return ast.Name(f"self_{node.func.value.attr}_O", ast.Load())
         else:
             self.generic_visit(node)
         return node

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e git://github.com/leonardt/staticfg.git#egg=staticfg

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
         "coreir>=2.0.*",
         "hwtypes>=1.0.*",
         "ast_tools>=0.0.10",
-        "kratos"
+        "kratos",
+        "staticfg"
     ],
     python_requires='>=3.6',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setup(
         "coreir>=2.0.*",
         "hwtypes>=1.0.*",
         "ast_tools>=0.0.10",
-        "kratos",
-        "staticfg"
+        "kratos"
     ],
     python_requires='>=3.6',
     long_description=long_description,

--- a/tests/test_syntax/gold/RegisterMode.json
+++ b/tests/test_syntax/gold/RegisterMode.json
@@ -199,13 +199,100 @@
             "genargs":{"width":["Int",2]},
             "modargs":{"value":[["BitVector",2],"2'h1"]}
           },
+          "magma_Bit_and_inst0":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst1":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst10":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst11":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst2":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst3":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst4":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst5":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst6":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst7":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst8":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst9":{
+            "modref":"corebit.and"
+          },
           "magma_Bit_not_inst0":{
             "modref":"corebit.not"
           },
           "magma_Bit_not_inst1":{
             "modref":"corebit.not"
           },
+          "magma_Bit_not_inst10":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst11":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst12":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst13":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst14":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst15":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst16":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst17":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst18":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst19":{
+            "modref":"corebit.not"
+          },
           "magma_Bit_not_inst2":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst20":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst21":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst22":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst23":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst24":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst25":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst26":{
             "modref":"corebit.not"
           },
           "magma_Bit_not_inst3":{
@@ -220,10 +307,34 @@
           "magma_Bit_not_inst6":{
             "modref":"corebit.not"
           },
+          "magma_Bit_not_inst7":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst8":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst9":{
+            "modref":"corebit.not"
+          },
           "magma_Bit_xor_inst0":{
             "modref":"corebit.xor"
           },
           "magma_Bit_xor_inst1":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst10":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst11":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst12":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst13":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst14":{
             "modref":"corebit.xor"
           },
           "magma_Bit_xor_inst2":{
@@ -239,6 +350,15 @@
             "modref":"corebit.xor"
           },
           "magma_Bit_xor_inst6":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst7":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst8":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst9":{
             "modref":"corebit.xor"
           },
           "magma_Bits_2_eq_inst0":{
@@ -262,6 +382,22 @@
             "genargs":{"width":["Int",2]}
           },
           "magma_Bits_2_eq_inst13":{
+            "genref":"coreir.eq",
+            "genargs":{"width":["Int",2]}
+          },
+          "magma_Bits_2_eq_inst14":{
+            "genref":"coreir.eq",
+            "genargs":{"width":["Int",2]}
+          },
+          "magma_Bits_2_eq_inst15":{
+            "genref":"coreir.eq",
+            "genargs":{"width":["Int",2]}
+          },
+          "magma_Bits_2_eq_inst16":{
+            "genref":"coreir.eq",
+            "genargs":{"width":["Int",2]}
+          },
+          "magma_Bits_2_eq_inst17":{
             "genref":"coreir.eq",
             "genargs":{"width":["Int",2]}
           },
@@ -311,13 +447,13 @@
           ["self.clk_en","Mux2xOutBit_inst3.I0"],
           ["bit_const_0_None.out","Mux2xOutBit_inst3.I1"],
           ["Mux2xOutBit_inst4.I0","Mux2xOutBit_inst3.O"],
-          ["magma_Bits_2_eq_inst7.out","Mux2xOutBit_inst3.S"],
+          ["magma_Bit_and_inst3.out","Mux2xOutBit_inst3.S"],
           ["bit_const_0_None.out","Mux2xOutBit_inst4.I1"],
           ["Mux2xOutBit_inst5.I0","Mux2xOutBit_inst4.O"],
-          ["magma_Bits_2_eq_inst11.out","Mux2xOutBit_inst4.S"],
+          ["magma_Bit_and_inst9.out","Mux2xOutBit_inst4.S"],
           ["bit_const_1_None.out","Mux2xOutBit_inst5.I1"],
           ["self.O1","Mux2xOutBit_inst5.O"],
-          ["magma_Bit_not_inst4.out","Mux2xOutBit_inst5.S"],
+          ["magma_Bit_not_inst24.out","Mux2xOutBit_inst5.S"],
           ["self.value","Mux2xOutBits4_inst0.I0"],
           ["self.value","Mux2xOutBits4_inst0.I1"],
           ["Mux2xOutBits4_inst2.I0","Mux2xOutBits4_inst0.O"],
@@ -329,21 +465,21 @@
           ["Mux2xOutBits4_inst7.O","Mux2xOutBits4_inst10.I0"],
           ["self.const_","Mux2xOutBits4_inst10.I1"],
           ["Mux2xOutBits4_inst13.I0","Mux2xOutBits4_inst10.O"],
-          ["magma_Bits_2_eq_inst12.out","Mux2xOutBits4_inst10.S"],
+          ["magma_Bit_and_inst10.out","Mux2xOutBits4_inst10.S"],
           ["Mux2xOutBits4_inst8.O","Mux2xOutBits4_inst11.I0"],
           ["self.self_register_O","Mux2xOutBits4_inst11.I1"],
           ["Mux2xOutBits4_inst14.I0","Mux2xOutBits4_inst11.O"],
-          ["magma_Bits_2_eq_inst13.out","Mux2xOutBits4_inst11.S"],
+          ["magma_Bit_and_inst11.out","Mux2xOutBits4_inst11.S"],
           ["Mux2xOutBits4_inst9.O","Mux2xOutBits4_inst12.I0"],
           ["self.config_data","Mux2xOutBits4_inst12.I1"],
           ["self.O0","Mux2xOutBits4_inst12.O"],
-          ["magma_Bit_not_inst3.out","Mux2xOutBits4_inst12.S"],
+          ["magma_Bit_not_inst23.out","Mux2xOutBits4_inst12.S"],
           ["self.self_register_O","Mux2xOutBits4_inst13.I1"],
           ["self.O2","Mux2xOutBits4_inst13.O"],
-          ["magma_Bit_not_inst5.out","Mux2xOutBits4_inst13.S"],
+          ["magma_Bit_not_inst25.out","Mux2xOutBits4_inst13.S"],
           ["self.self_register_O","Mux2xOutBits4_inst14.I1"],
           ["self.O3","Mux2xOutBits4_inst14.O"],
-          ["magma_Bit_not_inst6.out","Mux2xOutBits4_inst14.S"],
+          ["magma_Bit_not_inst26.out","Mux2xOutBits4_inst14.S"],
           ["self.value","Mux2xOutBits4_inst2.I1"],
           ["Mux2xOutBits4_inst4.I0","Mux2xOutBits4_inst2.O"],
           ["magma_Bits_2_eq_inst3.out","Mux2xOutBits4_inst2.S"],
@@ -357,56 +493,124 @@
           ["self.value","Mux2xOutBits4_inst6.I0"],
           ["self.value","Mux2xOutBits4_inst6.I1"],
           ["Mux2xOutBits4_inst9.I0","Mux2xOutBits4_inst6.O"],
-          ["magma_Bits_2_eq_inst6.out","Mux2xOutBits4_inst6.S"],
+          ["magma_Bit_and_inst1.out","Mux2xOutBits4_inst6.S"],
           ["self.self_register_O","Mux2xOutBits4_inst7.I0"],
           ["self.value","Mux2xOutBits4_inst7.I1"],
-          ["magma_Bits_2_eq_inst8.out","Mux2xOutBits4_inst7.S"],
+          ["magma_Bit_and_inst5.out","Mux2xOutBits4_inst7.S"],
           ["self.self_register_O","Mux2xOutBits4_inst8.I0"],
           ["self.self_register_O","Mux2xOutBits4_inst8.I1"],
-          ["magma_Bits_2_eq_inst9.out","Mux2xOutBits4_inst8.S"],
+          ["magma_Bit_and_inst7.out","Mux2xOutBits4_inst8.S"],
           ["self.value","Mux2xOutBits4_inst9.I1"],
-          ["magma_Bits_2_eq_inst10.out","Mux2xOutBits4_inst9.S"],
+          ["magma_Bit_and_inst8.out","Mux2xOutBits4_inst9.S"],
           ["magma_Bit_xor_inst0.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst1.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst10.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst11.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst12.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst13.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst14.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst2.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst3.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst4.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst5.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst6.in1","bit_const_1_None.out"],
-          ["magma_Bits_2_eq_inst10.in1","const_0_2.out"],
+          ["magma_Bit_xor_inst7.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst8.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst9.in1","bit_const_1_None.out"],
           ["magma_Bits_2_eq_inst11.in1","const_0_2.out"],
-          ["magma_Bits_2_eq_inst12.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst13.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst14.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst15.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst16.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst17.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst3.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst4.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst5.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst7.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst9.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst0.in1","const_1_2.out"],
           ["magma_Bits_2_eq_inst1.in1","const_1_2.out"],
+          ["magma_Bits_2_eq_inst10.in1","const_1_2.out"],
+          ["magma_Bits_2_eq_inst12.in1","const_1_2.out"],
           ["magma_Bits_2_eq_inst2.in1","const_1_2.out"],
           ["magma_Bits_2_eq_inst6.in1","const_1_2.out"],
-          ["magma_Bits_2_eq_inst7.in1","const_1_2.out"],
           ["magma_Bits_2_eq_inst8.in1","const_1_2.out"],
-          ["magma_Bits_2_eq_inst9.in1","const_1_2.out"],
+          ["magma_Bits_2_eq_inst6.out","magma_Bit_and_inst0.in0"],
+          ["magma_Bit_not_inst4.out","magma_Bit_and_inst0.in1"],
+          ["magma_Bit_and_inst1.in0","magma_Bit_and_inst0.out"],
+          ["magma_Bit_not_inst5.out","magma_Bit_and_inst1.in1"],
+          ["magma_Bits_2_eq_inst16.out","magma_Bit_and_inst10.in0"],
+          ["magma_Bit_not_inst20.out","magma_Bit_and_inst10.in1"],
+          ["magma_Bits_2_eq_inst17.out","magma_Bit_and_inst11.in0"],
+          ["magma_Bit_not_inst22.out","magma_Bit_and_inst11.in1"],
+          ["magma_Bits_2_eq_inst8.out","magma_Bit_and_inst2.in0"],
+          ["magma_Bit_not_inst7.out","magma_Bit_and_inst2.in1"],
+          ["magma_Bit_and_inst3.in0","magma_Bit_and_inst2.out"],
+          ["magma_Bit_not_inst8.out","magma_Bit_and_inst3.in1"],
+          ["magma_Bits_2_eq_inst10.out","magma_Bit_and_inst4.in0"],
+          ["magma_Bit_not_inst10.out","magma_Bit_and_inst4.in1"],
+          ["magma_Bit_and_inst5.in0","magma_Bit_and_inst4.out"],
+          ["magma_Bit_not_inst11.out","magma_Bit_and_inst5.in1"],
+          ["magma_Bits_2_eq_inst12.out","magma_Bit_and_inst6.in0"],
+          ["magma_Bit_not_inst13.out","magma_Bit_and_inst6.in1"],
+          ["magma_Bit_and_inst7.in0","magma_Bit_and_inst6.out"],
+          ["magma_Bit_not_inst14.out","magma_Bit_and_inst7.in1"],
+          ["magma_Bits_2_eq_inst14.out","magma_Bit_and_inst8.in0"],
+          ["magma_Bit_not_inst16.out","magma_Bit_and_inst8.in1"],
+          ["magma_Bits_2_eq_inst15.out","magma_Bit_and_inst9.in0"],
+          ["magma_Bit_not_inst18.out","magma_Bit_and_inst9.in1"],
           ["magma_Bit_xor_inst0.out","magma_Bit_not_inst0.in"],
           ["magma_Bit_xor_inst1.out","magma_Bit_not_inst1.in"],
+          ["magma_Bit_not_inst9.out","magma_Bit_not_inst10.in"],
+          ["magma_Bits_2_eq_inst11.out","magma_Bit_not_inst11.in"],
+          ["magma_Bit_xor_inst6.out","magma_Bit_not_inst12.in"],
+          ["magma_Bit_not_inst13.in","magma_Bit_not_inst12.out"],
+          ["magma_Bits_2_eq_inst13.out","magma_Bit_not_inst14.in"],
+          ["magma_Bit_xor_inst7.out","magma_Bit_not_inst15.in"],
+          ["magma_Bit_not_inst16.in","magma_Bit_not_inst15.out"],
+          ["magma_Bit_xor_inst8.out","magma_Bit_not_inst17.in"],
+          ["magma_Bit_not_inst18.in","magma_Bit_not_inst17.out"],
+          ["magma_Bit_xor_inst9.out","magma_Bit_not_inst19.in"],
+          ["magma_Bit_not_inst20.in","magma_Bit_not_inst19.out"],
           ["magma_Bit_xor_inst2.out","magma_Bit_not_inst2.in"],
+          ["magma_Bit_xor_inst10.out","magma_Bit_not_inst21.in"],
+          ["magma_Bit_not_inst22.in","magma_Bit_not_inst21.out"],
+          ["magma_Bit_xor_inst11.out","magma_Bit_not_inst23.in"],
+          ["magma_Bit_xor_inst12.out","magma_Bit_not_inst24.in"],
+          ["magma_Bit_xor_inst13.out","magma_Bit_not_inst25.in"],
+          ["magma_Bit_xor_inst14.out","magma_Bit_not_inst26.in"],
           ["magma_Bit_xor_inst3.out","magma_Bit_not_inst3.in"],
-          ["magma_Bit_xor_inst4.out","magma_Bit_not_inst4.in"],
-          ["magma_Bit_xor_inst5.out","magma_Bit_not_inst5.in"],
-          ["magma_Bit_xor_inst6.out","magma_Bit_not_inst6.in"],
+          ["magma_Bit_not_inst4.in","magma_Bit_not_inst3.out"],
+          ["magma_Bits_2_eq_inst7.out","magma_Bit_not_inst5.in"],
+          ["magma_Bit_xor_inst4.out","magma_Bit_not_inst6.in"],
+          ["magma_Bit_not_inst7.in","magma_Bit_not_inst6.out"],
+          ["magma_Bits_2_eq_inst9.out","magma_Bit_not_inst8.in"],
+          ["magma_Bit_xor_inst5.out","magma_Bit_not_inst9.in"],
           ["self.config_we","magma_Bit_xor_inst0.in0"],
           ["self.config_we","magma_Bit_xor_inst1.in0"],
+          ["self.config_we","magma_Bit_xor_inst10.in0"],
+          ["self.config_we","magma_Bit_xor_inst11.in0"],
+          ["self.config_we","magma_Bit_xor_inst12.in0"],
+          ["self.config_we","magma_Bit_xor_inst13.in0"],
+          ["self.config_we","magma_Bit_xor_inst14.in0"],
           ["self.config_we","magma_Bit_xor_inst2.in0"],
           ["self.config_we","magma_Bit_xor_inst3.in0"],
           ["self.config_we","magma_Bit_xor_inst4.in0"],
           ["self.config_we","magma_Bit_xor_inst5.in0"],
           ["self.config_we","magma_Bit_xor_inst6.in0"],
+          ["self.config_we","magma_Bit_xor_inst7.in0"],
+          ["self.config_we","magma_Bit_xor_inst8.in0"],
+          ["self.config_we","magma_Bit_xor_inst9.in0"],
           ["self.mode","magma_Bits_2_eq_inst0.in0"],
           ["self.mode","magma_Bits_2_eq_inst1.in0"],
           ["self.mode","magma_Bits_2_eq_inst10.in0"],
           ["self.mode","magma_Bits_2_eq_inst11.in0"],
           ["self.mode","magma_Bits_2_eq_inst12.in0"],
           ["self.mode","magma_Bits_2_eq_inst13.in0"],
+          ["self.mode","magma_Bits_2_eq_inst14.in0"],
+          ["self.mode","magma_Bits_2_eq_inst15.in0"],
+          ["self.mode","magma_Bits_2_eq_inst16.in0"],
+          ["self.mode","magma_Bits_2_eq_inst17.in0"],
           ["self.mode","magma_Bits_2_eq_inst2.in0"],
           ["self.mode","magma_Bits_2_eq_inst3.in0"],
           ["self.mode","magma_Bits_2_eq_inst4.in0"],

--- a/tests/test_syntax/gold/RegisterMode.v
+++ b/tests/test_syntax/gold/RegisterMode.v
@@ -69,6 +69,14 @@ module corebit_const #(
   assign out = value;
 endmodule
 
+module corebit_and (
+    input in0,
+    input in1,
+    output out
+);
+  assign out = in0 & in1;
+endmodule
+
 module commonlib_muxn__N2__width4 (
     input [3:0] in_data_0,
     input [3:0] in_data_1,
@@ -221,26 +229,70 @@ wire bit_const_0_None_out;
 wire bit_const_1_None_out;
 wire [1:0] const_0_2_out;
 wire [1:0] const_1_2_out;
+wire magma_Bit_and_inst0_out;
+wire magma_Bit_and_inst1_out;
+wire magma_Bit_and_inst10_out;
+wire magma_Bit_and_inst11_out;
+wire magma_Bit_and_inst2_out;
+wire magma_Bit_and_inst3_out;
+wire magma_Bit_and_inst4_out;
+wire magma_Bit_and_inst5_out;
+wire magma_Bit_and_inst6_out;
+wire magma_Bit_and_inst7_out;
+wire magma_Bit_and_inst8_out;
+wire magma_Bit_and_inst9_out;
 wire magma_Bit_not_inst0_out;
 wire magma_Bit_not_inst1_out;
+wire magma_Bit_not_inst10_out;
+wire magma_Bit_not_inst11_out;
+wire magma_Bit_not_inst12_out;
+wire magma_Bit_not_inst13_out;
+wire magma_Bit_not_inst14_out;
+wire magma_Bit_not_inst15_out;
+wire magma_Bit_not_inst16_out;
+wire magma_Bit_not_inst17_out;
+wire magma_Bit_not_inst18_out;
+wire magma_Bit_not_inst19_out;
 wire magma_Bit_not_inst2_out;
+wire magma_Bit_not_inst20_out;
+wire magma_Bit_not_inst21_out;
+wire magma_Bit_not_inst22_out;
+wire magma_Bit_not_inst23_out;
+wire magma_Bit_not_inst24_out;
+wire magma_Bit_not_inst25_out;
+wire magma_Bit_not_inst26_out;
 wire magma_Bit_not_inst3_out;
 wire magma_Bit_not_inst4_out;
 wire magma_Bit_not_inst5_out;
 wire magma_Bit_not_inst6_out;
+wire magma_Bit_not_inst7_out;
+wire magma_Bit_not_inst8_out;
+wire magma_Bit_not_inst9_out;
 wire magma_Bit_xor_inst0_out;
 wire magma_Bit_xor_inst1_out;
+wire magma_Bit_xor_inst10_out;
+wire magma_Bit_xor_inst11_out;
+wire magma_Bit_xor_inst12_out;
+wire magma_Bit_xor_inst13_out;
+wire magma_Bit_xor_inst14_out;
 wire magma_Bit_xor_inst2_out;
 wire magma_Bit_xor_inst3_out;
 wire magma_Bit_xor_inst4_out;
 wire magma_Bit_xor_inst5_out;
 wire magma_Bit_xor_inst6_out;
+wire magma_Bit_xor_inst7_out;
+wire magma_Bit_xor_inst8_out;
+wire magma_Bit_xor_inst9_out;
 wire magma_Bits_2_eq_inst0_out;
 wire magma_Bits_2_eq_inst1_out;
 wire magma_Bits_2_eq_inst10_out;
 wire magma_Bits_2_eq_inst11_out;
 wire magma_Bits_2_eq_inst12_out;
 wire magma_Bits_2_eq_inst13_out;
+wire magma_Bits_2_eq_inst14_out;
+wire magma_Bits_2_eq_inst15_out;
+wire magma_Bits_2_eq_inst16_out;
+wire magma_Bits_2_eq_inst17_out;
 wire magma_Bits_2_eq_inst2_out;
 wire magma_Bits_2_eq_inst3_out;
 wire magma_Bits_2_eq_inst4_out;
@@ -270,19 +322,19 @@ Mux2xOutBit Mux2xOutBit_inst2 (
 Mux2xOutBit Mux2xOutBit_inst3 (
     .I0(clk_en),
     .I1(bit_const_0_None_out),
-    .S(magma_Bits_2_eq_inst7_out),
+    .S(magma_Bit_and_inst3_out),
     .O(Mux2xOutBit_inst3_O)
 );
 Mux2xOutBit Mux2xOutBit_inst4 (
     .I0(Mux2xOutBit_inst3_O),
     .I1(bit_const_0_None_out),
-    .S(magma_Bits_2_eq_inst11_out),
+    .S(magma_Bit_and_inst9_out),
     .O(Mux2xOutBit_inst4_O)
 );
 Mux2xOutBit Mux2xOutBit_inst5 (
     .I0(Mux2xOutBit_inst4_O),
     .I1(bit_const_1_None_out),
-    .S(magma_Bit_not_inst4_out),
+    .S(magma_Bit_not_inst24_out),
     .O(Mux2xOutBit_inst5_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst0 (
@@ -300,31 +352,31 @@ Mux2xOutBits4 Mux2xOutBits4_inst1 (
 Mux2xOutBits4 Mux2xOutBits4_inst10 (
     .I0(Mux2xOutBits4_inst7_O),
     .I1(const_),
-    .S(magma_Bits_2_eq_inst12_out),
+    .S(magma_Bit_and_inst10_out),
     .O(Mux2xOutBits4_inst10_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst11 (
     .I0(Mux2xOutBits4_inst8_O),
     .I1(self_register_O),
-    .S(magma_Bits_2_eq_inst13_out),
+    .S(magma_Bit_and_inst11_out),
     .O(Mux2xOutBits4_inst11_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst12 (
     .I0(Mux2xOutBits4_inst9_O),
     .I1(config_data),
-    .S(magma_Bit_not_inst3_out),
+    .S(magma_Bit_not_inst23_out),
     .O(Mux2xOutBits4_inst12_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst13 (
     .I0(Mux2xOutBits4_inst10_O),
     .I1(self_register_O),
-    .S(magma_Bit_not_inst5_out),
+    .S(magma_Bit_not_inst25_out),
     .O(Mux2xOutBits4_inst13_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst14 (
     .I0(Mux2xOutBits4_inst11_O),
     .I1(self_register_O),
-    .S(magma_Bit_not_inst6_out),
+    .S(magma_Bit_not_inst26_out),
     .O(Mux2xOutBits4_inst14_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst2 (
@@ -354,25 +406,25 @@ Mux2xOutBits4 Mux2xOutBits4_inst5 (
 Mux2xOutBits4 Mux2xOutBits4_inst6 (
     .I0(value),
     .I1(value),
-    .S(magma_Bits_2_eq_inst6_out),
+    .S(magma_Bit_and_inst1_out),
     .O(Mux2xOutBits4_inst6_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst7 (
     .I0(self_register_O),
     .I1(value),
-    .S(magma_Bits_2_eq_inst8_out),
+    .S(magma_Bit_and_inst5_out),
     .O(Mux2xOutBits4_inst7_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst8 (
     .I0(self_register_O),
     .I1(self_register_O),
-    .S(magma_Bits_2_eq_inst9_out),
+    .S(magma_Bit_and_inst7_out),
     .O(Mux2xOutBits4_inst8_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst9 (
     .I0(Mux2xOutBits4_inst6_O),
     .I1(value),
-    .S(magma_Bits_2_eq_inst10_out),
+    .S(magma_Bit_and_inst8_out),
     .O(Mux2xOutBits4_inst9_O)
 );
 corebit_const #(
@@ -397,6 +449,66 @@ coreir_const #(
 ) const_1_2 (
     .out(const_1_2_out)
 );
+corebit_and magma_Bit_and_inst0 (
+    .in0(magma_Bits_2_eq_inst6_out),
+    .in1(magma_Bit_not_inst4_out),
+    .out(magma_Bit_and_inst0_out)
+);
+corebit_and magma_Bit_and_inst1 (
+    .in0(magma_Bit_and_inst0_out),
+    .in1(magma_Bit_not_inst5_out),
+    .out(magma_Bit_and_inst1_out)
+);
+corebit_and magma_Bit_and_inst10 (
+    .in0(magma_Bits_2_eq_inst16_out),
+    .in1(magma_Bit_not_inst20_out),
+    .out(magma_Bit_and_inst10_out)
+);
+corebit_and magma_Bit_and_inst11 (
+    .in0(magma_Bits_2_eq_inst17_out),
+    .in1(magma_Bit_not_inst22_out),
+    .out(magma_Bit_and_inst11_out)
+);
+corebit_and magma_Bit_and_inst2 (
+    .in0(magma_Bits_2_eq_inst8_out),
+    .in1(magma_Bit_not_inst7_out),
+    .out(magma_Bit_and_inst2_out)
+);
+corebit_and magma_Bit_and_inst3 (
+    .in0(magma_Bit_and_inst2_out),
+    .in1(magma_Bit_not_inst8_out),
+    .out(magma_Bit_and_inst3_out)
+);
+corebit_and magma_Bit_and_inst4 (
+    .in0(magma_Bits_2_eq_inst10_out),
+    .in1(magma_Bit_not_inst10_out),
+    .out(magma_Bit_and_inst4_out)
+);
+corebit_and magma_Bit_and_inst5 (
+    .in0(magma_Bit_and_inst4_out),
+    .in1(magma_Bit_not_inst11_out),
+    .out(magma_Bit_and_inst5_out)
+);
+corebit_and magma_Bit_and_inst6 (
+    .in0(magma_Bits_2_eq_inst12_out),
+    .in1(magma_Bit_not_inst13_out),
+    .out(magma_Bit_and_inst6_out)
+);
+corebit_and magma_Bit_and_inst7 (
+    .in0(magma_Bit_and_inst6_out),
+    .in1(magma_Bit_not_inst14_out),
+    .out(magma_Bit_and_inst7_out)
+);
+corebit_and magma_Bit_and_inst8 (
+    .in0(magma_Bits_2_eq_inst14_out),
+    .in1(magma_Bit_not_inst16_out),
+    .out(magma_Bit_and_inst8_out)
+);
+corebit_and magma_Bit_and_inst9 (
+    .in0(magma_Bits_2_eq_inst15_out),
+    .in1(magma_Bit_not_inst18_out),
+    .out(magma_Bit_and_inst9_out)
+);
 corebit_not magma_Bit_not_inst0 (
     .in(magma_Bit_xor_inst0_out),
     .out(magma_Bit_not_inst0_out)
@@ -405,25 +517,105 @@ corebit_not magma_Bit_not_inst1 (
     .in(magma_Bit_xor_inst1_out),
     .out(magma_Bit_not_inst1_out)
 );
+corebit_not magma_Bit_not_inst10 (
+    .in(magma_Bit_not_inst9_out),
+    .out(magma_Bit_not_inst10_out)
+);
+corebit_not magma_Bit_not_inst11 (
+    .in(magma_Bits_2_eq_inst11_out),
+    .out(magma_Bit_not_inst11_out)
+);
+corebit_not magma_Bit_not_inst12 (
+    .in(magma_Bit_xor_inst6_out),
+    .out(magma_Bit_not_inst12_out)
+);
+corebit_not magma_Bit_not_inst13 (
+    .in(magma_Bit_not_inst12_out),
+    .out(magma_Bit_not_inst13_out)
+);
+corebit_not magma_Bit_not_inst14 (
+    .in(magma_Bits_2_eq_inst13_out),
+    .out(magma_Bit_not_inst14_out)
+);
+corebit_not magma_Bit_not_inst15 (
+    .in(magma_Bit_xor_inst7_out),
+    .out(magma_Bit_not_inst15_out)
+);
+corebit_not magma_Bit_not_inst16 (
+    .in(magma_Bit_not_inst15_out),
+    .out(magma_Bit_not_inst16_out)
+);
+corebit_not magma_Bit_not_inst17 (
+    .in(magma_Bit_xor_inst8_out),
+    .out(magma_Bit_not_inst17_out)
+);
+corebit_not magma_Bit_not_inst18 (
+    .in(magma_Bit_not_inst17_out),
+    .out(magma_Bit_not_inst18_out)
+);
+corebit_not magma_Bit_not_inst19 (
+    .in(magma_Bit_xor_inst9_out),
+    .out(magma_Bit_not_inst19_out)
+);
 corebit_not magma_Bit_not_inst2 (
     .in(magma_Bit_xor_inst2_out),
     .out(magma_Bit_not_inst2_out)
+);
+corebit_not magma_Bit_not_inst20 (
+    .in(magma_Bit_not_inst19_out),
+    .out(magma_Bit_not_inst20_out)
+);
+corebit_not magma_Bit_not_inst21 (
+    .in(magma_Bit_xor_inst10_out),
+    .out(magma_Bit_not_inst21_out)
+);
+corebit_not magma_Bit_not_inst22 (
+    .in(magma_Bit_not_inst21_out),
+    .out(magma_Bit_not_inst22_out)
+);
+corebit_not magma_Bit_not_inst23 (
+    .in(magma_Bit_xor_inst11_out),
+    .out(magma_Bit_not_inst23_out)
+);
+corebit_not magma_Bit_not_inst24 (
+    .in(magma_Bit_xor_inst12_out),
+    .out(magma_Bit_not_inst24_out)
+);
+corebit_not magma_Bit_not_inst25 (
+    .in(magma_Bit_xor_inst13_out),
+    .out(magma_Bit_not_inst25_out)
+);
+corebit_not magma_Bit_not_inst26 (
+    .in(magma_Bit_xor_inst14_out),
+    .out(magma_Bit_not_inst26_out)
 );
 corebit_not magma_Bit_not_inst3 (
     .in(magma_Bit_xor_inst3_out),
     .out(magma_Bit_not_inst3_out)
 );
 corebit_not magma_Bit_not_inst4 (
-    .in(magma_Bit_xor_inst4_out),
+    .in(magma_Bit_not_inst3_out),
     .out(magma_Bit_not_inst4_out)
 );
 corebit_not magma_Bit_not_inst5 (
-    .in(magma_Bit_xor_inst5_out),
+    .in(magma_Bits_2_eq_inst7_out),
     .out(magma_Bit_not_inst5_out)
 );
 corebit_not magma_Bit_not_inst6 (
-    .in(magma_Bit_xor_inst6_out),
+    .in(magma_Bit_xor_inst4_out),
     .out(magma_Bit_not_inst6_out)
+);
+corebit_not magma_Bit_not_inst7 (
+    .in(magma_Bit_not_inst6_out),
+    .out(magma_Bit_not_inst7_out)
+);
+corebit_not magma_Bit_not_inst8 (
+    .in(magma_Bits_2_eq_inst9_out),
+    .out(magma_Bit_not_inst8_out)
+);
+corebit_not magma_Bit_not_inst9 (
+    .in(magma_Bit_xor_inst5_out),
+    .out(magma_Bit_not_inst9_out)
 );
 corebit_xor magma_Bit_xor_inst0 (
     .in0(config_we),
@@ -434,6 +626,31 @@ corebit_xor magma_Bit_xor_inst1 (
     .in0(config_we),
     .in1(bit_const_1_None_out),
     .out(magma_Bit_xor_inst1_out)
+);
+corebit_xor magma_Bit_xor_inst10 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst10_out)
+);
+corebit_xor magma_Bit_xor_inst11 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst11_out)
+);
+corebit_xor magma_Bit_xor_inst12 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst12_out)
+);
+corebit_xor magma_Bit_xor_inst13 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst13_out)
+);
+corebit_xor magma_Bit_xor_inst14 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst14_out)
 );
 corebit_xor magma_Bit_xor_inst2 (
     .in0(config_we),
@@ -460,6 +677,21 @@ corebit_xor magma_Bit_xor_inst6 (
     .in1(bit_const_1_None_out),
     .out(magma_Bit_xor_inst6_out)
 );
+corebit_xor magma_Bit_xor_inst7 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst7_out)
+);
+corebit_xor magma_Bit_xor_inst8 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst8_out)
+);
+corebit_xor magma_Bit_xor_inst9 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst9_out)
+);
 coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst0 (
@@ -478,7 +710,7 @@ coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst10 (
     .in0(mode),
-    .in1(const_0_2_out),
+    .in1(const_1_2_out),
     .out(magma_Bits_2_eq_inst10_out)
 );
 coreir_eq #(
@@ -492,7 +724,7 @@ coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst12 (
     .in0(mode),
-    .in1(const_0_2_out),
+    .in1(const_1_2_out),
     .out(magma_Bits_2_eq_inst12_out)
 );
 coreir_eq #(
@@ -501,6 +733,34 @@ coreir_eq #(
     .in0(mode),
     .in1(const_0_2_out),
     .out(magma_Bits_2_eq_inst13_out)
+);
+coreir_eq #(
+    .width(2)
+) magma_Bits_2_eq_inst14 (
+    .in0(mode),
+    .in1(const_0_2_out),
+    .out(magma_Bits_2_eq_inst14_out)
+);
+coreir_eq #(
+    .width(2)
+) magma_Bits_2_eq_inst15 (
+    .in0(mode),
+    .in1(const_0_2_out),
+    .out(magma_Bits_2_eq_inst15_out)
+);
+coreir_eq #(
+    .width(2)
+) magma_Bits_2_eq_inst16 (
+    .in0(mode),
+    .in1(const_0_2_out),
+    .out(magma_Bits_2_eq_inst16_out)
+);
+coreir_eq #(
+    .width(2)
+) magma_Bits_2_eq_inst17 (
+    .in0(mode),
+    .in1(const_0_2_out),
+    .out(magma_Bits_2_eq_inst17_out)
 );
 coreir_eq #(
     .width(2)
@@ -541,7 +801,7 @@ coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst7 (
     .in0(mode),
-    .in1(const_1_2_out),
+    .in1(const_0_2_out),
     .out(magma_Bits_2_eq_inst7_out)
 );
 coreir_eq #(
@@ -555,7 +815,7 @@ coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst9 (
     .in0(mode),
-    .in1(const_1_2_out),
+    .in1(const_0_2_out),
     .out(magma_Bits_2_eq_inst9_out)
 );
 assign O0 = Mux2xOutBits4_inst12_O;

--- a/tests/test_syntax/gold/RegisterModeARST.json
+++ b/tests/test_syntax/gold/RegisterModeARST.json
@@ -203,13 +203,100 @@
             "genargs":{"width":["Int",2]},
             "modargs":{"value":[["BitVector",2],"2'h1"]}
           },
+          "magma_Bit_and_inst0":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst1":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst10":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst11":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst2":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst3":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst4":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst5":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst6":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst7":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst8":{
+            "modref":"corebit.and"
+          },
+          "magma_Bit_and_inst9":{
+            "modref":"corebit.and"
+          },
           "magma_Bit_not_inst0":{
             "modref":"corebit.not"
           },
           "magma_Bit_not_inst1":{
             "modref":"corebit.not"
           },
+          "magma_Bit_not_inst10":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst11":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst12":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst13":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst14":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst15":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst16":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst17":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst18":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst19":{
+            "modref":"corebit.not"
+          },
           "magma_Bit_not_inst2":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst20":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst21":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst22":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst23":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst24":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst25":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst26":{
             "modref":"corebit.not"
           },
           "magma_Bit_not_inst3":{
@@ -224,10 +311,34 @@
           "magma_Bit_not_inst6":{
             "modref":"corebit.not"
           },
+          "magma_Bit_not_inst7":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst8":{
+            "modref":"corebit.not"
+          },
+          "magma_Bit_not_inst9":{
+            "modref":"corebit.not"
+          },
           "magma_Bit_xor_inst0":{
             "modref":"corebit.xor"
           },
           "magma_Bit_xor_inst1":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst10":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst11":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst12":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst13":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst14":{
             "modref":"corebit.xor"
           },
           "magma_Bit_xor_inst2":{
@@ -243,6 +354,15 @@
             "modref":"corebit.xor"
           },
           "magma_Bit_xor_inst6":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst7":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst8":{
+            "modref":"corebit.xor"
+          },
+          "magma_Bit_xor_inst9":{
             "modref":"corebit.xor"
           },
           "magma_Bits_2_eq_inst0":{
@@ -266,6 +386,22 @@
             "genargs":{"width":["Int",2]}
           },
           "magma_Bits_2_eq_inst13":{
+            "genref":"coreir.eq",
+            "genargs":{"width":["Int",2]}
+          },
+          "magma_Bits_2_eq_inst14":{
+            "genref":"coreir.eq",
+            "genargs":{"width":["Int",2]}
+          },
+          "magma_Bits_2_eq_inst15":{
+            "genref":"coreir.eq",
+            "genargs":{"width":["Int",2]}
+          },
+          "magma_Bits_2_eq_inst16":{
+            "genref":"coreir.eq",
+            "genargs":{"width":["Int",2]}
+          },
+          "magma_Bits_2_eq_inst17":{
             "genref":"coreir.eq",
             "genargs":{"width":["Int",2]}
           },
@@ -315,13 +451,13 @@
           ["self.clk_en","Mux2xOutBit_inst3.I0"],
           ["bit_const_0_None.out","Mux2xOutBit_inst3.I1"],
           ["Mux2xOutBit_inst4.I0","Mux2xOutBit_inst3.O"],
-          ["magma_Bits_2_eq_inst7.out","Mux2xOutBit_inst3.S"],
+          ["magma_Bit_and_inst3.out","Mux2xOutBit_inst3.S"],
           ["bit_const_0_None.out","Mux2xOutBit_inst4.I1"],
           ["Mux2xOutBit_inst5.I0","Mux2xOutBit_inst4.O"],
-          ["magma_Bits_2_eq_inst11.out","Mux2xOutBit_inst4.S"],
+          ["magma_Bit_and_inst9.out","Mux2xOutBit_inst4.S"],
           ["bit_const_1_None.out","Mux2xOutBit_inst5.I1"],
           ["self.O1","Mux2xOutBit_inst5.O"],
-          ["magma_Bit_not_inst4.out","Mux2xOutBit_inst5.S"],
+          ["magma_Bit_not_inst24.out","Mux2xOutBit_inst5.S"],
           ["self.value","Mux2xOutBits4_inst0.I0"],
           ["self.value","Mux2xOutBits4_inst0.I1"],
           ["Mux2xOutBits4_inst2.I0","Mux2xOutBits4_inst0.O"],
@@ -333,21 +469,21 @@
           ["Mux2xOutBits4_inst7.O","Mux2xOutBits4_inst10.I0"],
           ["self.const_","Mux2xOutBits4_inst10.I1"],
           ["Mux2xOutBits4_inst13.I0","Mux2xOutBits4_inst10.O"],
-          ["magma_Bits_2_eq_inst12.out","Mux2xOutBits4_inst10.S"],
+          ["magma_Bit_and_inst10.out","Mux2xOutBits4_inst10.S"],
           ["Mux2xOutBits4_inst8.O","Mux2xOutBits4_inst11.I0"],
           ["self.self_register_O","Mux2xOutBits4_inst11.I1"],
           ["Mux2xOutBits4_inst14.I0","Mux2xOutBits4_inst11.O"],
-          ["magma_Bits_2_eq_inst13.out","Mux2xOutBits4_inst11.S"],
+          ["magma_Bit_and_inst11.out","Mux2xOutBits4_inst11.S"],
           ["Mux2xOutBits4_inst9.O","Mux2xOutBits4_inst12.I0"],
           ["self.config_data","Mux2xOutBits4_inst12.I1"],
           ["self.O0","Mux2xOutBits4_inst12.O"],
-          ["magma_Bit_not_inst3.out","Mux2xOutBits4_inst12.S"],
+          ["magma_Bit_not_inst23.out","Mux2xOutBits4_inst12.S"],
           ["self.self_register_O","Mux2xOutBits4_inst13.I1"],
           ["self.O2","Mux2xOutBits4_inst13.O"],
-          ["magma_Bit_not_inst5.out","Mux2xOutBits4_inst13.S"],
+          ["magma_Bit_not_inst25.out","Mux2xOutBits4_inst13.S"],
           ["self.self_register_O","Mux2xOutBits4_inst14.I1"],
           ["self.O3","Mux2xOutBits4_inst14.O"],
-          ["magma_Bit_not_inst6.out","Mux2xOutBits4_inst14.S"],
+          ["magma_Bit_not_inst26.out","Mux2xOutBits4_inst14.S"],
           ["self.value","Mux2xOutBits4_inst2.I1"],
           ["Mux2xOutBits4_inst4.I0","Mux2xOutBits4_inst2.O"],
           ["magma_Bits_2_eq_inst3.out","Mux2xOutBits4_inst2.S"],
@@ -361,56 +497,124 @@
           ["self.value","Mux2xOutBits4_inst6.I0"],
           ["self.value","Mux2xOutBits4_inst6.I1"],
           ["Mux2xOutBits4_inst9.I0","Mux2xOutBits4_inst6.O"],
-          ["magma_Bits_2_eq_inst6.out","Mux2xOutBits4_inst6.S"],
+          ["magma_Bit_and_inst1.out","Mux2xOutBits4_inst6.S"],
           ["self.self_register_O","Mux2xOutBits4_inst7.I0"],
           ["self.value","Mux2xOutBits4_inst7.I1"],
-          ["magma_Bits_2_eq_inst8.out","Mux2xOutBits4_inst7.S"],
+          ["magma_Bit_and_inst5.out","Mux2xOutBits4_inst7.S"],
           ["self.self_register_O","Mux2xOutBits4_inst8.I0"],
           ["self.self_register_O","Mux2xOutBits4_inst8.I1"],
-          ["magma_Bits_2_eq_inst9.out","Mux2xOutBits4_inst8.S"],
+          ["magma_Bit_and_inst7.out","Mux2xOutBits4_inst8.S"],
           ["self.value","Mux2xOutBits4_inst9.I1"],
-          ["magma_Bits_2_eq_inst10.out","Mux2xOutBits4_inst9.S"],
+          ["magma_Bit_and_inst8.out","Mux2xOutBits4_inst9.S"],
           ["magma_Bit_xor_inst0.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst1.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst10.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst11.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst12.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst13.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst14.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst2.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst3.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst4.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst5.in1","bit_const_1_None.out"],
           ["magma_Bit_xor_inst6.in1","bit_const_1_None.out"],
-          ["magma_Bits_2_eq_inst10.in1","const_0_2.out"],
+          ["magma_Bit_xor_inst7.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst8.in1","bit_const_1_None.out"],
+          ["magma_Bit_xor_inst9.in1","bit_const_1_None.out"],
           ["magma_Bits_2_eq_inst11.in1","const_0_2.out"],
-          ["magma_Bits_2_eq_inst12.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst13.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst14.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst15.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst16.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst17.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst3.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst4.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst5.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst7.in1","const_0_2.out"],
+          ["magma_Bits_2_eq_inst9.in1","const_0_2.out"],
           ["magma_Bits_2_eq_inst0.in1","const_1_2.out"],
           ["magma_Bits_2_eq_inst1.in1","const_1_2.out"],
+          ["magma_Bits_2_eq_inst10.in1","const_1_2.out"],
+          ["magma_Bits_2_eq_inst12.in1","const_1_2.out"],
           ["magma_Bits_2_eq_inst2.in1","const_1_2.out"],
           ["magma_Bits_2_eq_inst6.in1","const_1_2.out"],
-          ["magma_Bits_2_eq_inst7.in1","const_1_2.out"],
           ["magma_Bits_2_eq_inst8.in1","const_1_2.out"],
-          ["magma_Bits_2_eq_inst9.in1","const_1_2.out"],
+          ["magma_Bits_2_eq_inst6.out","magma_Bit_and_inst0.in0"],
+          ["magma_Bit_not_inst4.out","magma_Bit_and_inst0.in1"],
+          ["magma_Bit_and_inst1.in0","magma_Bit_and_inst0.out"],
+          ["magma_Bit_not_inst5.out","magma_Bit_and_inst1.in1"],
+          ["magma_Bits_2_eq_inst16.out","magma_Bit_and_inst10.in0"],
+          ["magma_Bit_not_inst20.out","magma_Bit_and_inst10.in1"],
+          ["magma_Bits_2_eq_inst17.out","magma_Bit_and_inst11.in0"],
+          ["magma_Bit_not_inst22.out","magma_Bit_and_inst11.in1"],
+          ["magma_Bits_2_eq_inst8.out","magma_Bit_and_inst2.in0"],
+          ["magma_Bit_not_inst7.out","magma_Bit_and_inst2.in1"],
+          ["magma_Bit_and_inst3.in0","magma_Bit_and_inst2.out"],
+          ["magma_Bit_not_inst8.out","magma_Bit_and_inst3.in1"],
+          ["magma_Bits_2_eq_inst10.out","magma_Bit_and_inst4.in0"],
+          ["magma_Bit_not_inst10.out","magma_Bit_and_inst4.in1"],
+          ["magma_Bit_and_inst5.in0","magma_Bit_and_inst4.out"],
+          ["magma_Bit_not_inst11.out","magma_Bit_and_inst5.in1"],
+          ["magma_Bits_2_eq_inst12.out","magma_Bit_and_inst6.in0"],
+          ["magma_Bit_not_inst13.out","magma_Bit_and_inst6.in1"],
+          ["magma_Bit_and_inst7.in0","magma_Bit_and_inst6.out"],
+          ["magma_Bit_not_inst14.out","magma_Bit_and_inst7.in1"],
+          ["magma_Bits_2_eq_inst14.out","magma_Bit_and_inst8.in0"],
+          ["magma_Bit_not_inst16.out","magma_Bit_and_inst8.in1"],
+          ["magma_Bits_2_eq_inst15.out","magma_Bit_and_inst9.in0"],
+          ["magma_Bit_not_inst18.out","magma_Bit_and_inst9.in1"],
           ["magma_Bit_xor_inst0.out","magma_Bit_not_inst0.in"],
           ["magma_Bit_xor_inst1.out","magma_Bit_not_inst1.in"],
+          ["magma_Bit_not_inst9.out","magma_Bit_not_inst10.in"],
+          ["magma_Bits_2_eq_inst11.out","magma_Bit_not_inst11.in"],
+          ["magma_Bit_xor_inst6.out","magma_Bit_not_inst12.in"],
+          ["magma_Bit_not_inst13.in","magma_Bit_not_inst12.out"],
+          ["magma_Bits_2_eq_inst13.out","magma_Bit_not_inst14.in"],
+          ["magma_Bit_xor_inst7.out","magma_Bit_not_inst15.in"],
+          ["magma_Bit_not_inst16.in","magma_Bit_not_inst15.out"],
+          ["magma_Bit_xor_inst8.out","magma_Bit_not_inst17.in"],
+          ["magma_Bit_not_inst18.in","magma_Bit_not_inst17.out"],
+          ["magma_Bit_xor_inst9.out","magma_Bit_not_inst19.in"],
+          ["magma_Bit_not_inst20.in","magma_Bit_not_inst19.out"],
           ["magma_Bit_xor_inst2.out","magma_Bit_not_inst2.in"],
+          ["magma_Bit_xor_inst10.out","magma_Bit_not_inst21.in"],
+          ["magma_Bit_not_inst22.in","magma_Bit_not_inst21.out"],
+          ["magma_Bit_xor_inst11.out","magma_Bit_not_inst23.in"],
+          ["magma_Bit_xor_inst12.out","magma_Bit_not_inst24.in"],
+          ["magma_Bit_xor_inst13.out","magma_Bit_not_inst25.in"],
+          ["magma_Bit_xor_inst14.out","magma_Bit_not_inst26.in"],
           ["magma_Bit_xor_inst3.out","magma_Bit_not_inst3.in"],
-          ["magma_Bit_xor_inst4.out","magma_Bit_not_inst4.in"],
-          ["magma_Bit_xor_inst5.out","magma_Bit_not_inst5.in"],
-          ["magma_Bit_xor_inst6.out","magma_Bit_not_inst6.in"],
+          ["magma_Bit_not_inst4.in","magma_Bit_not_inst3.out"],
+          ["magma_Bits_2_eq_inst7.out","magma_Bit_not_inst5.in"],
+          ["magma_Bit_xor_inst4.out","magma_Bit_not_inst6.in"],
+          ["magma_Bit_not_inst7.in","magma_Bit_not_inst6.out"],
+          ["magma_Bits_2_eq_inst9.out","magma_Bit_not_inst8.in"],
+          ["magma_Bit_xor_inst5.out","magma_Bit_not_inst9.in"],
           ["self.config_we","magma_Bit_xor_inst0.in0"],
           ["self.config_we","magma_Bit_xor_inst1.in0"],
+          ["self.config_we","magma_Bit_xor_inst10.in0"],
+          ["self.config_we","magma_Bit_xor_inst11.in0"],
+          ["self.config_we","magma_Bit_xor_inst12.in0"],
+          ["self.config_we","magma_Bit_xor_inst13.in0"],
+          ["self.config_we","magma_Bit_xor_inst14.in0"],
           ["self.config_we","magma_Bit_xor_inst2.in0"],
           ["self.config_we","magma_Bit_xor_inst3.in0"],
           ["self.config_we","magma_Bit_xor_inst4.in0"],
           ["self.config_we","magma_Bit_xor_inst5.in0"],
           ["self.config_we","magma_Bit_xor_inst6.in0"],
+          ["self.config_we","magma_Bit_xor_inst7.in0"],
+          ["self.config_we","magma_Bit_xor_inst8.in0"],
+          ["self.config_we","magma_Bit_xor_inst9.in0"],
           ["self.mode","magma_Bits_2_eq_inst0.in0"],
           ["self.mode","magma_Bits_2_eq_inst1.in0"],
           ["self.mode","magma_Bits_2_eq_inst10.in0"],
           ["self.mode","magma_Bits_2_eq_inst11.in0"],
           ["self.mode","magma_Bits_2_eq_inst12.in0"],
           ["self.mode","magma_Bits_2_eq_inst13.in0"],
+          ["self.mode","magma_Bits_2_eq_inst14.in0"],
+          ["self.mode","magma_Bits_2_eq_inst15.in0"],
+          ["self.mode","magma_Bits_2_eq_inst16.in0"],
+          ["self.mode","magma_Bits_2_eq_inst17.in0"],
           ["self.mode","magma_Bits_2_eq_inst2.in0"],
           ["self.mode","magma_Bits_2_eq_inst3.in0"],
           ["self.mode","magma_Bits_2_eq_inst4.in0"],

--- a/tests/test_syntax/gold/RegisterModeARST.v
+++ b/tests/test_syntax/gold/RegisterModeARST.v
@@ -74,6 +74,14 @@ module corebit_const #(
   assign out = value;
 endmodule
 
+module corebit_and (
+    input in0,
+    input in1,
+    output out
+);
+  assign out = in0 & in1;
+endmodule
+
 module commonlib_muxn__N2__width4 (
     input [3:0] in_data_0,
     input [3:0] in_data_1,
@@ -229,26 +237,70 @@ wire bit_const_0_None_out;
 wire bit_const_1_None_out;
 wire [1:0] const_0_2_out;
 wire [1:0] const_1_2_out;
+wire magma_Bit_and_inst0_out;
+wire magma_Bit_and_inst1_out;
+wire magma_Bit_and_inst10_out;
+wire magma_Bit_and_inst11_out;
+wire magma_Bit_and_inst2_out;
+wire magma_Bit_and_inst3_out;
+wire magma_Bit_and_inst4_out;
+wire magma_Bit_and_inst5_out;
+wire magma_Bit_and_inst6_out;
+wire magma_Bit_and_inst7_out;
+wire magma_Bit_and_inst8_out;
+wire magma_Bit_and_inst9_out;
 wire magma_Bit_not_inst0_out;
 wire magma_Bit_not_inst1_out;
+wire magma_Bit_not_inst10_out;
+wire magma_Bit_not_inst11_out;
+wire magma_Bit_not_inst12_out;
+wire magma_Bit_not_inst13_out;
+wire magma_Bit_not_inst14_out;
+wire magma_Bit_not_inst15_out;
+wire magma_Bit_not_inst16_out;
+wire magma_Bit_not_inst17_out;
+wire magma_Bit_not_inst18_out;
+wire magma_Bit_not_inst19_out;
 wire magma_Bit_not_inst2_out;
+wire magma_Bit_not_inst20_out;
+wire magma_Bit_not_inst21_out;
+wire magma_Bit_not_inst22_out;
+wire magma_Bit_not_inst23_out;
+wire magma_Bit_not_inst24_out;
+wire magma_Bit_not_inst25_out;
+wire magma_Bit_not_inst26_out;
 wire magma_Bit_not_inst3_out;
 wire magma_Bit_not_inst4_out;
 wire magma_Bit_not_inst5_out;
 wire magma_Bit_not_inst6_out;
+wire magma_Bit_not_inst7_out;
+wire magma_Bit_not_inst8_out;
+wire magma_Bit_not_inst9_out;
 wire magma_Bit_xor_inst0_out;
 wire magma_Bit_xor_inst1_out;
+wire magma_Bit_xor_inst10_out;
+wire magma_Bit_xor_inst11_out;
+wire magma_Bit_xor_inst12_out;
+wire magma_Bit_xor_inst13_out;
+wire magma_Bit_xor_inst14_out;
 wire magma_Bit_xor_inst2_out;
 wire magma_Bit_xor_inst3_out;
 wire magma_Bit_xor_inst4_out;
 wire magma_Bit_xor_inst5_out;
 wire magma_Bit_xor_inst6_out;
+wire magma_Bit_xor_inst7_out;
+wire magma_Bit_xor_inst8_out;
+wire magma_Bit_xor_inst9_out;
 wire magma_Bits_2_eq_inst0_out;
 wire magma_Bits_2_eq_inst1_out;
 wire magma_Bits_2_eq_inst10_out;
 wire magma_Bits_2_eq_inst11_out;
 wire magma_Bits_2_eq_inst12_out;
 wire magma_Bits_2_eq_inst13_out;
+wire magma_Bits_2_eq_inst14_out;
+wire magma_Bits_2_eq_inst15_out;
+wire magma_Bits_2_eq_inst16_out;
+wire magma_Bits_2_eq_inst17_out;
 wire magma_Bits_2_eq_inst2_out;
 wire magma_Bits_2_eq_inst3_out;
 wire magma_Bits_2_eq_inst4_out;
@@ -278,19 +330,19 @@ Mux2xOutBit Mux2xOutBit_inst2 (
 Mux2xOutBit Mux2xOutBit_inst3 (
     .I0(clk_en),
     .I1(bit_const_0_None_out),
-    .S(magma_Bits_2_eq_inst7_out),
+    .S(magma_Bit_and_inst3_out),
     .O(Mux2xOutBit_inst3_O)
 );
 Mux2xOutBit Mux2xOutBit_inst4 (
     .I0(Mux2xOutBit_inst3_O),
     .I1(bit_const_0_None_out),
-    .S(magma_Bits_2_eq_inst11_out),
+    .S(magma_Bit_and_inst9_out),
     .O(Mux2xOutBit_inst4_O)
 );
 Mux2xOutBit Mux2xOutBit_inst5 (
     .I0(Mux2xOutBit_inst4_O),
     .I1(bit_const_1_None_out),
-    .S(magma_Bit_not_inst4_out),
+    .S(magma_Bit_not_inst24_out),
     .O(Mux2xOutBit_inst5_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst0 (
@@ -308,31 +360,31 @@ Mux2xOutBits4 Mux2xOutBits4_inst1 (
 Mux2xOutBits4 Mux2xOutBits4_inst10 (
     .I0(Mux2xOutBits4_inst7_O),
     .I1(const_),
-    .S(magma_Bits_2_eq_inst12_out),
+    .S(magma_Bit_and_inst10_out),
     .O(Mux2xOutBits4_inst10_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst11 (
     .I0(Mux2xOutBits4_inst8_O),
     .I1(self_register_O),
-    .S(magma_Bits_2_eq_inst13_out),
+    .S(magma_Bit_and_inst11_out),
     .O(Mux2xOutBits4_inst11_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst12 (
     .I0(Mux2xOutBits4_inst9_O),
     .I1(config_data),
-    .S(magma_Bit_not_inst3_out),
+    .S(magma_Bit_not_inst23_out),
     .O(Mux2xOutBits4_inst12_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst13 (
     .I0(Mux2xOutBits4_inst10_O),
     .I1(self_register_O),
-    .S(magma_Bit_not_inst5_out),
+    .S(magma_Bit_not_inst25_out),
     .O(Mux2xOutBits4_inst13_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst14 (
     .I0(Mux2xOutBits4_inst11_O),
     .I1(self_register_O),
-    .S(magma_Bit_not_inst6_out),
+    .S(magma_Bit_not_inst26_out),
     .O(Mux2xOutBits4_inst14_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst2 (
@@ -362,25 +414,25 @@ Mux2xOutBits4 Mux2xOutBits4_inst5 (
 Mux2xOutBits4 Mux2xOutBits4_inst6 (
     .I0(value),
     .I1(value),
-    .S(magma_Bits_2_eq_inst6_out),
+    .S(magma_Bit_and_inst1_out),
     .O(Mux2xOutBits4_inst6_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst7 (
     .I0(self_register_O),
     .I1(value),
-    .S(magma_Bits_2_eq_inst8_out),
+    .S(magma_Bit_and_inst5_out),
     .O(Mux2xOutBits4_inst7_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst8 (
     .I0(self_register_O),
     .I1(self_register_O),
-    .S(magma_Bits_2_eq_inst9_out),
+    .S(magma_Bit_and_inst7_out),
     .O(Mux2xOutBits4_inst8_O)
 );
 Mux2xOutBits4 Mux2xOutBits4_inst9 (
     .I0(Mux2xOutBits4_inst6_O),
     .I1(value),
-    .S(magma_Bits_2_eq_inst10_out),
+    .S(magma_Bit_and_inst8_out),
     .O(Mux2xOutBits4_inst9_O)
 );
 corebit_const #(
@@ -405,6 +457,66 @@ coreir_const #(
 ) const_1_2 (
     .out(const_1_2_out)
 );
+corebit_and magma_Bit_and_inst0 (
+    .in0(magma_Bits_2_eq_inst6_out),
+    .in1(magma_Bit_not_inst4_out),
+    .out(magma_Bit_and_inst0_out)
+);
+corebit_and magma_Bit_and_inst1 (
+    .in0(magma_Bit_and_inst0_out),
+    .in1(magma_Bit_not_inst5_out),
+    .out(magma_Bit_and_inst1_out)
+);
+corebit_and magma_Bit_and_inst10 (
+    .in0(magma_Bits_2_eq_inst16_out),
+    .in1(magma_Bit_not_inst20_out),
+    .out(magma_Bit_and_inst10_out)
+);
+corebit_and magma_Bit_and_inst11 (
+    .in0(magma_Bits_2_eq_inst17_out),
+    .in1(magma_Bit_not_inst22_out),
+    .out(magma_Bit_and_inst11_out)
+);
+corebit_and magma_Bit_and_inst2 (
+    .in0(magma_Bits_2_eq_inst8_out),
+    .in1(magma_Bit_not_inst7_out),
+    .out(magma_Bit_and_inst2_out)
+);
+corebit_and magma_Bit_and_inst3 (
+    .in0(magma_Bit_and_inst2_out),
+    .in1(magma_Bit_not_inst8_out),
+    .out(magma_Bit_and_inst3_out)
+);
+corebit_and magma_Bit_and_inst4 (
+    .in0(magma_Bits_2_eq_inst10_out),
+    .in1(magma_Bit_not_inst10_out),
+    .out(magma_Bit_and_inst4_out)
+);
+corebit_and magma_Bit_and_inst5 (
+    .in0(magma_Bit_and_inst4_out),
+    .in1(magma_Bit_not_inst11_out),
+    .out(magma_Bit_and_inst5_out)
+);
+corebit_and magma_Bit_and_inst6 (
+    .in0(magma_Bits_2_eq_inst12_out),
+    .in1(magma_Bit_not_inst13_out),
+    .out(magma_Bit_and_inst6_out)
+);
+corebit_and magma_Bit_and_inst7 (
+    .in0(magma_Bit_and_inst6_out),
+    .in1(magma_Bit_not_inst14_out),
+    .out(magma_Bit_and_inst7_out)
+);
+corebit_and magma_Bit_and_inst8 (
+    .in0(magma_Bits_2_eq_inst14_out),
+    .in1(magma_Bit_not_inst16_out),
+    .out(magma_Bit_and_inst8_out)
+);
+corebit_and magma_Bit_and_inst9 (
+    .in0(magma_Bits_2_eq_inst15_out),
+    .in1(magma_Bit_not_inst18_out),
+    .out(magma_Bit_and_inst9_out)
+);
 corebit_not magma_Bit_not_inst0 (
     .in(magma_Bit_xor_inst0_out),
     .out(magma_Bit_not_inst0_out)
@@ -413,25 +525,105 @@ corebit_not magma_Bit_not_inst1 (
     .in(magma_Bit_xor_inst1_out),
     .out(magma_Bit_not_inst1_out)
 );
+corebit_not magma_Bit_not_inst10 (
+    .in(magma_Bit_not_inst9_out),
+    .out(magma_Bit_not_inst10_out)
+);
+corebit_not magma_Bit_not_inst11 (
+    .in(magma_Bits_2_eq_inst11_out),
+    .out(magma_Bit_not_inst11_out)
+);
+corebit_not magma_Bit_not_inst12 (
+    .in(magma_Bit_xor_inst6_out),
+    .out(magma_Bit_not_inst12_out)
+);
+corebit_not magma_Bit_not_inst13 (
+    .in(magma_Bit_not_inst12_out),
+    .out(magma_Bit_not_inst13_out)
+);
+corebit_not magma_Bit_not_inst14 (
+    .in(magma_Bits_2_eq_inst13_out),
+    .out(magma_Bit_not_inst14_out)
+);
+corebit_not magma_Bit_not_inst15 (
+    .in(magma_Bit_xor_inst7_out),
+    .out(magma_Bit_not_inst15_out)
+);
+corebit_not magma_Bit_not_inst16 (
+    .in(magma_Bit_not_inst15_out),
+    .out(magma_Bit_not_inst16_out)
+);
+corebit_not magma_Bit_not_inst17 (
+    .in(magma_Bit_xor_inst8_out),
+    .out(magma_Bit_not_inst17_out)
+);
+corebit_not magma_Bit_not_inst18 (
+    .in(magma_Bit_not_inst17_out),
+    .out(magma_Bit_not_inst18_out)
+);
+corebit_not magma_Bit_not_inst19 (
+    .in(magma_Bit_xor_inst9_out),
+    .out(magma_Bit_not_inst19_out)
+);
 corebit_not magma_Bit_not_inst2 (
     .in(magma_Bit_xor_inst2_out),
     .out(magma_Bit_not_inst2_out)
+);
+corebit_not magma_Bit_not_inst20 (
+    .in(magma_Bit_not_inst19_out),
+    .out(magma_Bit_not_inst20_out)
+);
+corebit_not magma_Bit_not_inst21 (
+    .in(magma_Bit_xor_inst10_out),
+    .out(magma_Bit_not_inst21_out)
+);
+corebit_not magma_Bit_not_inst22 (
+    .in(magma_Bit_not_inst21_out),
+    .out(magma_Bit_not_inst22_out)
+);
+corebit_not magma_Bit_not_inst23 (
+    .in(magma_Bit_xor_inst11_out),
+    .out(magma_Bit_not_inst23_out)
+);
+corebit_not magma_Bit_not_inst24 (
+    .in(magma_Bit_xor_inst12_out),
+    .out(magma_Bit_not_inst24_out)
+);
+corebit_not magma_Bit_not_inst25 (
+    .in(magma_Bit_xor_inst13_out),
+    .out(magma_Bit_not_inst25_out)
+);
+corebit_not magma_Bit_not_inst26 (
+    .in(magma_Bit_xor_inst14_out),
+    .out(magma_Bit_not_inst26_out)
 );
 corebit_not magma_Bit_not_inst3 (
     .in(magma_Bit_xor_inst3_out),
     .out(magma_Bit_not_inst3_out)
 );
 corebit_not magma_Bit_not_inst4 (
-    .in(magma_Bit_xor_inst4_out),
+    .in(magma_Bit_not_inst3_out),
     .out(magma_Bit_not_inst4_out)
 );
 corebit_not magma_Bit_not_inst5 (
-    .in(magma_Bit_xor_inst5_out),
+    .in(magma_Bits_2_eq_inst7_out),
     .out(magma_Bit_not_inst5_out)
 );
 corebit_not magma_Bit_not_inst6 (
-    .in(magma_Bit_xor_inst6_out),
+    .in(magma_Bit_xor_inst4_out),
     .out(magma_Bit_not_inst6_out)
+);
+corebit_not magma_Bit_not_inst7 (
+    .in(magma_Bit_not_inst6_out),
+    .out(magma_Bit_not_inst7_out)
+);
+corebit_not magma_Bit_not_inst8 (
+    .in(magma_Bits_2_eq_inst9_out),
+    .out(magma_Bit_not_inst8_out)
+);
+corebit_not magma_Bit_not_inst9 (
+    .in(magma_Bit_xor_inst5_out),
+    .out(magma_Bit_not_inst9_out)
 );
 corebit_xor magma_Bit_xor_inst0 (
     .in0(config_we),
@@ -442,6 +634,31 @@ corebit_xor magma_Bit_xor_inst1 (
     .in0(config_we),
     .in1(bit_const_1_None_out),
     .out(magma_Bit_xor_inst1_out)
+);
+corebit_xor magma_Bit_xor_inst10 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst10_out)
+);
+corebit_xor magma_Bit_xor_inst11 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst11_out)
+);
+corebit_xor magma_Bit_xor_inst12 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst12_out)
+);
+corebit_xor magma_Bit_xor_inst13 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst13_out)
+);
+corebit_xor magma_Bit_xor_inst14 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst14_out)
 );
 corebit_xor magma_Bit_xor_inst2 (
     .in0(config_we),
@@ -468,6 +685,21 @@ corebit_xor magma_Bit_xor_inst6 (
     .in1(bit_const_1_None_out),
     .out(magma_Bit_xor_inst6_out)
 );
+corebit_xor magma_Bit_xor_inst7 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst7_out)
+);
+corebit_xor magma_Bit_xor_inst8 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst8_out)
+);
+corebit_xor magma_Bit_xor_inst9 (
+    .in0(config_we),
+    .in1(bit_const_1_None_out),
+    .out(magma_Bit_xor_inst9_out)
+);
 coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst0 (
@@ -486,7 +718,7 @@ coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst10 (
     .in0(mode),
-    .in1(const_0_2_out),
+    .in1(const_1_2_out),
     .out(magma_Bits_2_eq_inst10_out)
 );
 coreir_eq #(
@@ -500,7 +732,7 @@ coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst12 (
     .in0(mode),
-    .in1(const_0_2_out),
+    .in1(const_1_2_out),
     .out(magma_Bits_2_eq_inst12_out)
 );
 coreir_eq #(
@@ -509,6 +741,34 @@ coreir_eq #(
     .in0(mode),
     .in1(const_0_2_out),
     .out(magma_Bits_2_eq_inst13_out)
+);
+coreir_eq #(
+    .width(2)
+) magma_Bits_2_eq_inst14 (
+    .in0(mode),
+    .in1(const_0_2_out),
+    .out(magma_Bits_2_eq_inst14_out)
+);
+coreir_eq #(
+    .width(2)
+) magma_Bits_2_eq_inst15 (
+    .in0(mode),
+    .in1(const_0_2_out),
+    .out(magma_Bits_2_eq_inst15_out)
+);
+coreir_eq #(
+    .width(2)
+) magma_Bits_2_eq_inst16 (
+    .in0(mode),
+    .in1(const_0_2_out),
+    .out(magma_Bits_2_eq_inst16_out)
+);
+coreir_eq #(
+    .width(2)
+) magma_Bits_2_eq_inst17 (
+    .in0(mode),
+    .in1(const_0_2_out),
+    .out(magma_Bits_2_eq_inst17_out)
 );
 coreir_eq #(
     .width(2)
@@ -549,7 +809,7 @@ coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst7 (
     .in0(mode),
-    .in1(const_1_2_out),
+    .in1(const_0_2_out),
     .out(magma_Bits_2_eq_inst7_out)
 );
 coreir_eq #(
@@ -563,7 +823,7 @@ coreir_eq #(
     .width(2)
 ) magma_Bits_2_eq_inst9 (
     .in0(mode),
-    .in1(const_1_2_out),
+    .in1(const_0_2_out),
     .out(magma_Bits_2_eq_inst9_out)
 );
 assign O0 = Mux2xOutBits4_inst12_O;

--- a/tests/test_syntax/test_coroutine/build/.gitignore
+++ b/tests/test_syntax/test_coroutine/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_syntax/test_coroutine/test_uart.py
+++ b/tests/test_syntax/test_coroutine/test_uart.py
@@ -30,6 +30,7 @@ def test_uart():
     m.compile("build/UART", UART)
 
     tester = fault.Tester(UART, UART.CLK)
+    tester.poke(UART.CLK, 0)
     tester.poke(UART.ASYNCRESET, 0)
     tester.eval()
     tester.poke(UART.ASYNCRESET, 1)

--- a/tests/test_syntax/test_coroutine/test_uart.py
+++ b/tests/test_syntax/test_coroutine/test_uart.py
@@ -1,0 +1,25 @@
+import magma as m
+
+
+def test_uart():
+    @m.syntax.coroutine
+    class UART:
+        def __init__(self):
+            self.message: m.Bits[8] = 0
+            self.i: m.Bits[2] = 0
+            self.tx: m.Bit = 1
+
+        def __call__(self, run: m.Bit, message: m.Bits[8]) -> m.Bit:
+            self.tx = 1  # end bit or idle
+            yield self.tx.prev()
+            if run:
+                self.message = message
+                self.tx = 0  # start bit
+                yield self.tx.prev()
+                while True:
+                    self.i += 1
+                    self.tx = self.message[self.i.prev()]
+                    yield self.tx.prev()
+                    if self.i == 0:
+                        break
+    m.compile("build/uart", UART)

--- a/tests/test_syntax/test_coroutine/test_uart.py
+++ b/tests/test_syntax/test_coroutine/test_uart.py
@@ -21,18 +21,19 @@ def test_uart():
             self.tx: m.Bit = 1
 
         def __call__(self, run: m.Bit, message: m.Bits[8]) -> m.Bit:
-            self.tx = m.bit(1)  # end bit or idle
-            yield self.tx.prev()
-            if run:
-                self.message = message
-                self.tx = m.bit(0)  # start bit
+            while True:
+                self.tx = m.bit(1)  # end bit or idle
                 yield self.tx.prev()
-                while True:
-                    self.i = self.i - 1
-                    self.tx = self.message[self.i.prev()]
+                if run:
+                    self.message = message
+                    self.tx = m.bit(0)  # start bit
                     yield self.tx.prev()
-                    if self.i == 7:
-                        break
+                    while True:
+                        self.i = self.i - 1
+                        self.tx = self.message[self.i.prev()]
+                        yield self.tx.prev()
+                        if self.i == 7:
+                            break
 
     m.compile("build/UART", UART)
 

--- a/tests/test_syntax/test_coroutine/test_uart.py
+++ b/tests/test_syntax/test_coroutine/test_uart.py
@@ -6,18 +6,18 @@ def test_uart():
     class UART:
         def __init__(self):
             self.message: m.Bits[8] = 0
-            self.i: m.Bits[2] = 0
+            self.i: m.UInt[3] = 0
             self.tx: m.Bit = 1
 
         def __call__(self, run: m.Bit, message: m.Bits[8]) -> m.Bit:
-            self.tx = 1  # end bit or idle
+            self.tx = m.bit(1)  # end bit or idle
             yield self.tx.prev()
             if run:
                 self.message = message
-                self.tx = 0  # start bit
+                self.tx = m.bit(0)  # start bit
                 yield self.tx.prev()
                 while True:
-                    self.i += 1
+                    self.i = self.i + 1
                     self.tx = self.message[self.i.prev()]
                     yield self.tx.prev()
                     if self.i == 0:

--- a/tests/test_syntax/test_coroutine/test_uart.py
+++ b/tests/test_syntax/test_coroutine/test_uart.py
@@ -1,8 +1,15 @@
 import os
 import tempfile
+import sys
 
 import magma as m
 import fault
+
+TEST_SYNTAX_PATH = os.path.join(os.path.dirname(__file__), '../')
+
+sys.path.append(TEST_SYNTAX_PATH)
+
+from test_sequential import DefineRegister, phi
 
 
 def test_uart():

--- a/tests/test_syntax/test_sequential.py
+++ b/tests/test_syntax/test_sequential.py
@@ -94,8 +94,8 @@ def DefineCoreirReg(width, init=0, has_async_reset=False,
         coreir_name = "reg_arst" if (has_async_reset or has_async_resetn) else "reg"
         verilog_name = "coreir_" + coreir_name
         coreir_lib = "coreir"
-        simulate=gen_sim_register(width, init, False, has_async_reset,
-                                  has_async_resetn)
+        simulate = gen_sim_register(width, init, False, has_async_reset,
+                                    has_async_resetn)
     return CoreIRReg
 
 

--- a/tests/test_syntax/test_sequential.py
+++ b/tests/test_syntax/test_sequential.py
@@ -86,6 +86,7 @@ def DefineCoreirReg(width, init=0, has_async_reset=False,
         io = m.IO(**io_dict)
         renamed_ports = m.circuit.coreir_port_mapping
         stateful = True
+        primitive = True
         circuit_type_methods = methods
         default_kwargs = {"init": coreir.type.BitVector[width](init)}
         coreir_genargs = gen_args


### PR DESCRIPTION
This is an initial PR adding Silica's coroutine capabilities to magma by building on top of sequential.

A magma coroutine is a sequential circuit that can use `yield` inside the `__call__` method.

The implementation requires a fork of the `staticfg` package to support `break` statements.  I will be submitting a PR to the mainline shortly, but since this is an experimental feature I think the `requirements.txt` pattern should suffice.  Anyone interested in using this can manually install the fork easily.

The implementation uses the basic "tracing" algorithm that generates the logic for each yield.  The SSA algorithm will come in a follow up pull request.  As will more complicated circuits/tests for the JTAG and SSA.

This also adds support for the `self.<register_name>.prev()` syntax proposed by @phanrahan .  This will return the previous value of the register, even if it has already been updated with a blocking assignment.  This is useful for circuits that register their outputs.  It is syntax sugar for storing the current value in a temporary, then referring to the temporary (avoiding the syntactic overhead for the common case of registered outputs). 

The gold files for some tests were updated because the SSA logic was changed to use the `~` operator primitive instead of the `Not` mantle function.  Also needed to fix a bug in the SSA logic for nested returns.

There's some updates to old declare circuit syntax to avoid deprecation warnings that came up in the tests.