### PR TITLE
Only check interface in debug mode

### DIFF
--- a/magma/backend/coreir_transformer.py
+++ b/magma/backend/coreir_transformer.py
@@ -19,6 +19,7 @@ from ..logging import root_logger
 from ..passes import InstanceGraphPass
 from ..tuple import Tuple
 from .util import get_codegen_debug_info
+from magma.config import get_debug_mode
 
 
 # NOTE(rsetaluri): We do not need to set the level of this logger since it has
@@ -274,7 +275,8 @@ class DeclarationTransformer(LeafTransformer):
         if self.decl.name in self.backend.modules:
             _logger.debug(f"{self.decl} already compiled, skipping")
             return self.backend.modules[self.decl.name]
-        check_magma_interface(self.decl.interface)
+        if get_debug_mode():
+            check_magma_interface(self.decl.interface)
         module_type = magma_interface_to_coreir_module_type(
             self.backend.context, self.decl.interface)
         if isinstance(self.decl.interface, InterfaceKind):


### PR DESCRIPTION
Improves performance by forgoing this interface safety check unless we're in debug mode.  A future improvement might be to catch interface related type errors and then do this check in the exception handling to perhaps discover a more useful error message (I think the reason this was added in the first place was to catch interface types that the backend couldn't handle up front).  Really, we should be assuming that we can handle valid interface types so I think we could also consider removing this check all together (except perhaps for use in the exception handling technique mentioned above).  If we can't handle a valid interface type, either that's a very bad user error (injecting unsupported types into the system, which I don't think we need to handle gracefully) or its an internal error, which should be fixed (and won't need this safety guard).