### PR TITLE
Copy locals for inline_verilog inside loops

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -134,6 +134,8 @@ class _DefinitionContextManager:
 def _has_definition(cls, port=None):
     if cls.instances:
         return True
+    if cls._context_._inline_verilog:
+        return True
     if port is None:
         interface = getattr(cls, "interface", None)
         if not interface:

--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -1,3 +1,4 @@
+import copy
 import string
 from ast_tools.stack import _SKIP_FRAME_DEBUG_STMT, get_symbol_table
 from magma.circuit import _definition_context_stack
@@ -49,7 +50,7 @@ class ProcessInlineVerilogPass(CircuitPass):
 
 def inline_verilog(format_str, **kwargs):
     exec(_SKIP_FRAME_DEBUG_STMT)
-    symbol_table = get_symbol_table([inline_verilog])
+    symbol_table = get_symbol_table([inline_verilog], copy_locals=True)
 
     context = _definition_context_stack.peek()
     context.add_inline_verilog(format_str, kwargs, symbol_table)

--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -1,4 +1,3 @@
-import copy
 import string
 from ast_tools.stack import _SKIP_FRAME_DEBUG_STMT, get_symbol_table
 from magma.circuit import _definition_context_stack

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "graphviz",
         "coreir>=2.0.*",
         "hwtypes>=1.0.*",
-        "ast_tools>=0.0.10",
+        "ast_tools>=0.0.15",
         "kratos",
         "staticfg"
     ],

--- a/tests/test_verilog/gold/test_inline_loop_var.v
+++ b/tests/test_verilog/gold/test_inline_loop_var.v
@@ -1,0 +1,71 @@
+module coreir_undriven #(
+    parameter width = 1
+) (
+    output [width-1:0] out
+);
+
+endmodule
+
+module Main (
+    output [4:0] O_0,
+    output [4:0] O_1,
+    output [4:0] O_2,
+    output [4:0] O_3,
+    output [4:0] O_4
+);
+wire [4:0] undriven_inst0_out;
+wire [4:0] undriven_inst1_out;
+wire [4:0] undriven_inst2_out;
+wire [4:0] undriven_inst3_out;
+wire [4:0] undriven_inst4_out;
+coreir_undriven #(
+    .width(5)
+) undriven_inst0 (
+    .out(undriven_inst0_out)
+);
+coreir_undriven #(
+    .width(5)
+) undriven_inst1 (
+    .out(undriven_inst1_out)
+);
+coreir_undriven #(
+    .width(5)
+) undriven_inst2 (
+    .out(undriven_inst2_out)
+);
+coreir_undriven #(
+    .width(5)
+) undriven_inst3 (
+    .out(undriven_inst3_out)
+);
+coreir_undriven #(
+    .width(5)
+) undriven_inst4 (
+    .out(undriven_inst4_out)
+);
+assign O_0 = undriven_inst0_out;
+assign O_1 = undriven_inst1_out;
+assign O_2 = undriven_inst2_out;
+assign O_3 = undriven_inst3_out;
+assign O_4 = undriven_inst4_out;
+
+assign O[0] = 0;
+            
+
+
+assign O[1] = 1;
+            
+
+
+assign O[2] = 2;
+            
+
+
+assign O[3] = 3;
+            
+
+
+assign O[4] = 4;
+            
+endmodule
+

--- a/tests/test_verilog/test_inline.py
+++ b/tests/test_verilog/test_inline.py
@@ -96,3 +96,18 @@ assert property (@(posedge CLK) {valid_in} |-> ##3 {ready_out});\
     assert m.testing.check_files_equal(__file__,
                                        f"build/test_inline_tuple.sv",
                                        f"gold/test_inline_tuple.sv")
+
+
+def test_inline_loop_var():
+    class Main(m.Circuit):
+        _ignore_undriven_ = True
+        io = m.IO(O=m.Out(m.Array[5, m.Bits[5]]))
+        for i in range(5):
+            m.inline_verilog("""
+assign O[{i}] = {i};
+            """)
+
+    m.compile(f"build/test_inline_loop_var", Main, drive_undriven=True)
+    assert m.testing.check_files_equal(__file__,
+                                       f"build/test_inline_loop_var.v",
+                                       f"gold/test_inline_loop_var.v")


### PR DESCRIPTION
Fixes a bug where locals are modified after inline_verilog is called (e.g. inside a loop) by copying the frames before storing it (since we are staging the logic until later).  Before this change, the resulting verilog would use the same (final) value of the loop variable for each inline string.

Depends on https://github.com/leonardt/ast_tools/pull/45

Also modifies the has_definition check to handle the case when there's only inline_verilog (used in the test)