### PR TITLE
Hotfix issue with length zero array

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -91,8 +91,12 @@ class InsertWrapCasts(DefinitionPass):
             wrapped = self.wrap_if_named_type(port[0], definition)
             if not wrapped:
                 return False
-            for t in port[1:]:
-                self.wrap_if_named_type(t, definition)
+            # TODO: Magma doesn't support length zero array, so slicing a
+            # length 1 array off the end doesn't work as expected in normal
+            # Python
+            if len(port) > 1:
+                for t in port[1:]:
+                    self.wrap_if_named_type(t, definition)
             return True
         if not port.is_input():
             return False

--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -93,10 +93,9 @@ class InsertWrapCasts(DefinitionPass):
                 return False
             # TODO: Magma doesn't support length zero array, so slicing a
             # length 1 array off the end doesn't work as expected in normal
-            # Python
-            if len(port) > 1:
-                for t in port[1:]:
-                    self.wrap_if_named_type(t, definition)
+            # Python, so we explicilty slice port.ts
+            for t in port.ts[1:]:
+                self.wrap_if_named_type(t, definition)
             return True
         if not port.is_input():
             return False

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -101,8 +101,8 @@ def _wire_clock_port(port, clocktype, defnclk):
             return False
         # TODO: Magma doesn't support length zero array, so slicing a
         # length 1 array off the end doesn't work as expected in normal
-        # Python
-        if len(port) > 1:
+        # Python, so we explicilty slice port.ts
+        for t in port.ts[1:]:
             for elem in port[1:]:
               _wire_clock_port(elem, clocktype, defnclk)
     elif isinstance(port, clocktype) and not port.driven():

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -99,8 +99,12 @@ def _wire_clock_port(port, clocktype, defnclk):
         # Only traverse all children circuit if first child has a clock
         if not wired:
             return False
-        for elem in port[1:]:
-          _wire_clock_port(elem, clocktype, defnclk)
+        # TODO: Magma doesn't support length zero array, so slicing a
+        # length 1 array off the end doesn't work as expected in normal
+        # Python
+        if len(port) > 1:
+            for elem in port[1:]:
+              _wire_clock_port(elem, clocktype, defnclk)
     elif isinstance(port, clocktype) and not port.driven():
         wire(defnclk, port)
         wired = True


### PR DESCRIPTION
Regression introduced by https://github.com/phanrahan/magma/pull/682 where working with an array of length 1 will cause the code path to try to iterate over an array of length 0.  For this to work, magma needs to construct an array of length 0, which causes an exception (we don't allow length 0 arrays https://github.com/phanrahan/magma/blob/f04540f7403641e6d8f32be07da85252504b26f8/magma/array.py#L92).  I think ideally we'd work out some pythonic behavior where slicing off the end works since this is a common python pattern, but for now this change adds a guard to the new code path so we can unblock @mbstrange2