### PR TITLE
Add 'driving' API

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -350,16 +350,8 @@ class Array(Type, metaclass=ArrayMeta):
                 return False
         return True
 
-    def driving_all(self):
-        return [t.driving() for t in self]
-
     def driving(self):
-        ts = [t.driving() for t in self]
-        if any(t is None for t in ts):
-            return None
-        if Array._iswhole(ts):
-            return ts[0].name.array
-        return type(self).flip()(*ts)
+        return [t.driving() for t in self]
 
     def wired(self):
         for t in self.ts:

--- a/magma/array.py
+++ b/magma/array.py
@@ -350,6 +350,17 @@ class Array(Type, metaclass=ArrayMeta):
                 return False
         return True
 
+    def driving_all(self):
+        return [t.driving() for t in self]
+
+    def driving(self):
+        ts = [t.driving() for t in self]
+        if any(t is None for t in ts):
+            return None
+        if Array._iswhole(ts):
+            return ts[0].name.array
+        return type(self).flip()(*ts)
+
     def wired(self):
         for t in self.ts:
             if not t.wired():

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -203,7 +203,7 @@ def _get_intermediate_values(value):
     values = OrderedIdentitySet()
     while driver is not None:
         values |= _add_intermediate_value(driver)
-        if driver.is_output():
+        if not driver.is_input():
             break
         value = driver
         driver = driver.value()

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -180,12 +180,8 @@ class Digital(Type, metaclass=DigitalMeta):
     def driven(self):
         return self._wire.driven()
 
-    def driving_all(self):
-        return self._wire.driving()
-
     def driving(self):
-        driving = self.driving_all()
-        return driving[0] if len(driving) == 1 else None
+        return self._wire.driving()
 
     @classmethod
     def unflatten(cls, value):

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -181,7 +181,7 @@ class Digital(Type, metaclass=DigitalMeta):
         return self._wire.driven()
 
     def driving_all(self):
-        return [d.bit for d in self._wire.driving]
+        return self._wire.driving()
 
     def driving(self):
         driving = self.driving_all()

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -180,6 +180,13 @@ class Digital(Type, metaclass=DigitalMeta):
     def driven(self):
         return self._wire.driven()
 
+    def driving_all(self):
+        return [d.bit for d in self._wire.driving]
+
+    def driving(self):
+        driving = self.driving_all()
+        return driving[0] if len(driving) == 1 else None
+
     @classmethod
     def unflatten(cls, value):
         if len(value) != 1 or not isinstance(value[0], Digital):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -284,6 +284,17 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
 
         return type(self).flip()(*ts)
 
+    def driving_all(self):
+        return {k: t.driving() for k, t in self.items()}
+
+    def driving(self):
+        ts = [t.driving() for t in self]
+        if any(t is None for t in ts):
+            return None
+        if Tuple._iswhole(ts, self.keys()):
+            return ts[0].name.tuple
+        return type(self).flip()(*ts)
+
     @classmethod
     def unflatten(cls, value):
         values = []

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -284,16 +284,8 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
 
         return type(self).flip()(*ts)
 
-    def driving_all(self):
-        return {k: t.driving() for k, t in self.items()}
-
     def driving(self):
-        ts = [t.driving() for t in self]
-        if any(t is None for t in ts):
-            return None
-        if Tuple._iswhole(ts, self.keys()):
-            return ts[0].name.tuple
-        return type(self).flip()(*ts)
+        return {k: t.driving() for k, t in self.items()}
 
     @classmethod
     def unflatten(cls, value):

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -11,55 +11,55 @@ class Wire:
     Each wire is represented by a bit.
     """
     def __init__(self, bit):
-        self.bit = bit
-        self.driving = []
-        self.driver = None
+        self._bit = bit
+        self._driving = []
+        self._driver = None
 
     def __repr__(self):
-        return repr(self.bit)
+        return repr(self._bit)
 
     def __str__(self):
-        return str(self.bit)
+        return str(self._bit)
 
     def anon(self):
-        return self.bit.anon()
+        return self._bit.anon()
 
     def unwire(self, other):
-        other.driving.remove(self)
-        self.driver = None
+        other._driving.remove(self)
+        self._driver = None
 
     def connect(self, other, debug_info):
         """
         Connect two wires, self should be an input and other should be an
         output, or both should be inouts
         """
-        if self.driver is not None and self.bit.is_input():
+        if self._driver is not None and self._bit.is_input():
             _logger.warning(
                 "Wiring multiple outputs to same wire, using last connection."
-                f" Input: {self.bit.debug_name}, "
-                f" Old Output: {self.driver.bit.debug_name}, "
-                f" New Output: {other.bit.debug_name}",
+                f" Input: {self._bit.debug_name}, "
+                f" Old Output: {self._driver._bit.debug_name}, "
+                f" New Output: {other._bit.debug_name}",
                 debug_info=debug_info
             )
-        if self.bit.is_output():
-            _logger.error(f"Using `{self.bit.debug_name}` (an output) as an "
+        if self._bit.is_output():
+            _logger.error(f"Using `{self._bit.debug_name}` (an output) as an "
                           f"input", debug_info=debug_info)
             return
-        if other.bit.is_input():
-            _logger.error(f"Using `{other.bit.debug_name}` (an input) as an "
+        if other._bit.is_input():
+            _logger.error(f"Using `{other._bit.debug_name}` (an input) as an "
                           f"output", debug_info=debug_info)
             return
-        if self.bit.is_inout() and not other.bit.is_inout():
-            _logger.error(f"Using `{other.bit.debug_name}` (not inout) as an "
+        if self._bit.is_inout() and not other._bit.is_inout():
+            _logger.error(f"Using `{other._bit.debug_name}` (not inout) as an "
                           f"inout", debug_info=debug_info)
             return
-        if not self.bit.is_inout() and other.bit.is_inout():
-            _logger.error(f"Using `{self.bit.debug_name}` (not inout) as an "
+        if not self._bit.is_inout() and other._bit.is_inout():
+            _logger.error(f"Using `{self._bit.debug_name}` (not inout) as an "
                           f"inout", debug_info=debug_info)
             return
 
-        self.driver = other
-        other.driving.append(self)
+        self._driver = other
+        other._driving.append(self)
 
     def trace(self, skip_self=True):
         """
@@ -69,24 +69,38 @@ class Wire:
         Upon the first invocation (from a user), we skip the current bit (so
         we don't trace to ourselves)
         """
-        if self.driver is not None:
-            return self.driver.trace(skip_self=False)
-        if not skip_self and (self.bit.is_output() or self.bit.is_inout()):
-            return self.bit
+        if self._driver is not None:
+            return self._driver.trace(skip_self=False)
+        if not skip_self and (self._bit.is_output() or self._bit.is_inout()):
+            return self._bit
         return None
 
     def value(self):
         """
         Return the driver of this wire
         """
-        if self.bit.is_output():
+        if self._bit.is_output():
             raise TypeError("Can only get value of non outputs")
-        if self.driver is None:
+        if self._driver is None:
             return None
-        return self.driver.bit
+        return self._driver._bit
 
     def driven(self):
         return self.trace() is not None
 
     def wired(self):
-        return self.driver or self.driving
+        return self._driver or self._driving
+
+    def driving(self):
+        """
+        Return a (possibly empty) list of all bits this bit is driving.
+        """
+        return [driving._bit for driving in self._driving]
+
+    @property
+    def driver(self):
+        return self._driver
+
+    @property
+    def bit(self):
+        return self._bit

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -77,13 +77,15 @@ class Wire:
 
     def value(self):
         """
-        Return the driver of this wire
+        Return the bit connected to this bit. Specifically, return the bit this
+        bit is driving if it exists. Else if, there is a unique "drivee" bit,
+        return that bit. Otherwise, return None.
         """
-        if self._bit.is_output():
-            raise TypeError("Can only get value of non outputs")
-        if self._driver is None:
-            return None
-        return self._driver._bit
+        if self._driver is not None:
+            return self._driver._bit
+        if len(self._driving) == 1:
+            return self._driving[0]._bit
+        return None
 
     def driven(self):
         return self.trace() is not None

--- a/tests/test_type/test_anon.py
+++ b/tests/test_type/test_anon.py
@@ -14,8 +14,7 @@ def test_anon_bit():
     assert b0 is b1._wire.driver.bit
     assert b1 is b0._wire.driving()[0]
     assert b1.value() is b0
-    assert b0.driving_all() == [b1]
-    assert b0.driving() is b1
+    assert b0.driving() == [b1]
     assert b0.value() is b1
 
 

--- a/tests/test_type/test_anon.py
+++ b/tests/test_type/test_anon.py
@@ -12,7 +12,7 @@ def test_anon_bit():
     # b0 is treated as an output connected to b1 (treated as input)
     wire(b0, b1)
     assert b0 is b1._wire.driver.bit
-    assert b1 is b0._wire.driving[0].bit
+    assert b1 is b0._wire.driving()[0]
     assert b1.value() is b0
     assert b0.driving_all() == [b1]
     assert b0.driving() is b1

--- a/tests/test_type/test_anon.py
+++ b/tests/test_type/test_anon.py
@@ -14,6 +14,8 @@ def test_anon_bit():
     assert b0 is b1._wire.driver.bit
     assert b1 is b0._wire.driving[0].bit
     assert b1.value() is b0
+    assert b0.driving_all() == [b1]
+    assert b0.driving() is b1
 
 
 def test_anon_bits():

--- a/tests/test_type/test_anon.py
+++ b/tests/test_type/test_anon.py
@@ -16,6 +16,7 @@ def test_anon_bit():
     assert b1.value() is b0
     assert b0.driving_all() == [b1]
     assert b0.driving() is b1
+    assert b0.value() is b1
 
 
 def test_anon_bits():

--- a/tests/test_type/test_array.py
+++ b/tests/test_type/test_array.py
@@ -182,6 +182,9 @@ def test_wire():
     assert a0.value() is None, "No value"
     assert a1.value() is a0
 
+    assert a0.driving_all() == [a1[0], a1[1]]
+    assert a0.driving() is a1
+
     b0 = a0[0]
     b1 = a1[0]
 

--- a/tests/test_type/test_array.py
+++ b/tests/test_type/test_array.py
@@ -182,8 +182,7 @@ def test_wire():
     assert a1.value() is a0
     assert a0.value() is a1
 
-    assert a0.driving_all() == [a1[0], a1[1]]
-    assert a0.driving() is a1
+    assert a0.driving() == [[a1[0]], [a1[1]]]
 
     b0 = a0[0]
     b1 = a1[0]

--- a/tests/test_type/test_array.py
+++ b/tests/test_type/test_array.py
@@ -179,8 +179,8 @@ def test_wire():
     assert a0.trace() is None, "Cannot trace to input"
     assert a1.trace() is None, "Cannot trace to input"
 
-    assert a0.value() is None, "No value"
     assert a1.value() is a0
+    assert a0.value() is a1
 
     assert a0.driving_all() == [a1[0], a1[1]]
     assert a0.driving() is a1

--- a/tests/test_type/test_array.py
+++ b/tests/test_type/test_array.py
@@ -189,5 +189,5 @@ def test_wire():
     b1 = a1[0]
 
     assert b0 is b1._wire.driver.bit
-    assert b1 is b0._wire.driving[0].bit
+    assert b1 is b0._wire.driving()[0]
     assert b1.value() is b0

--- a/tests/test_type/test_bit.py
+++ b/tests/test_type/test_bit.py
@@ -152,8 +152,7 @@ def test_wire1():
 
     assert b1.value() is b0, "Value is b0"
 
-    assert b0.driving_all() == [b1]
-    assert b0.driving() is b1
+    assert b0.driving() == [b1]
     assert b0.value() is b1
 
     assert b0 is b1._wire.driver.bit
@@ -181,8 +180,7 @@ def test_wire2():
     assert b1.value() is b0, "Value is b0"
     assert b0.value() is b1, "Value is b1"
 
-    assert b0.driving_all() == [b1]
-    assert b0.driving() is b1
+    assert b0.driving() == [b1]
 
     assert b0 is b1._wire.driver.bit
     assert b1 is b0._wire.driving()[0]
@@ -200,8 +198,7 @@ def test_wire3():
     assert b0.value() is b1
     assert b1.value() is b0
 
-    assert b0.driving_all() == [b1]
-    assert b0.driving() is b1
+    assert b0.driving() == [b1]
 
 
 def test_wire4():
@@ -219,10 +216,8 @@ def test_wire4():
     assert b0.value() is None
     assert b1.value() is None
 
-    assert b1.driving_all() == []
-    assert b1.driving() is None
-    assert b0.driving_all() == []
-    assert b0.driving() is None
+    assert b1.driving() == []
+    assert b0.driving() == []
 
 
 def test_wire5():
@@ -234,10 +229,8 @@ def test_wire5():
     assert not b0.wired()
     assert not b1.wired()
 
-    assert b1.driving_all() == []
-    assert b1.driving() is None
-    assert b0.driving_all() == []
-    assert b0.driving() is None
+    assert b1.driving() == []
+    assert b0.driving() == []
     assert b1.value() is None
     assert b0.value() is None
 

--- a/tests/test_type/test_bit.py
+++ b/tests/test_type/test_bit.py
@@ -156,7 +156,7 @@ def test_wire1():
     assert b0.driving() is b1
 
     assert b0 is b1._wire.driver.bit
-    assert b1 is b0._wire.driving[0].bit
+    assert b1 is b0._wire.driving()[0]
 
 
 def test_wire2():
@@ -183,7 +183,7 @@ def test_wire2():
     assert b0.driving() is b1
 
     assert b0 is b1._wire.driver.bit
-    assert b1 is b0._wire.driving[0].bit
+    assert b1 is b0._wire.driving()[0]
 
 
 def test_wire3():

--- a/tests/test_type/test_bit.py
+++ b/tests/test_type/test_bit.py
@@ -154,6 +154,7 @@ def test_wire1():
 
     assert b0.driving_all() == [b1]
     assert b0.driving() is b1
+    assert b0.value() is b1
 
     assert b0 is b1._wire.driver.bit
     assert b1 is b0._wire.driving()[0]
@@ -178,6 +179,7 @@ def test_wire2():
     assert b1.trace() is b0, "Should trace to b0"
 
     assert b1.value() is b0, "Value is b0"
+    assert b0.value() is b1, "Value is b1"
 
     assert b0.driving_all() == [b1]
     assert b0.driving() is b1
@@ -195,7 +197,7 @@ def test_wire3():
     assert b0.wired()
     assert b1.wired()
 
-    assert b0.value() is None
+    assert b0.value() is b1
     assert b1.value() is b0
 
     assert b0.driving_all() == [b1]
@@ -236,6 +238,8 @@ def test_wire5():
     assert b1.driving() is None
     assert b0.driving_all() == []
     assert b0.driving() is None
+    assert b1.value() is None
+    assert b0.value() is None
 
 
 def test_invert():

--- a/tests/test_type/test_bit.py
+++ b/tests/test_type/test_bit.py
@@ -152,6 +152,9 @@ def test_wire1():
 
     assert b1.value() is b0, "Value is b0"
 
+    assert b0.driving_all() == [b1]
+    assert b0.driving() is b1
+
     assert b0 is b1._wire.driver.bit
     assert b1 is b0._wire.driving[0].bit
 
@@ -176,6 +179,9 @@ def test_wire2():
 
     assert b1.value() is b0, "Value is b0"
 
+    assert b0.driving_all() == [b1]
+    assert b0.driving() is b1
+
     assert b0 is b1._wire.driver.bit
     assert b1 is b0._wire.driving[0].bit
 
@@ -191,6 +197,9 @@ def test_wire3():
 
     assert b0.value() is None
     assert b1.value() is b0
+
+    assert b0.driving_all() == [b1]
+    assert b0.driving() is b1
 
 
 def test_wire4():
@@ -208,6 +217,11 @@ def test_wire4():
     assert b0.value() is None
     assert b1.value() is None
 
+    assert b1.driving_all() == []
+    assert b1.driving() is None
+    assert b0.driving_all() == []
+    assert b0.driving() is None
+
 
 def test_wire5():
     b0 = BitOut(name='b0')
@@ -217,6 +231,11 @@ def test_wire5():
 
     assert not b0.wired()
     assert not b1.wired()
+
+    assert b1.driving_all() == []
+    assert b1.driving() is None
+    assert b0.driving_all() == []
+    assert b0.driving() is None
 
 
 def test_invert():

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -156,6 +156,9 @@ def test_wire():
     assert t0.value() is None
     assert t1.value() is t0
 
+    assert t0.driving_all() == dict(x=t1.x, y=t1.y)
+    assert t0.driving() is t1
+
     b0 = t0.x
     b1 = t1.x
 

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -163,7 +163,7 @@ def test_wire():
     b1 = t1.x
 
     assert b0 is b1._wire.driver.bit
-    assert b1 is b0._wire.driving[0].bit
+    assert b1 is b0._wire.driving()[0]
     assert b1.value() is b0
 
 

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -156,8 +156,7 @@ def test_wire():
     assert t1.value() is t0
     assert t0.value() is t1
 
-    assert t0.driving_all() == dict(x=t1.x, y=t1.y)
-    assert t0.driving() is t1
+    assert t0.driving() == dict(x=[t1.x], y=[t1.y])
 
     b0 = t0.x
     b1 = t1.x

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -153,8 +153,8 @@ def test_wire():
     assert t0.wired()
     assert t1.wired()
 
-    assert t0.value() is None
     assert t1.value() is t0
+    assert t0.value() is t1
 
     assert t0.driving_all() == dict(x=t1.x, y=t1.y)
     assert t0.driving() is t1


### PR DESCRIPTION
Sometimes we want to know what values a bit is driving, similar to how `value()` tells us what value is driving a bit. Of course the difference is that `value()` is 1-to-1 (or None), where as a bit can be driving many other bits. Therefore I proposed 2 functions `driving()` and `driving_all()`, which can be described as follows:

- `T::driving()` returns a value of type `T` (flipped) if the value is driving *exactly* one other value (defined recursively of course for Array, Tuple, etc.). If it is not exactly one, then we return `None`.
- `T::driving_all()` returns a python data-type value, where leaf level objects are lists of driving values. So for example, `Bit::driving_all()` will return a list of all bits this bit is driving; `Array::driving_all()` will return a list of lists, where each element of the outer list is a list of all bits each bit of the array is driving; `Tuple::driving_all()` will return a python dict. We can't return the magma types as they exist (as we can in `driving`) because each element may be driving multiple bits, which can't be currently represented. Perhaps there's a more elegant way to do this, but ultimately this is the data-structure we want.

#667 is an alternative implementation which uses the existing `value()` function to provide the same functionality. See there for more discussion.