### PR TITLE
Relax getitem width check

### DIFF
--- a/magma/bits.py
+++ b/magma/bits.py
@@ -531,9 +531,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
 
     def __getitem__(self, index):
         if isinstance(index, Bits):
-            if not 2 ** len(index) == len(self):
+            if len(index) > len(self):
                 raise TypeError(f"Unexpected index width: {len(index)}")
-            index = index.zext(len(self) - len(index))
+            if len(index) < len(self):
+                index = index.zext(len(self) - len(index))
             return (self >> index)[0]
         return super().__getitem__(index)
 

--- a/tests/test_syntax/gold/TestReplaceArray.json
+++ b/tests/test_syntax/gold/TestReplaceArray.json
@@ -21,14 +21,14 @@
           ["O",["Array",2,"Bit"]]
         ]],
         "instances":{
-          "const_3_2":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",2]},
-            "modargs":{"value":[["BitVector",2],"2'h3"]}
+          "bit_const_1_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",true]}
           }
         },
         "connections":[
-          ["self.O","const_3_2.out"]
+          ["self.O.0","bit_const_1_None.out"],
+          ["self.O.1","bit_const_1_None.out"]
         ]
       }
     }

--- a/tests/test_syntax/gold/TestReplaceArray.v
+++ b/tests/test_syntax/gold/TestReplaceArray.v
@@ -1,8 +1,7 @@
-module coreir_const #(
-    parameter width = 1,
+module corebit_const #(
     parameter value = 1
 ) (
-    output [width-1:0] out
+    output out
 );
   assign out = value;
 endmodule
@@ -10,14 +9,13 @@ endmodule
 module TestReplaceArray_comb (
     output [1:0] O
 );
-wire [1:0] const_3_2_out;
-coreir_const #(
-    .value(2'h3),
-    .width(2)
-) const_3_2 (
-    .out(const_3_2_out)
+wire bit_const_1_None_out;
+corebit_const #(
+    .value(1'b1)
+) bit_const_1_None (
+    .out(bit_const_1_None_out)
 );
-assign O = const_3_2_out;
+assign O = {bit_const_1_None_out,bit_const_1_None_out};
 endmodule
 
 module TestReplaceArray (

--- a/tests/test_syntax/gold/TestReplaceArrayStrKey.json
+++ b/tests/test_syntax/gold/TestReplaceArrayStrKey.json
@@ -35,14 +35,14 @@
           ["O",["Array",2,"Bit"]]
         ]],
         "instances":{
-          "const_3_2":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",2]},
-            "modargs":{"value":[["BitVector",2],"2'h3"]}
+          "bit_const_1_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",true]}
           }
         },
         "connections":[
-          ["self.O","const_3_2.out"]
+          ["self.O.0","bit_const_1_None.out"],
+          ["self.O.1","bit_const_1_None.out"]
         ]
       },
       "TestReplaceArray_comb":{
@@ -50,14 +50,14 @@
           ["O",["Array",2,"Bit"]]
         ]],
         "instances":{
-          "const_3_2":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",2]},
-            "modargs":{"value":[["BitVector",2],"2'h3"]}
+          "bit_const_1_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",true]}
           }
         },
         "connections":[
-          ["self.O","const_3_2.out"]
+          ["self.O.0","bit_const_1_None.out"],
+          ["self.O.1","bit_const_1_None.out"]
         ]
       }
     }

--- a/tests/test_syntax/gold/TestReplaceArrayStrKey.v
+++ b/tests/test_syntax/gold/TestReplaceArrayStrKey.v
@@ -1,8 +1,7 @@
-module coreir_const #(
-    parameter width = 1,
+module corebit_const #(
     parameter value = 1
 ) (
-    output [width-1:0] out
+    output out
 );
   assign out = value;
 endmodule
@@ -10,14 +9,13 @@ endmodule
 module TestReplaceArrayStrKey_comb (
     output [1:0] O
 );
-wire [1:0] const_3_2_out;
-coreir_const #(
-    .value(2'h3),
-    .width(2)
-) const_3_2 (
-    .out(const_3_2_out)
+wire bit_const_1_None_out;
+corebit_const #(
+    .value(1'b1)
+) bit_const_1_None (
+    .out(bit_const_1_None_out)
 );
-assign O = const_3_2_out;
+assign O = {bit_const_1_None_out,bit_const_1_None_out};
 endmodule
 
 module TestReplaceArrayStrKey (


### PR DESCRIPTION
We need to relax this check since there are cases when the widths don't match up exactly, e.g. we're doing get item on a Bits[10] with a value of Bits[4] (we use clog2 for the index which rounds up).  This relaxes it to match the BitVector/primitive interface where the index just needs to match the width of the input being selected (since we're using the shift operator).