### PR TITLE
Enable backwards compatability for undriven/unused logic

### DIFF
--- a/magma/passes/drive_undriven.py
+++ b/magma/passes/drive_undriven.py
@@ -1,4 +1,5 @@
 from .passes import EditCircuitPass
+from ..is_definition import isdefinition
 
 
 def _drive_undriven(interface):
@@ -14,5 +15,6 @@ class DriveUndrivenPass(EditCircuitPass):
     def edit(self, circuit):
         if _drive_undriven(circuit.interface):
             circuit._is_definition = True
-        for inst in circuit.instances:
-            _drive_undriven(inst.interface)
+        if isdefinition(circuit):
+            for inst in circuit.instances:
+                _drive_undriven(inst.interface)

--- a/magma/passes/passes.py
+++ b/magma/passes/passes.py
@@ -48,8 +48,9 @@ class CircuitPass(Pass):
         self.circuits = {}
 
     def _run(self, circuit):
-        for inst in circuit.instances:
-            self._run(type(inst))
+        if isdefinition(circuit):
+            for inst in circuit.instances:
+                self._run(type(inst))
         # Call each definition only once.
         id_ = id(circuit)
         if id_ not in self.circuits:

--- a/magma/passes/terminate_unused.py
+++ b/magma/passes/terminate_unused.py
@@ -5,7 +5,7 @@ from ..is_definition import isdefinition
 def _terminate_unused(interface):
     terminated = False
     for port in interface.ports.values():
-        if port.is_output() and port.wired() is False:
+        if port.is_output() and not port.wired():
             terminated = True
             port.unused()
     return terminated

--- a/magma/passes/terminate_unused.py
+++ b/magma/passes/terminate_unused.py
@@ -1,4 +1,5 @@
 from .passes import EditCircuitPass
+from ..is_definition import isdefinition
 
 
 def _terminate_unused(interface):
@@ -14,5 +15,6 @@ class TerminateUnusedPass(EditCircuitPass):
     def edit(self, circuit):
         if _terminate_unused(circuit.interface):
             circuit._is_definition = True
-        for inst in circuit.instances:
-            _terminate_unused(inst.interface)
+        if isdefinition(circuit):
+            for inst in circuit.instances:
+                _terminate_unused(inst.interface)

--- a/tests/test_circuit/gold/test_ignore_unused_undriven_basic.v
+++ b/tests/test_circuit/gold/test_ignore_unused_undriven_basic.v
@@ -4,9 +4,18 @@ module corebit_undriven (
 
 endmodule
 
+module corebit_term (
+    input in
+);
+
+endmodule
+
 module Main (
     input I,
     output O
+);
+corebit_term corebit_term_inst0 (
+    .in(I)
 );
 corebit_undriven corebit_undriven_inst0 (
     .out(O)

--- a/tests/test_circuit/gold/test_ignore_unused_undriven_hierarchy.v
+++ b/tests/test_circuit/gold/test_ignore_unused_undriven_hierarchy.v
@@ -1,3 +1,4 @@
+// Module `Bar` defined externally
 module corebit_undriven (
     output out
 );
@@ -9,6 +10,9 @@ module Foo (
     input I1,
     output O0,
     output O1
+);
+Bar Bar_inst0 (
+    .I(I1)
 );
 corebit_undriven corebit_undriven_inst0 (
     .out(O0)

--- a/tests/test_circuit/gold/test_ignore_unused_undriven_hierarchy.v
+++ b/tests/test_circuit/gold/test_ignore_unused_undriven_hierarchy.v
@@ -5,6 +5,12 @@ module corebit_undriven (
 
 endmodule
 
+module corebit_term (
+    input in
+);
+
+endmodule
+
 module Foo (
     input I0,
     input I1,
@@ -33,6 +39,12 @@ Foo Foo_inst0 (
     .I1(corebit_undriven_inst1_out),
     .O0(O0),
     .O1(Foo_inst0_O1)
+);
+corebit_term corebit_term_inst0 (
+    .in(I1)
+);
+corebit_term corebit_term_inst1 (
+    .in(Foo_inst0_O1)
 );
 corebit_undriven corebit_undriven_inst0 (
     .out(O1)

--- a/tests/test_circuit/test_undriven_unused.py
+++ b/tests/test_circuit/test_undriven_unused.py
@@ -20,11 +20,15 @@ def test_ignore_unused_undriven_basic():
 
 
 def test_ignore_unused_undriven_hierarchy():
+    # For backwards compatability test
+    Bar = m.DeclareCircuit("Bar", "I", m.In(m.Bit))
+
     class Foo(m.Circuit):
         io = m.IO(I0=m.In(m.Bit), I1=m.In(m.Bit),
                   O0=m.Out(m.Bit), O1=m.Out(m.Bit))
 
         io.O1 @= io.I0
+        Bar()(io.I1)
 
     class Main(m.Circuit):
         _ignore_undriven_ = True

--- a/tests/test_deprecated/test_old_io_syntax/gold/test_ignore_unused_undriven_basic.v
+++ b/tests/test_deprecated/test_old_io_syntax/gold/test_ignore_unused_undriven_basic.v
@@ -4,9 +4,18 @@ module corebit_undriven (
 
 endmodule
 
+module corebit_term (
+    input in
+);
+
+endmodule
+
 module Main (
     input I,
     output O
+);
+corebit_term corebit_term_inst0 (
+    .in(I)
 );
 corebit_undriven corebit_undriven_inst0 (
     .out(O)

--- a/tests/test_deprecated/test_old_io_syntax/gold/test_ignore_unused_undriven_hierarchy.v
+++ b/tests/test_deprecated/test_old_io_syntax/gold/test_ignore_unused_undriven_hierarchy.v
@@ -4,11 +4,20 @@ module corebit_undriven (
 
 endmodule
 
+module corebit_term (
+    input in
+);
+
+endmodule
+
 module Foo (
     input I0,
     input I1,
     output O0,
     output O1
+);
+corebit_term corebit_term_inst0 (
+    .in(I1)
 );
 corebit_undriven corebit_undriven_inst0 (
     .out(O0)
@@ -29,6 +38,12 @@ Foo Foo_inst0 (
     .I1(corebit_undriven_inst1_out),
     .O0(O0),
     .O1(Foo_inst0_O1)
+);
+corebit_term corebit_term_inst0 (
+    .in(I1)
+);
+corebit_term corebit_term_inst1 (
+    .in(Foo_inst0_O1)
 );
 corebit_undriven corebit_undriven_inst0 (
     .out(O1)


### PR DESCRIPTION
The old-style `DeclareCircuit` does not populate the `instances` attribute.  This updates the passes to check `isdefintion` before referencing the attribute for backwards compatibility.