### PR TITLE
Seq protol ret

### DIFF
--- a/magma/syntax/sequential.py
+++ b/magma/syntax/sequential.py
@@ -45,7 +45,10 @@ class RewriteSelfAttributes(ast.NodeTransformer):
             func = astor.to_source(node.func).rstrip()
             outputs = self.initial_value_map[attr][3].interface.outputs()
             if len(outputs) == 1:
-                return ast.Name(f"self_{attr}_{outputs[0]}", ast.Load())
+                name = outputs[0]
+                if isinstance(name, MagmaProtocol):
+                    name = name._get_magma_value_()
+                return ast.Name(f"self_{attr}_{name}", ast.Load())
             else:
                 assert outputs, "Expected module with at least one output"
                 return ast.Tuple([ast.Name(f"self_{attr}_{output}",

--- a/tests/test_syntax/test_sequential.py
+++ b/tests/test_syntax/test_sequential.py
@@ -673,3 +673,21 @@ def test_protocol_composition(target):
                 return data1
 
     compile_and_check("TestProtocolComposition", FooBar, target)
+
+
+def test_protocol_return(target):
+    WrappedBits8 = MWrapper[m.UInt[8]]
+
+    @m.circuit.sequential(async_reset=False)
+    class Foo:
+        def __call__(self, val: WrappedBits8) -> WrappedBits8:
+            return WrappedBits8(val.apply(lambda x: x + 1))
+
+
+    @m.circuit.sequential(async_reset=False)
+    class Bar:
+        def __init__(self):
+            self.f : Foo = Foo()
+
+        def __call__(self, val: WrappedBits8) -> m.UInt[8]:
+            return self.f(val)


### PR DESCRIPTION
This all looks very brittle, would very much be in favor of unifying this so we don't have to check `isinstance()` everywhere. As we've found several times. Very error prone and makes the code very hard to read where we do use it.