### PR TITLE
Add header/footer compile interface

### DIFF
--- a/magma/backend/coreir_compiler.py
+++ b/magma/backend/coreir_compiler.py
@@ -5,6 +5,10 @@ from ..compiler import Compiler
 from ..frontend import coreir_ as coreir_frontend
 from ..passes import InstanceGraphPass
 from ..passes.insert_coreir_wires import InsertCoreIRWires
+from ..logging import root_logger
+
+
+_logger = root_logger()
 
 
 def _make_verilog_cmd(deps, basename, opts):
@@ -37,6 +41,16 @@ class CoreIRCompiler(Compiler):
         self.__compile_coreir()
         if self.opts.get("output_verilog", False):
             self.__compile_verilog()
+            return
+        if self.opts.get("header_file", False):
+            _logger.warning("[coreir-compiler] header_file only supported "
+                            "when output_verilog=True, ignoring")
+        if self.opts.get("header_str", False):
+            _logger.warning("[coreir-compiler] header_str only supported "
+                            "when output_verilog=True, ignoring")
+        if self.opts.get("footer_str", False):
+            _logger.warning("[coreir-compiler] footer_str only "
+                            "supported when output_verilog=True, ignoring")
 
     def __compile_coreir(self):
         backend = coreir_frontend.GetCoreIRBackend()
@@ -51,9 +65,11 @@ class CoreIRCompiler(Compiler):
         # TODO(rsetaluri): Expose compilation to verilog in pycoreir rather than
         # calling the binary from the command line.
         cmd = _make_verilog_cmd(self.deps, self.basename, self.opts)
+
         ret = subprocess.run(cmd, shell=True).returncode
         if ret:
             raise RuntimeError(f"CoreIR cmd '{cmd}' failed with code {ret}")
+        self._process_header_footer()
 
         backend = coreir_frontend.GetCoreIRBackend()
         # TODO: We need fresh bind_files for each compile call
@@ -76,3 +92,23 @@ class CoreIRCompiler(Compiler):
                 deps |= key.coreir_wrapped_modules_libs_used
         deps |= set(self.namespaces)
         return deps
+
+    def _process_header_footer(self):
+        header = ""
+        footer = ""
+        if self.opts.get("header_file", False):
+            with open(self.opts["header_file"], "r") as header_file:
+                header = header_file.read() + "\n"
+        if self.opts.get("header_str", False):
+            header += self.opts["header_str"] + "\n"
+        if self.opts.get("footer_str", False):
+            footer = self.opts["footer_str"]
+        if header is not "" or footer is not "":
+            if self.opts.get("split", False):
+                _logger.warning(
+                    "header/footer logic not supported with split, ignoring")
+                return
+            with open(f"{self.basename}.v", "r") as verilog_file:
+                verilog = verilog_file.read()
+            with open(f"{self.basename}.v", "w") as verilog_file:
+                verilog_file.write(header + verilog + "\n" + footer)

--- a/tests/test_compile/build/.gitignore
+++ b/tests/test_compile/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_compile/gold/test_header_footer.v
+++ b/tests/test_compile/gold/test_header_footer.v
@@ -1,0 +1,21 @@
+/*
+This is a test header, useful for something like a copyright that you'd like to
+include in all your generated files
+*/
+
+`ifdef FOO
+// Module `Foo` defined externally
+module Main (
+    input I,
+    output O
+);
+wire Foo_inst0_y;
+Foo Foo_inst0 (
+    .x(I),
+    .y(Foo_inst0_y)
+);
+assign O = Foo_inst0_y;
+endmodule
+
+
+`endif

--- a/tests/test_compile/test_header.v
+++ b/tests/test_compile/test_header.v
@@ -1,0 +1,4 @@
+/*
+This is a test header, useful for something like a copyright that you'd like to
+include in all your generated files
+*/

--- a/tests/test_compile/test_header_footer.py
+++ b/tests/test_compile/test_header_footer.py
@@ -1,0 +1,21 @@
+import os
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_header_footer():
+    class Foo(m.Circuit):
+        io = m.IO(x=m.In(m.Bit), y=m.Out(m.Bit))
+
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+        foo = Foo()
+        foo.x @= io.I
+        io.O @= foo.y
+
+    header_file = os.path.join(os.path.dirname(__file__), "test_header.v")
+    m.compile("build/test_header_footer", Main, header_file=header_file,
+              header_str="`ifdef FOO", footer_str="`endif")
+
+    assert check_files_equal(__file__, f"build/test_header_footer.v",
+                             f"gold/test_header_footer.v")


### PR DESCRIPTION
Feature request to easily insert a header from a file (e.g. a copyright string), as well as header/footer strings (e.g. inserting `` `ifdef`` and `` `endif`)