### PR TITLE
Fix double update

### DIFF
--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -211,12 +211,13 @@ def _coroutine(defn_env, fn):
                     body = body[-1].body
             assert end_yield is not None, "Found path not ending in yield"
 
-            # Finish with updating the yield state register with the end yield
-            # of the path
-            body.append(ast.parse(
-                f"self.yield_state = m.bits({yield_encoding_map[end_yield]}, "
-                f"{yield_state_width})"
-            ).body[0])
+            if not manual_encoding:
+                # Finish with updating the yield state register with the end
+                # yield of the path
+                body.append(ast.parse(
+                    f"self.yield_state = m.bits({yield_encoding_map[end_yield]}, "
+                    f"{yield_state_width})"
+                ).body[0])
 
             # Return the value of the original end yield
             body.append(ast.Return(end_yield.value.value))

--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -215,8 +215,8 @@ def _coroutine(defn_env, fn):
                 # Finish with updating the yield state register with the end
                 # yield of the path
                 body.append(ast.parse(
-                    f"self.yield_state = m.bits({yield_encoding_map[end_yield]}, "
-                    f"{yield_state_width})"
+                    f"self.yield_state = m.bits("
+                    f"{yield_encoding_map[end_yield]}, {yield_state_width})"
                 ).body[0])
 
             # Return the value of the original end yield

--- a/tests/test_syntax/test_coroutine/test_jtag.py
+++ b/tests/test_syntax/test_coroutine/test_jtag.py
@@ -98,7 +98,7 @@ def test_jtag():
                 return tms
             return scan()
 
-    m.compile("build/JTAG", JTAG)
+    m.compile("build/JTAG", JTAG, inline=True)
 
     tester = fault.Tester(JTAG, JTAG.CLK)
     tester.circuit.tms = 1


### PR DESCRIPTION
When manual encoding is used, the compiler should not insert the update to the state register since the user has already provided this