### PR TITLE
Fix inline verilog bit select bug

### DIFF
--- a/magma/verilog_utils.py
+++ b/magma/verilog_utils.py
@@ -2,6 +2,7 @@ from string import Formatter
 import magma as m
 from magma.view import InstView, PortView
 from .t import Type
+from .digital import Digital
 
 
 def value_to_verilog_name(value):
@@ -32,7 +33,11 @@ def verilog_name(name, inst_sep="."):
         return str(name)
     if isinstance(name, m.ref.ArrayRef):
         array_name = verilog_name(name.array.name)
-        return f"{array_name}_{name.index}"
+        if issubclass(name.array.T, Digital):
+            index = f"[{name.index}]"
+        else:
+            index = f"_{name.index}"
+        return f"{array_name}{index}"
     if isinstance(name, m.ref.TupleRef):
         tuple_name = verilog_name(name.tuple.name)
         index = name.index

--- a/tests/test_verilog/gold/RTLMonitor.sv
+++ b/tests/test_verilog/gold/RTLMonitor.sv
@@ -31,13 +31,18 @@ module RTLMonitor (
     input out
 );
 wire [3:0] arr_2d_0;
+wire arr_2d_0_1;
 wire [3:0] arr_2d_1;
 assign arr_2d_0 = in1;
+assign arr_2d_0_1 = in1[1];
 assign arr_2d_1 = in2;
 corebit_term corebit_term_inst0 (
     .in(intermediate_tuple__0)
 );
 corebit_term corebit_term_inst1 (
+    .in(arr_2d_0_1)
+);
+corebit_term corebit_term_inst2 (
     .in(handshake_valid)
 );
 coreir_term #(
@@ -55,7 +60,7 @@ logic temp1, temp2;
 logic [3:0] temp3;
 assign temp1 = |(in1);
 assign temp2 = &(in1) & intermediate_tuple__0;
-assign temp3 = in1 ^ in2;
+assign temp3 = in1 ^ in2 & arr_2d_0[1];
 assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
 logic [3:0] temp4 [1:0];
 assign temp4 = '{arr_2d_1, arr_2d_0};

--- a/tests/test_verilog/gold/test_inline_simple.sv
+++ b/tests/test_verilog/gold/test_inline_simple.sv
@@ -1,3 +1,9 @@
+module corebit_term (
+    input in
+);
+
+endmodule
+
 module FF(input I, output reg O, input CLK);
 always @(posedge CLK) begin
   O <= I;
@@ -6,6 +12,7 @@ endmodule
 module Main (
     input I,
     output O,
+    input [1:0] arr,
     input CLK
 );
 FF FF_inst0 (
@@ -13,8 +20,18 @@ FF FF_inst0 (
     .O(O),
     .CLK(CLK)
 );
+corebit_term corebit_term_inst0 (
+    .in(arr[0])
+);
+corebit_term corebit_term_inst1 (
+    .in(arr[1])
+);
 
 assert property (@(posedge CLK) I |-> ##1 O);
+
+
+
+assert property (@(posedge CLK) arr[0] |-> ##1 arr[1]);
 
 endmodule
 

--- a/tests/test_verilog/rtl_monitor.py
+++ b/tests/test_verilog/rtl_monitor.py
@@ -22,7 +22,7 @@ logic temp1, temp2;
 logic [{width-1}:0] temp3;
 assign temp1 = |(in1);
 assign temp2 = &(in1) & {io.intermediate_tuple[0]};
-assign temp3 = in1 ^ in2;
+assign temp3 = in1 ^ in2 & {arr_2d[0][1]};
 assert property (@(posedge CLK) {valid} -> out === temp1 && temp2);
 logic [{width-1}:0] temp4 [1:0];
 assign temp4 = {arr_2d};

--- a/tests/test_verilog/test_inline.py
+++ b/tests/test_verilog/test_inline.py
@@ -13,11 +13,15 @@ endmodule
 """, type_map={"CLK": m.In(m.Clock)})[0]
 
     class Main(m.Circuit):
-        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit)) + m.ClockIO()
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit), arr=m.In(m.Bits[2]))
+        io += m.ClockIO()
         io.O <= FF()(io.I)
         m.inline_verilog("""
 assert property (@(posedge CLK) {I} |-> ##1 {O});
 """, O=io.O, I=io.I)
+        m.inline_verilog("""
+assert property (@(posedge CLK) {io.arr[0]} |-> ##1 {io.arr[1]});
+""")
 
     m.compile(f"build/test_inline_simple", Main, output="coreir-verilog",
               sv=True, inline=True)


### PR DESCRIPTION
Was not correctly generating an index expression (e.g. `arr[0]`) when selecting an index from an array.