### PR TITLE
value() returns driving value

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -402,6 +402,9 @@ class Array(Type, metaclass=ArrayMeta):
 
         return type(self).flip()(*ts)
 
+    def flat_value(self):
+        return [t.flat_value() for t in self]
+
     def value(self):
         ts = [t.value() for t in self.ts]
 

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -203,7 +203,7 @@ def _get_intermediate_values(value):
     values = OrderedIdentitySet()
     while driver is not None:
         values |= _add_intermediate_value(driver)
-        if driver.is_output():
+        if not driver.is_input():
             break
         value = driver
         driver = driver.value()

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -173,6 +173,9 @@ class Digital(Type, metaclass=DigitalMeta):
     def trace(self):
         return self._wire.trace()
 
+    def flat_value(self):
+        return self._wire.flat_value()
+
     # return the output Bit connected to this input Bit
     def value(self):
         return self._wire.value()

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -272,6 +272,9 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
 
         return type(self).flip()(*ts)
 
+    def flat_value(self):
+        return {k: t.flat_value() for k, t in self.items()}
+
     def value(self):
         ts = [t.value() for t in self.ts]
 

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -75,6 +75,13 @@ class Wire:
             return self.bit
         return None
 
+    def flat_value(self):
+        if self.driver is not None:
+            return self.driver.bit
+        if self.driving:
+            return self.driving
+        return None
+
     def value(self):
         """
         Return the driver of this wire

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -79,11 +79,11 @@ class Wire:
         """
         Return the driver of this wire
         """
-        if self.bit.is_output():
-            raise TypeError("Can only get value of non outputs")
-        if self.driver is None:
-            return None
-        return self.driver.bit
+        if self.driver is not None:
+            return self.driver.bit
+        if len(self.driving) == 1:
+            return self.driving[0].bit
+        return None
 
     def driven(self):
         return self.trace() is not None

--- a/tests/test_type/test_anon.py
+++ b/tests/test_type/test_anon.py
@@ -14,6 +14,7 @@ def test_anon_bit():
     assert b0 is b1._wire.driver.bit
     assert b1 is b0._wire.driving[0].bit
     assert b1.value() is b0
+    assert b0.value() is b1
 
 
 def test_anon_bits():

--- a/tests/test_type/test_array.py
+++ b/tests/test_type/test_array.py
@@ -179,8 +179,8 @@ def test_wire():
     assert a0.trace() is None, "Cannot trace to input"
     assert a1.trace() is None, "Cannot trace to input"
 
-    assert a0.value() is None, "No value"
     assert a1.value() is a0
+    assert a0.value() is a1
 
     b0 = a0[0]
     b1 = a1[0]

--- a/tests/test_type/test_bit.py
+++ b/tests/test_type/test_bit.py
@@ -152,6 +152,8 @@ def test_wire1():
 
     assert b1.value() is b0, "Value is b0"
 
+    assert b0.value() is b1
+
     assert b0 is b1._wire.driver.bit
     assert b1 is b0._wire.driving[0].bit
 
@@ -175,6 +177,7 @@ def test_wire2():
     assert b1.trace() is b0, "Should trace to b0"
 
     assert b1.value() is b0, "Value is b0"
+    assert b0.value() is b1, "Value is b1"
 
     assert b0 is b1._wire.driver.bit
     assert b1 is b0._wire.driving[0].bit
@@ -189,7 +192,7 @@ def test_wire3():
     assert b0.wired()
     assert b1.wired()
 
-    assert b0.value() is None
+    assert b0.value() is b1
     assert b1.value() is b0
 
 
@@ -217,6 +220,9 @@ def test_wire5():
 
     assert not b0.wired()
     assert not b1.wired()
+
+    assert b1.value() is None
+    assert b0.value() is None
 
 
 def test_invert():

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -153,8 +153,8 @@ def test_wire():
     assert t0.wired()
     assert t1.wired()
 
-    assert t0.value() is None
     assert t1.value() is t0
+    assert t0.value() is t1
 
     b0 = t0.x
     b1 = t1.x


### PR DESCRIPTION
Alternate implementation of #666 (😈)

Mechanically, this works mostly OOTB, since previously we raised an exception if the bit was an output. I don't think many places were checking for this anyway, so most code-paths are unaffected. The major one that is affected is that using `InOut`. The changes in `circuit.py` correspond to that.

This changes the semantics of `value()` to be "give me the value that drives me if there is one, otherwise give me the unique thing I drive if there is one". This somewhat stuffs multiple meanings into `value()` but I still like it since `value()` is kind of generic. Not tied to this however; would be ok reverting `value()` to the old semantics and adding `connection()` to mean this bidirectional thing...

Also, this PR doesn't include the `driving_all()` type of functionality. I was thinking of adding a `flat_value()` function which basically does something like `driving_all()` for **both** driver and driving (i.e. return a list of all things this bit is driving, or a POD structure of all things driving me, even if some are None).