### PR TITLE
Add coroutine jtag test

### DIFF
--- a/magma/syntax/__init__.py
+++ b/magma/syntax/__init__.py
@@ -1,3 +1,3 @@
 from magma.syntax.combinational import combinational
 from magma.syntax.verilog import build_kratos_debug_info
-from .coroutine import coroutine, generator
+from .coroutine import coroutine

--- a/magma/syntax/__init__.py
+++ b/magma/syntax/__init__.py
@@ -1,3 +1,3 @@
 from magma.syntax.combinational import combinational
 from magma.syntax.verilog import build_kratos_debug_info
-from .coroutine import coroutine
+from .coroutine import coroutine, generator

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -168,7 +168,7 @@ def _coroutine(defn_env, fn):
     if not manual_encoding:
         method_name_map["__init__"].body.append(ast.parse(
             f"self.yield_state: m.Bits[{yield_state_width}] = 0"
-    ).body[0])
+        ).body[0])
 
     # create new call body
     call_method.body = []

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -127,24 +127,6 @@ def get_options(tree):
     return class_vars
 
 
-def get_manual_encoding(paths):
-    encoding = None
-    for path in paths:
-        for stmt in path:
-            print(ast.dump(stmt))
-            if isinstance(stmt, ast.Assign) and len(stmt.targets) == 0 \
-                    and isinstance(stmt.targets[0], ast.Attribute) and \
-                    isinstance(stmt.targets[0].value, ast.Name) and \
-                    stmt.targets[0].value.id == "self" and \
-                    stmt.targets[0].attr == "yield_state":
-                if encoding is None:
-                    encoding = stmt.value
-                else:
-                    assert ast.dump(encoding) == ast.dump(stmt.value)
-    assert encoding is not None
-    return encoding
-
-
 def _coroutine(defn_env, fn):
     tree = get_ast(fn).body[0]
     method_name_map = build_method_name_map(tree)

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -158,9 +158,10 @@ def _coroutine(defn_env, fn):
                     encoding = len(yield_encoding_map)
                 else:
                     # TODO: Assumes previous stmt sets encoding
-                    encoding = block.statements[i - 1].value
-                yield_encoding_map[statement] = \
-                    astor.to_source(encoding).rstrip()
+                    encoding = astor.to_source(
+                        block.statements[i - 1].value
+                    ).rstrip()
+                yield_encoding_map[statement] = encoding
 
     # add yield state register declaration
     yield_state_width = clog2(len(yield_encoding_map))

--- a/magma/syntax/transforms/__init__.py
+++ b/magma/syntax/transforms/__init__.py
@@ -1,0 +1,1 @@
+from .inline_yield_from import inline_yield_from_functions

--- a/magma/syntax/transforms/inline_yield_from.py
+++ b/magma/syntax/transforms/inline_yield_from.py
@@ -1,0 +1,80 @@
+import copy
+import ast
+from .replace_symbols import replace_symbols
+import astor
+from ...ast_utils import get_ast
+
+
+class YieldFromFunctionInliner(ast.NodeTransformer):
+    def __init__(self, method_name_map):
+        self.method_name_map = method_name_map
+
+    def visit(self, node):
+        """
+        For nodes with a `body` attribute, we explicitly traverse them and
+        flatten any lists that are returned. This allows visitors to return
+        more than one node.
+        """
+        if hasattr(node, 'body') and not isinstance(node, ast.IfExp):
+            new_body = []
+            for statement in node.body:
+                result = self.visit(statement)
+                if isinstance(result, list):
+                    new_body.extend(result)
+                else:
+                    new_body.append(result)
+            node.body = new_body
+            if isinstance(node, ast.If):
+                new_orelse = []
+                for statement in node.orelse:
+                    result = self.visit(statement)
+                    if isinstance(result, list):
+                        new_orelse.extend(result)
+                    else:
+                        new_orelse.append(result)
+                node.orelse = new_orelse
+            return node
+        return super().visit(node)
+
+    def visit_Assign(self, node):
+        """
+        If node.value is a YieldFrom that is inlined, it will return a list, so
+        here we pass the list on so it can be flattened into the body of the
+        parent node
+        """
+        node.value = self.visit(node.value)
+        if isinstance(node.value, list):
+            return node.value
+        return node
+
+    def visit_Expr(self, node):
+        node = self.generic_visit(node)
+        if isinstance(node.value, list):
+            return node.value
+        return node
+
+
+    def visit_YieldFrom(self, node):
+        if isinstance(node.value, ast.Call):
+            func = node.value
+            if (not isinstance(func.func, ast.Attribute)
+                    and isinstance(func.func.value, ast.Name)
+                    and func.func.value.id == "self"):
+                raise NotImplementedError(ast.dump(func))
+            tree = copy.deepcopy(self.method_name_map[func.func.attr])
+            symbol_table = {}
+            # Skip self arg
+            for arg, param in zip(func.args, tree.args.args[1:]):
+                symbol_table[param.arg] = arg
+            tree = replace_symbols(tree, symbol_table)
+            # TODO: Assumes make function is well formed
+            # TODO: Assumes return is well formed
+            return tree.body[0].body[:-1]
+        else:
+            return node
+
+
+
+def inline_yield_from_functions(tree, method_name_map):
+    return YieldFromFunctionInliner(method_name_map).visit(tree)
+

--- a/magma/syntax/transforms/inline_yield_from.py
+++ b/magma/syntax/transforms/inline_yield_from.py
@@ -53,7 +53,6 @@ class YieldFromFunctionInliner(ast.NodeTransformer):
             return node.value
         return node
 
-
     def visit_YieldFrom(self, node):
         if isinstance(node.value, ast.Call):
             func = node.value
@@ -74,7 +73,5 @@ class YieldFromFunctionInliner(ast.NodeTransformer):
             return node
 
 
-
 def inline_yield_from_functions(tree, method_name_map):
     return YieldFromFunctionInliner(method_name_map).visit(tree)
-

--- a/magma/syntax/transforms/replace_symbols.py
+++ b/magma/syntax/transforms/replace_symbols.py
@@ -1,0 +1,21 @@
+import ast
+from copy import deepcopy
+
+
+class SymbolReplacer(ast.NodeTransformer):
+    def __init__(self, symbol_table, ctx):
+        self.symbol_table = symbol_table
+        self.ctx = ctx
+
+    def visit_Name(self, node):
+        if node.id in self.symbol_table:
+            if self.ctx is None:
+                new_node = deepcopy(self.symbol_table[node.id])
+                new_node.ctx = node.ctx
+                return new_node
+            elif isinstance(node.ctx, self.ctx):
+                return deepcopy(self.symbol_table[node.id])
+        return node
+
+def replace_symbols(tree, symbol_table, ctx=None):
+    return SymbolReplacer(symbol_table, ctx).visit(tree)

--- a/magma/syntax/transforms/replace_symbols.py
+++ b/magma/syntax/transforms/replace_symbols.py
@@ -17,5 +17,6 @@ class SymbolReplacer(ast.NodeTransformer):
                 return deepcopy(self.symbol_table[node.id])
         return node
 
+
 def replace_symbols(tree, symbol_table, ctx=None):
     return SymbolReplacer(symbol_table, ctx).visit(tree)

--- a/tests/test_syntax/test_coroutine/test_jtag.py
+++ b/tests/test_syntax/test_coroutine/test_jtag.py
@@ -32,33 +32,34 @@ def test_jtag():
 
     @m.syntax.coroutine
     class JTAG:
+        _manual_encoding_ = True
+
         def __init__(self):
-            # TODO: Reuse for yield state
-            self.state: m.Bits[4] = TEST_LOGIC_RESET
+            self.yield_state: m.Bits[4] = TEST_LOGIC_RESET
 
         def __call__(self, tms: m.Bit) -> m.Bits[4]:
             # TODO: Prune infeasible paths (or check if synthesis optimizes
             # them out)
             while True:
                 while True:
-                    self.state = TEST_LOGIC_RESET
-                    yield self.state.prev()
+                    self.yield_state = TEST_LOGIC_RESET
+                    yield self.yield_state.prev()
                     if tms == 0:
                         break
                 while tms == 0:
-                    self.state = RUN_TEST_IDLE
-                    yield self.state.prev()
+                    self.yield_state = RUN_TEST_IDLE
+                    yield self.yield_state.prev()
                 while tms == 1:
-                    self.state = SELECT_DR_SCAN
-                    yield self.state.prev()
+                    self.yield_state = SELECT_DR_SCAN
+                    yield self.yield_state.prev()
                     if tms == 0:
                         # dr
                         yield from self.make_scan(CAPTURE_DR, SHIFT_DR,
                                                   EXIT1_DR, PAUSE_DR, EXIT2_DR,
                                                   UPDATE_DR)
                     else:
-                        self.state = SELECT_IR_SCAN
-                        yield self.state.prev()
+                        self.yield_state = SELECT_IR_SCAN
+                        yield self.yield_state.prev()
                         if tms == 0:
                             # ir
                             yield from self.make_scan(CAPTURE_IR, SHIFT_IR,
@@ -69,31 +70,31 @@ def test_jtag():
 
         def make_scan(self, capture, shift, exit_1, pause, exit_2, update):
             def scan(self, tms: m.Bit) -> m.Bits[4]:
-                self.state = capture
-                yield self.state.prev()
+                self.yield_state = capture
+                yield self.yield_state.prev()
                 while True:
                     if tms == 0:
                         while True:
-                            self.state = shift
-                            yield self.state.prev()
+                            self.yield_state = shift
+                            yield self.yield_state.prev()
                             if tms != 0:
                                 break
-                    self.state = exit_1
-                    yield self.state.prev()
+                    self.yield_state = exit_1
+                    yield self.yield_state.prev()
                     if tms == 0:
                         while True:
-                            self.state = pause
-                            yield self.state.prev()
+                            self.yield_state = pause
+                            yield self.yield_state.prev()
                             if tms != 0:
                                 break
-                        self.state = exit_2
-                        yield self.state.prev()
+                        self.yield_state = exit_2
+                        yield self.yield_state.prev()
                         if tms != 0:
                             break
                     else:
                         break
-                self.state = update
-                yield self.state.prev()
+                self.yield_state = update
+                yield self.yield_state.prev()
                 return tms
             return scan()
 

--- a/tests/test_syntax/test_coroutine/test_jtag.py
+++ b/tests/test_syntax/test_coroutine/test_jtag.py
@@ -1,0 +1,231 @@
+import tempfile
+import os
+import sys
+
+import magma as m
+import fault
+
+TEST_SYNTAX_PATH = os.path.join(os.path.dirname(__file__), '../')
+
+sys.path.append(TEST_SYNTAX_PATH)
+
+from test_sequential import DefineRegister, phi
+
+
+def test_jtag():
+    TEST_LOGIC_RESET = m.bits(15, 4)
+    RUN_TEST_IDLE = m.bits(12, 4)
+    SELECT_DR_SCAN = m.bits(7, 4)
+    CAPTURE_DR = m.bits(6, 4)
+    SHIFT_DR = m.bits(2, 4)
+    EXIT1_DR = m.bits(1, 4)
+    PAUSE_DR = m.bits(3, 4)
+    EXIT2_DR = m.bits(0, 4)
+    UPDATE_DR = m.bits(5, 4)
+    SELECT_IR_SCAN = m.bits(4, 4)
+    CAPTURE_IR = m.bits(14, 4)
+    SHIFT_IR = m.bits(10, 4)
+    EXIT1_IR = m.bits(9, 4)
+    PAUSE_IR = m.bits(11, 4)
+    EXIT2_IR = m.bits(8, 4)
+    UPDATE_IR = m.bits(13, 4)
+
+    @m.syntax.coroutine
+    class JTAG:
+        def __init__(self):
+            # TODO: Reuse for yield state
+            self.state: m.Bits[4] = TEST_LOGIC_RESET
+
+        def __call__(self, tms: m.Bit) -> m.Bits[4]:
+            # TODO: Prune infeasible paths (or check if synthesis optimizes
+            # them out)
+            while True:
+                while True:
+                    self.state = TEST_LOGIC_RESET
+                    yield self.state.prev()
+                    if tms == 0:
+                        break
+                while tms == 0:
+                    self.state = RUN_TEST_IDLE
+                    yield self.state.prev()
+                while tms == 1:
+                    self.state = SELECT_DR_SCAN
+                    yield self.state.prev()
+                    if tms == 0:
+                        # dr
+                        yield from self.make_scan(CAPTURE_DR, SHIFT_DR,
+                                                  EXIT1_DR, PAUSE_DR, EXIT2_DR,
+                                                  UPDATE_DR)
+                    else:
+                        self.state = SELECT_IR_SCAN
+                        yield self.state.prev()
+                        if tms == 0:
+                            # ir
+                            yield from self.make_scan(CAPTURE_IR, SHIFT_IR,
+                                                      EXIT1_IR, PAUSE_IR,
+                                                      EXIT2_IR, UPDATE_IR)
+                        else:
+                            break
+
+        def make_scan(self, capture, shift, exit_1, pause, exit_2, update):
+            def scan(self, tms: m.Bit) -> m.Bits[4]:
+                self.state = capture
+                yield self.state.prev()
+                while True:
+                    if tms == 0:
+                        while True:
+                            self.state = shift
+                            yield self.state.prev()
+                            if tms != 0:
+                                break
+                    self.state = exit_1
+                    yield self.state.prev()
+                    if tms == 0:
+                        while True:
+                            self.state = pause
+                            yield self.state.prev()
+                            if tms != 0:
+                                break
+                        self.state = exit_2
+                        yield self.state.prev()
+                        if tms != 0:
+                            break
+                    else:
+                        break
+                self.state = update
+                yield self.state.prev()
+                return tms
+            return scan()
+
+    m.compile("build/JTAG", JTAG)
+
+    tester = fault.Tester(JTAG, JTAG.CLK)
+    tester.circuit.tms = 1
+    tester.circuit.ASYNCRESET = 0
+    tester.eval()
+    tester.circuit.ASYNCRESET = 1
+    tester.eval()
+    tester.circuit.ASYNCRESET = 0
+    tester.eval()
+    tester.step(2)
+    tester.circuit.O.expect(int(TEST_LOGIC_RESET))
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(TEST_LOGIC_RESET))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(RUN_TEST_IDLE))
+
+    tester.step(2)
+    tester.circuit.O.expect(int(RUN_TEST_IDLE))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_DR_SCAN))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(CAPTURE_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT1_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(PAUSE_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(PAUSE_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT2_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT1_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(UPDATE_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_DR_SCAN))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_IR_SCAN))
+
+    # BEGIN REPEAT FOR IR
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(CAPTURE_IR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT1_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(PAUSE_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(PAUSE_IR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT2_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_IR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT1_IR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(UPDATE_IR))
+    # END REPEAT FOR IR
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_DR_SCAN))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_IR_SCAN))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(TEST_LOGIC_RESET))
+
+    directory = f"{os.path.abspath(os.path.dirname(__file__))}/build/"
+    tester.compile_and_run(target="verilator", directory=directory,
+                           flags=['-Wno-fatal', "--trace"], skip_compile=True)


### PR DESCRIPTION
Preliminary JTAG implementation.

There's still some improvements to be made but this adds what's needed for a functional compiler output.

improvements:
1) Merge JTAG yield output and yield state register (the FSM yields it's state as the output, the choice of each yield's encoding is important, allow the user to override the default encoding for yield IDs, need a good syntax for this).  This is important for optimization (shouldn't need two separate registers), but functionality this implementation works.
2) The compiler does not prune infeasible paths from the control flow graph, so if you write this the wrong way, it will break the compiler (e.g. infinite loop in the CFG even though it's infeasible).  CC @cdonovick given a list of conditions in AST form, e.g. `(tmp == 0) & (tms == 1)` is there a simple way to check satisfiability using pysmt and/or smtbitvector? I can collect the variable names in the expression pretty easily, so I could create a lambda's and pass in a symbolic variable for each value and return a constructed expression.  Then I just need to pass this to a solver.  