### PR TITLE
Avoid *args initialization of Array

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -403,7 +403,7 @@ class Array(Type, metaclass=ArrayMeta):
         if Array._iswhole(ts):
             return ts[0].name.array
 
-        return type(self).flip()(*ts)
+        return type(self).flip()(ts)
 
     def value(self):
         ts = [t.value() for t in self.ts]
@@ -415,7 +415,7 @@ class Array(Type, metaclass=ArrayMeta):
         if Array._iswhole(ts):
             return ts[0].name.array
 
-        return type(self).flip()(*ts)
+        return type(self).flip()(ts)
 
     def const(self):
         for t in self.ts:


### PR DESCRIPTION
Another place where Array initialization doesn't work, basically, for example:

```python
T = Array[1, Array[16, Bit]]
x = T()
ts = x.ts
y = T(*ts)
```

doesn't work (something obscure and *bad* in Array constructor code).

This surfaced in Garnet due to global buffer which has not super common types like `Array[1, Array[16, Bit]]`.