### PR TITLE
Always mark unused to prevent inlining of primitive output ports

### DIFF
--- a/magma/bit.py
+++ b/magma/bit.py
@@ -183,7 +183,10 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
     def unused(self):
         if self.is_input() or self.is_inout():
             raise TypeError("unused cannot be used with input/inout")
-        DefineUnused()().I.wire(self)
+        if not getattr(self, "_magma_unused_", False):
+            DefineUnused()().I.wire(self)
+            # "Cache" unused calls so only one is produced
+            self._magma_unused_ = True
 
     def undriven(self):
         if self.is_output() or self.is_inout():

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -522,7 +522,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def unused(self):
         if self.is_input() or self.is_inout():
             raise TypeError("unused cannot be used with input/inout")
-        DefineUnused(len(self))().I.wire(self)
+        if not getattr(self, "_magma_unused_", False):
+            DefineUnused(len(self))().I.wire(self)
+            # "Cache" unused calls so only one is produced
+            self._magma_unused_ = True
 
     def undriven(self):
         if self.is_output() or self.is_inout():

--- a/magma/verilog_utils.py
+++ b/magma/verilog_utils.py
@@ -64,9 +64,8 @@ def convert_values_to_verilog_str(value):
             # TODO: Could be driven after, but that will just override
             # this wiring so it's okay for now
             value.undriven()
-        elif value.is_output() and not value.wired():
-            value.unused()
-        elif not (value.is_input() or value.is_output() or value.is_inout()):
+        elif not value.is_input():
+            # Always set to unused so the output wire isn't inlined
             value.unused()
         return value_to_verilog_name(value)
     if isinstance(value, PortView):

--- a/tests/test_verilog/gold/TestDisplay.v
+++ b/tests/test_verilog/gold/TestDisplay.v
@@ -31,9 +31,12 @@ FF FF_inst0 (
     .CE(CE)
 );
 corebit_term corebit_term_inst0 (
-    .in(coreir_wrapInClock_inst0_out)
+    .in(FF_inst0_O)
 );
 corebit_term corebit_term_inst1 (
+    .in(coreir_wrapInClock_inst0_out)
+);
+corebit_term corebit_term_inst2 (
     .in(CE)
 );
 coreir_wrap coreir_wrapInClock_inst0 (

--- a/tests/test_verilog/gold/TestFDisplay.v
+++ b/tests/test_verilog/gold/TestFDisplay.v
@@ -31,9 +31,12 @@ FF FF_inst0 (
     .CE(CE)
 );
 corebit_term corebit_term_inst0 (
-    .in(coreir_wrapInClock_inst0_out)
+    .in(FF_inst0_O)
 );
 corebit_term corebit_term_inst1 (
+    .in(coreir_wrapInClock_inst0_out)
+);
+corebit_term corebit_term_inst2 (
     .in(CE)
 );
 coreir_wrap coreir_wrapInClock_inst0 (

--- a/tests/test_verilog/gold/TestFLog.v
+++ b/tests/test_verilog/gold/TestFLog.v
@@ -31,9 +31,12 @@ FF FF_inst0 (
     .CE(CE)
 );
 corebit_term corebit_term_inst0 (
-    .in(coreir_wrapInClock_inst0_out)
+    .in(FF_inst0_O)
 );
 corebit_term corebit_term_inst1 (
+    .in(coreir_wrapInClock_inst0_out)
+);
+corebit_term corebit_term_inst2 (
     .in(CE)
 );
 coreir_wrap coreir_wrapInClock_inst0 (

--- a/tests/test_verilog/gold/TestLog.v
+++ b/tests/test_verilog/gold/TestLog.v
@@ -31,9 +31,12 @@ FF FF_inst0 (
     .CE(CE)
 );
 corebit_term corebit_term_inst0 (
-    .in(coreir_wrapInClock_inst0_out)
+    .in(FF_inst0_O)
 );
 corebit_term corebit_term_inst1 (
+    .in(coreir_wrapInClock_inst0_out)
+);
+corebit_term corebit_term_inst2 (
     .in(CE)
 );
 coreir_wrap coreir_wrapInClock_inst0 (

--- a/tests/test_verilog/gold/test_inline_simple.sv
+++ b/tests/test_verilog/gold/test_inline_simple.sv
@@ -21,9 +21,12 @@ FF FF_inst0 (
     .CLK(CLK)
 );
 corebit_term corebit_term_inst0 (
-    .in(arr[0])
+    .in(I)
 );
 corebit_term corebit_term_inst1 (
+    .in(arr[0])
+);
+corebit_term corebit_term_inst2 (
     .in(arr[1])
 );
 

--- a/tests/test_verilog/gold/test_inline_tuple.sv
+++ b/tests/test_verilog/gold/test_inline_tuple.sv
@@ -1,4 +1,10 @@
 // Module `InnerInnerDelayUnit` defined externally
+module corebit_term (
+    input in
+);
+
+endmodule
+
 module InnerDelayUnit (
     input CLK,
     input [4:0] INPUT_0_data,
@@ -91,6 +97,12 @@ DelayUnit DelayUnit_inst0 (
     .OUTPUT_1_data(O_0_data),
     .OUTPUT_1_ready(O_0_ready),
     .OUTPUT_1_valid(O_0_valid)
+);
+corebit_term corebit_term_inst0 (
+    .in(I_0_valid)
+);
+corebit_term corebit_term_inst1 (
+    .in(O_1_ready)
 );
 assert property (@(posedge CLK) I_0_valid |-> ##3 O_1_ready);
 


### PR DESCRIPTION
Prevents the verilog backend from inlining the outputs of primitives that are referred to by the inline verilog.  This issue will be avoided once I merge in the inline verilog module wrapper (since the connection to the module will do the same thing), but this is a temporary workaround for the existing logic.