### PR TITLE
Bind after uniquification

### DIFF
--- a/magma/clock.py
+++ b/magma/clock.py
@@ -15,7 +15,7 @@ class _ClockType(Digital):
         Bit.unused(self)
 
     def undriven(self):
-        Bit.unused(self)
+        Bit.undriven(self)
 
 
 class Clock(_ClockType, metaclass=DigitalMeta):

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -45,12 +45,14 @@ def compile(basename, main, output="coreir-verilog", **kwargs):
     opts = kwargs.copy()
     compiler = _make_compiler(output, main, basename, opts)
 
-    # Steps to process bind's and inline verilog generation.
+    # Steps to process inline verilog generation.
     ProcessInlineVerilogPass(main).run()
-    BindPass(main, compile).run()
 
     # Default behavior is to perform uniquification, but can be overriden.
     uniquification_pass(main, opts.get("uniquify", "UNIQUIFY"))
+
+    BindPass(main, compile).run()
+
     if opts.get("drive_undriven", False):
         DriveUndrivenPass(main).run()
     if opts.get("terminate_unused", False):

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -51,6 +51,7 @@ def compile(basename, main, output="coreir-verilog", **kwargs):
     # Default behavior is to perform uniquification, but can be overriden.
     uniquification_pass(main, opts.get("uniquify", "UNIQUIFY"))
 
+    # Bind after uniquification so the bind logic works on unique modules
     BindPass(main, compile).run()
 
     if opts.get("drive_undriven", False):

--- a/magma/generator.py
+++ b/magma/generator.py
@@ -26,8 +26,9 @@ class GeneratorMeta(type):
             result = old_generate(*args, **kwargs)
             if hasattr(result, "circuit_definition"):
                 result = result.circuit_definition
-            for gen in cls.bind_generators:
-                gen.generate_bind(result, *args, **kwargs)
+            if not result.bind_modules_bound:
+                for gen in cls.bind_generators:
+                    gen.generate_bind(result, *args, **kwargs)
             return result
 
         cls.generate = generate_wrapper

--- a/magma/passes/drive_undriven.py
+++ b/magma/passes/drive_undriven.py
@@ -2,12 +2,20 @@ from .passes import EditDefinitionPass
 from ..is_definition import isdefinition
 
 
+def _drive_if_undriven_input(port):
+    if port.is_mixed():
+        # Sum so it doesn't short circuit
+        return sum(_drive_if_undriven_input(p) for p in port)
+    if port.is_input() and port.trace() is None:
+        port.undriven()
+        return True
+    return False
+
+
 def _drive_undriven(interface):
     undriven = False
     for port in interface.ports.values():
-        if port.is_input() and port.trace() is None:
-            undriven = True
-            port.undriven()
+        undriven |= _drive_if_undriven_input(port)
     return undriven
 
 

--- a/magma/passes/drive_undriven.py
+++ b/magma/passes/drive_undriven.py
@@ -4,8 +4,9 @@ from ..is_definition import isdefinition
 
 def _drive_if_undriven_input(port):
     if port.is_mixed():
-        # Sum so it doesn't short circuit
-        return sum(_drive_if_undriven_input(p) for p in port)
+        # list comp so it doesn't short circuit
+        undrivens = [_drive_if_undriven_input(p) for p in port]
+        return any(undrivens)
     if port.is_input() and port.trace() is None:
         port.undriven()
         return True

--- a/magma/passes/terminate_unused.py
+++ b/magma/passes/terminate_unused.py
@@ -2,12 +2,20 @@ from .passes import EditDefinitionPass
 from ..is_definition import isdefinition
 
 
+def _terminate_if_unwired_output(port):
+    if port.is_mixed():
+        # Sum so it doesn't short circuit
+        return sum(_terminate_if_unwired_output(p) for p in port)
+    if port.is_output() and not port.wired():
+        port.unused()
+        return True
+    return False
+
+
 def _terminate_unused(interface):
     terminated = False
     for port in interface.ports.values():
-        if port.is_output() and not port.wired():
-            terminated = True
-            port.unused()
+        terminated |= _terminate_if_unwired_output(port)
     return terminated
 
 

--- a/magma/passes/terminate_unused.py
+++ b/magma/passes/terminate_unused.py
@@ -4,8 +4,9 @@ from ..is_definition import isdefinition
 
 def _terminate_if_unwired_output(port):
     if port.is_mixed():
-        # Sum so it doesn't short circuit
-        return sum(_terminate_if_unwired_output(p) for p in port)
+        # list comp so it doesn't short circuit
+        terminated = [_terminate_if_unwired_output(p) for p in port]
+        return any(terminated)
     if port.is_output() and not port.wired():
         port.unused()
         return True

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -63,7 +63,8 @@ class UniquificationPass(DefinitionPass):
             elif name != seen[key][0].name:
                 new_name = seen[key][0].name
                 type(definition).rename(definition, new_name)
-                for x, y in zip(seen[key][0], definition.bind_modules):
+                for x, y in zip(seen[key][0].bind_modules,
+                                definition.bind_modules):
                     type(y).rename(y, x.name)
             seen[key].append(definition)
 

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -51,8 +51,11 @@ class UniquificationPass(DefinitionPass):
         seen = self.seen.setdefault(name, {})
         if key not in seen:
             if self.mode is UniquificationMode.UNIQUIFY and len(seen) > 0:
-                new_name = name + "_unq" + str(len(seen))
+                suffix = "_unq" + str(len(seen))
+                new_name = name + suffix
                 type(definition).rename(definition, new_name)
+                for module in definition.bind_modules:
+                    type(module).rename(module, module.name + suffix)
             seen[key] = [definition]
         else:
             if self.mode is not UniquificationMode.UNIQUIFY:
@@ -60,6 +63,8 @@ class UniquificationPass(DefinitionPass):
             elif name != seen[key][0].name:
                 new_name = seen[key][0].name
                 type(definition).rename(definition, new_name)
+                for x, y in zip(seen[key][0], definition.bind_modules):
+                    type(y).rename(y, x.name)
             seen[key].append(definition)
 
     def run(self):

--- a/tests/test_verilog/gold/RTLMonitor_unq1.sv
+++ b/tests/test_verilog/gold/RTLMonitor_unq1.sv
@@ -1,0 +1,86 @@
+module coreir_term #(
+    parameter width = 1
+) (
+    input [width-1:0] in
+);
+
+endmodule
+
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module RTLMonitor_unq1 (
+    input CLK,
+    input handshake_arr_0_ready,
+    input handshake_arr_0_valid,
+    input handshake_arr_1_ready,
+    input handshake_arr_1_valid,
+    input handshake_arr_2_ready,
+    input handshake_arr_2_valid,
+    input handshake_ready,
+    input handshake_valid,
+    input [4:0] in1,
+    input [4:0] in2,
+    input intermediate_tuple__0,
+    input intermediate_tuple__1,
+    input mon_temp1,
+    input mon_temp2,
+    input out
+);
+wire _magma_inline_wire0;
+wire [4:0] _magma_inline_wire1_0;
+wire [4:0] _magma_inline_wire1_1;
+wire [4:0] arr_2d_0;
+wire [4:0] arr_2d_1;
+assign _magma_inline_wire0 = arr_2d_0[1];
+assign _magma_inline_wire1_0 = arr_2d_0;
+assign _magma_inline_wire1_1 = arr_2d_1;
+assign arr_2d_0 = in1;
+assign arr_2d_1 = in2;
+corebit_term corebit_term_inst0 (
+    .in(_magma_inline_wire0)
+);
+coreir_term #(
+    .width(5)
+) term_inst0 (
+    .in(_magma_inline_wire1_0)
+);
+coreir_term #(
+    .width(5)
+) term_inst1 (
+    .in(_magma_inline_wire1_1)
+);
+
+logic temp1, temp2;
+logic temp3;
+assign temp1 = |(in1);
+assign temp2 = &(in1) & intermediate_tuple__0;
+assign temp3 = temp1 ^ temp2 & _magma_inline_wire0;
+assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
+logic [4:0] temp4 [1:0];
+assign temp4 = '{_magma_inline_wire1_1, _magma_inline_wire1_0};
+                                   
+endmodule
+
+
+bind RTL_unq1 RTLMonitor_unq1 RTLMonitor_unq1_inst (
+    .CLK(CLK),
+    .in1(in1),
+    .in2(in2),
+    .out(out),
+    .handshake_ready(handshake_ready),
+    .handshake_valid(handshake_valid),
+    .handshake_arr_0_ready(handshake_arr_0_ready),
+    .handshake_arr_0_valid(handshake_arr_0_valid),
+    .handshake_arr_1_ready(handshake_arr_1_ready),
+    .handshake_arr_1_valid(handshake_arr_1_valid),
+    .handshake_arr_2_ready(handshake_arr_2_ready),
+    .handshake_arr_2_valid(handshake_arr_2_valid),
+    .mon_temp1(orr_5_inst0_O),
+    .mon_temp2(andr_5_inst0_O),
+    .intermediate_tuple__0(orr_5_inst0_O),
+    .intermediate_tuple__1(andr_5_inst0_O)
+);

--- a/tests/test_verilog/gold/bind_uniq_test.v
+++ b/tests/test_verilog/gold/bind_uniq_test.v
@@ -1,0 +1,301 @@
+module coreir_wrap (
+    input in,
+    output out
+);
+  assign out = in;
+endmodule
+
+module coreir_undriven #(
+    parameter width = 1
+) (
+    output [width-1:0] out
+);
+
+endmodule
+
+module coreir_term #(
+    parameter width = 1
+) (
+    input [width-1:0] in
+);
+
+endmodule
+
+module corebit_undriven (
+    output out
+);
+
+endmodule
+
+            module orr_5 (input [4:0] I, output O);
+            assign O = |(I);
+            endmodule
+            module orr_4 (input [3:0] I, output O);
+            assign O = |(I);
+            endmodule
+module corebit_term (
+    input in
+);
+
+endmodule
+
+            module logical_and (input I0, input I1, output O);
+            assign O = I0 && I1;
+            endmodule
+            module andr_5 (input [4:0] I, output O);
+            assign O = &(I);
+            endmodule
+            module andr_4 (input [3:0] I, output O);
+            assign O = &(I);
+            endmodule
+module RTL_unq1 (
+    input CLK,
+    input handshake_arr_0_ready,
+    output handshake_arr_0_valid,
+    input handshake_arr_1_ready,
+    output handshake_arr_1_valid,
+    input handshake_arr_2_ready,
+    output handshake_arr_2_valid,
+    input handshake_ready,
+    output handshake_valid,
+    input [4:0] in1,
+    input [4:0] in2,
+    output out
+);
+wire andr_5_inst0_O;
+wire coreir_wrapInClock_inst0_out;
+wire orr_5_inst0_O;
+andr_5 andr_5_inst0 (
+    .I(in1),
+    .O(andr_5_inst0_O)
+);
+corebit_term corebit_term_inst0 (
+    .in(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(CLK),
+    .out(coreir_wrapInClock_inst0_out)
+);
+logical_and logical_and_inst0 (
+    .I0(orr_5_inst0_O),
+    .I1(andr_5_inst0_O),
+    .O(out)
+);
+orr_5 orr_5_inst0 (
+    .I(in1),
+    .O(orr_5_inst0_O)
+);
+coreir_term #(
+    .width(5)
+) term_inst0 (
+    .in(in2)
+);
+assign handshake_arr_0_valid = handshake_arr_2_ready;
+assign handshake_arr_1_valid = handshake_arr_1_ready;
+assign handshake_arr_2_valid = handshake_arr_0_ready;
+assign handshake_valid = handshake_ready;
+endmodule
+
+module RTL (
+    input CLK,
+    input handshake_arr_0_ready,
+    output handshake_arr_0_valid,
+    input handshake_arr_1_ready,
+    output handshake_arr_1_valid,
+    input handshake_arr_2_ready,
+    output handshake_arr_2_valid,
+    input handshake_ready,
+    output handshake_valid,
+    input [3:0] in1,
+    input [3:0] in2,
+    output out
+);
+wire andr_4_inst0_O;
+wire coreir_wrapInClock_inst0_out;
+wire orr_4_inst0_O;
+andr_4 andr_4_inst0 (
+    .I(in1),
+    .O(andr_4_inst0_O)
+);
+corebit_term corebit_term_inst0 (
+    .in(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(CLK),
+    .out(coreir_wrapInClock_inst0_out)
+);
+logical_and logical_and_inst0 (
+    .I0(orr_4_inst0_O),
+    .I1(andr_4_inst0_O),
+    .O(out)
+);
+orr_4 orr_4_inst0 (
+    .I(in1),
+    .O(orr_4_inst0_O)
+);
+coreir_term #(
+    .width(4)
+) term_inst0 (
+    .in(in2)
+);
+assign handshake_arr_0_valid = handshake_arr_2_ready;
+assign handshake_arr_1_valid = handshake_arr_1_ready;
+assign handshake_arr_2_valid = handshake_arr_0_ready;
+assign handshake_valid = handshake_ready;
+endmodule
+
+module Main (
+    input CLK
+);
+wire RTL_inst0_handshake_arr_0_valid;
+wire RTL_inst0_handshake_arr_1_valid;
+wire RTL_inst0_handshake_arr_2_valid;
+wire RTL_inst0_handshake_valid;
+wire RTL_inst0_out;
+wire RTL_inst1_handshake_arr_0_valid;
+wire RTL_inst1_handshake_arr_1_valid;
+wire RTL_inst1_handshake_arr_2_valid;
+wire RTL_inst1_handshake_valid;
+wire RTL_inst1_out;
+wire corebit_undriven_inst0_out;
+wire corebit_undriven_inst1_out;
+wire corebit_undriven_inst2_out;
+wire corebit_undriven_inst3_out;
+wire corebit_undriven_inst4_out;
+wire corebit_undriven_inst5_out;
+wire corebit_undriven_inst6_out;
+wire corebit_undriven_inst7_out;
+wire corebit_undriven_inst8_out;
+wire corebit_undriven_inst9_out;
+wire coreir_wrapInClock_inst0_out;
+wire coreir_wrapOutClock_inst0_out;
+wire coreir_wrapOutClock_inst1_out;
+wire [3:0] undriven_inst0_out;
+wire [3:0] undriven_inst1_out;
+wire [4:0] undriven_inst2_out;
+wire [4:0] undriven_inst3_out;
+RTL RTL_inst0 (
+    .CLK(coreir_wrapOutClock_inst0_out),
+    .handshake_arr_0_ready(corebit_undriven_inst2_out),
+    .handshake_arr_0_valid(RTL_inst0_handshake_arr_0_valid),
+    .handshake_arr_1_ready(corebit_undriven_inst3_out),
+    .handshake_arr_1_valid(RTL_inst0_handshake_arr_1_valid),
+    .handshake_arr_2_ready(corebit_undriven_inst4_out),
+    .handshake_arr_2_valid(RTL_inst0_handshake_arr_2_valid),
+    .handshake_ready(corebit_undriven_inst1_out),
+    .handshake_valid(RTL_inst0_handshake_valid),
+    .in1(undriven_inst0_out),
+    .in2(undriven_inst1_out),
+    .out(RTL_inst0_out)
+);
+RTL_unq1 RTL_inst1 (
+    .CLK(coreir_wrapOutClock_inst1_out),
+    .handshake_arr_0_ready(corebit_undriven_inst7_out),
+    .handshake_arr_0_valid(RTL_inst1_handshake_arr_0_valid),
+    .handshake_arr_1_ready(corebit_undriven_inst8_out),
+    .handshake_arr_1_valid(RTL_inst1_handshake_arr_1_valid),
+    .handshake_arr_2_ready(corebit_undriven_inst9_out),
+    .handshake_arr_2_valid(RTL_inst1_handshake_arr_2_valid),
+    .handshake_ready(corebit_undriven_inst6_out),
+    .handshake_valid(RTL_inst1_handshake_valid),
+    .in1(undriven_inst2_out),
+    .in2(undriven_inst3_out),
+    .out(RTL_inst1_out)
+);
+corebit_term corebit_term_inst0 (
+    .in(coreir_wrapInClock_inst0_out)
+);
+corebit_term corebit_term_inst1 (
+    .in(RTL_inst0_out)
+);
+corebit_term corebit_term_inst10 (
+    .in(RTL_inst1_handshake_arr_2_valid)
+);
+corebit_term corebit_term_inst2 (
+    .in(RTL_inst0_handshake_valid)
+);
+corebit_term corebit_term_inst3 (
+    .in(RTL_inst0_handshake_arr_0_valid)
+);
+corebit_term corebit_term_inst4 (
+    .in(RTL_inst0_handshake_arr_1_valid)
+);
+corebit_term corebit_term_inst5 (
+    .in(RTL_inst0_handshake_arr_2_valid)
+);
+corebit_term corebit_term_inst6 (
+    .in(RTL_inst1_out)
+);
+corebit_term corebit_term_inst7 (
+    .in(RTL_inst1_handshake_valid)
+);
+corebit_term corebit_term_inst8 (
+    .in(RTL_inst1_handshake_arr_0_valid)
+);
+corebit_term corebit_term_inst9 (
+    .in(RTL_inst1_handshake_arr_1_valid)
+);
+corebit_undriven corebit_undriven_inst0 (
+    .out(corebit_undriven_inst0_out)
+);
+corebit_undriven corebit_undriven_inst1 (
+    .out(corebit_undriven_inst1_out)
+);
+corebit_undriven corebit_undriven_inst2 (
+    .out(corebit_undriven_inst2_out)
+);
+corebit_undriven corebit_undriven_inst3 (
+    .out(corebit_undriven_inst3_out)
+);
+corebit_undriven corebit_undriven_inst4 (
+    .out(corebit_undriven_inst4_out)
+);
+corebit_undriven corebit_undriven_inst5 (
+    .out(corebit_undriven_inst5_out)
+);
+corebit_undriven corebit_undriven_inst6 (
+    .out(corebit_undriven_inst6_out)
+);
+corebit_undriven corebit_undriven_inst7 (
+    .out(corebit_undriven_inst7_out)
+);
+corebit_undriven corebit_undriven_inst8 (
+    .out(corebit_undriven_inst8_out)
+);
+corebit_undriven corebit_undriven_inst9 (
+    .out(corebit_undriven_inst9_out)
+);
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(CLK),
+    .out(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(corebit_undriven_inst0_out),
+    .out(coreir_wrapOutClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst1 (
+    .in(corebit_undriven_inst5_out),
+    .out(coreir_wrapOutClock_inst1_out)
+);
+coreir_undriven #(
+    .width(4)
+) undriven_inst0 (
+    .out(undriven_inst0_out)
+);
+coreir_undriven #(
+    .width(4)
+) undriven_inst1 (
+    .out(undriven_inst1_out)
+);
+coreir_undriven #(
+    .width(5)
+) undriven_inst2 (
+    .out(undriven_inst2_out)
+);
+coreir_undriven #(
+    .width(5)
+) undriven_inst3 (
+    .out(undriven_inst3_out)
+);
+endmodule
+

--- a/tests/test_verilog/test_bind.py
+++ b/tests/test_verilog/test_bind.py
@@ -13,11 +13,6 @@ def test_bind():
     assert m.testing.check_files_equal(__file__,
                                        f"build/bind_test.v",
                                        f"gold/bind_test.v")
-
-    monitor_file = os.path.join(os.path.dirname(__file__), "build",
-                                "Monitor.sv")
-    if os.path.exists(monitor_file):
-        os.remove(monitor_file)
     assert m.testing.check_files_equal(__file__,
                                        f"build/RTLMonitor.sv",
                                        f"gold/RTLMonitor.sv")
@@ -27,3 +22,40 @@ def test_bind():
     if version >= 4.016:
         assert not os.system('cd tests/test_verilog/build && '
                              'verilator --lint-only bind_test.v RTLMonitor.sv')
+
+
+def test_bind_multi_unique_name():
+    class Main(m.Circuit):
+        _ignore_undriven_ = True
+        io = m.ClockIO()
+        RTL4 = RTL.generate(4)()
+        RTL5 = RTL.generate(5)()
+
+    m.compile("build/bind_uniq_test", Main, inline=True, drive_undriven=True,
+              terminate_unused=True)
+    assert m.testing.check_files_equal(__file__,
+                                       f"build/bind_uniq_test.v",
+                                       f"gold/bind_uniq_test.v")
+
+    assert m.testing.check_files_equal(__file__,
+                                       f"build/RTLMonitor.sv",
+                                       f"gold/RTLMonitor.sv")
+
+    assert m.testing.check_files_equal(__file__,
+                                       f"build/RTLMonitor_unq1.sv",
+                                       f"gold/RTLMonitor_unq1.sv")
+
+    result = run('verilator --version', shell=True, capture_output=True)
+    version = float(result.stdout.split()[1])
+    if version >= 4.016:
+        assert not os.system('cd tests/test_verilog/build && '
+                             'verilator --lint-only bind_uniq_test.v '
+                             'RTLMonitor.sv RTLMonitor_unq1.sv -Wno-MODDUP')
+        # TODO: For now, we ignore duplicate modules since each monitor will
+        # regenerate coreir primitives.  # since these have the same definition
+        # it's okay, but in general this is a bad flag to have on because if
+        # you do have duplicate modules with different definitions, you'd want
+        # to catch that
+        # When we merge the inline verilog module branch, this will be resolved since
+        # bind modules can be represented explicitly in the graph and compiled
+        # by coreir, so only one definition per primitive will be emitted


### PR DESCRIPTION
Unique modules should have unique binds, and binds should not be re-run when cacheing occurs.

Also fixes minor undriven/unused logic bug for mixed direction ports that came up in the new  test.