### PR TITLE
Init Register(T) primitive

### DIFF
--- a/magma/clock.py
+++ b/magma/clock.py
@@ -26,8 +26,12 @@ ClockIn = Clock[Direction.In]
 ClockOut = Clock[Direction.Out]
 
 
+class AbstractReset(_ClockType, metaclass=DigitalMeta):
+    pass
+
+
 # synchronous reset, active high (i.e. reset when signal is 1)
-class Reset(_ClockType, metaclass=DigitalMeta):
+class Reset(AbstractReset):
     pass
 
 
@@ -36,7 +40,7 @@ ResetOut = Reset[Direction.Out]
 
 
 # synchronous reset, active low (i.e. reset when signal is 0)
-class ResetN(_ClockType, metaclass=DigitalMeta):
+class ResetN(AbstractReset):
     pass
 
 
@@ -45,7 +49,7 @@ ResetNOut = ResetN[Direction.Out]
 
 
 # asynchronous reset, active high (i.e. reset when signal is 1)
-class AsyncReset(_ClockType, metaclass=DigitalMeta):
+class AsyncReset(AbstractReset):
     pass
 
 
@@ -54,7 +58,7 @@ AsyncResetOut = AsyncReset[Direction.Out]
 
 
 # asynchronous reset, active low (i.e. reset when signal is 0)
-class AsyncResetN(_ClockType, metaclass=DigitalMeta):
+class AsyncResetN(AbstractReset):
     pass
 
 

--- a/magma/clock_io.py
+++ b/magma/clock_io.py
@@ -1,9 +1,9 @@
-from .clock import AsyncReset, AsyncResetN, Clock, Enable, Reset
+from .clock import AsyncReset, AsyncResetN, Clock, Enable, Reset, ResetN
 from .interface import IO
 from .t import In
 
 
-def ClockIO(has_enable=False, has_reset=False, has_ce=False,
+def ClockIO(has_enable=False, has_reset=False, has_resetn=False, has_ce=False,
             has_async_reset=False, has_async_resetn=False):
     args = {'CLK': In(Clock)}
     has_enable |= has_ce
@@ -11,6 +11,8 @@ def ClockIO(has_enable=False, has_reset=False, has_ce=False,
         args['CE'] = In(Enable)
     if has_reset:
         args['RESET'] = In(Reset)
+    if has_resetn:
+        args['RESETN'] = In(ResetN)
     if has_async_reset:
         args['ASYNCRESET'] = In(AsyncReset)
     if has_async_resetn:

--- a/magma/primitives/__init__.py
+++ b/magma/primitives/__init__.py
@@ -1,0 +1,1 @@
+from magma.primitives.register import Register

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -123,15 +123,16 @@ class Register(Generator2):
                            has_resetn=has_resetn)
         if init is None:
             init = 0
-        elif init is int:
-            init = T(init)
-        else:
-            init = as_bits(init)
-            if not init.const():
-                raise TypeError("init must be a const value")
-            init = int(init)
 
-        reg = _CoreIRRegister(T.flat_length(), init=init,
+        if isinstance(init, int):
+            init = T(init)
+
+        if has_async_reset or has_async_resetn:
+            coreir_init = int(as_bits(init))
+        else:
+            coreir_init = 0
+
+        reg = _CoreIRRegister(T.flat_length(), init=coreir_init,
                               has_async_reset=has_async_reset,
                               has_async_resetn=has_async_resetn)()
         O = reg.O

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -23,7 +23,7 @@ class _CoreIRRegister(Generator2):
     def __init__(self, width, init=0, has_async_reset=False,
                  has_async_resetn=False):
         self.name = "reg_P"
-        self.coreir_config_args = {"init": coreir.type.BitVector[width](init)}
+        self.coreir_configargs = {"init": coreir.type.BitVector[width](init)}
         T = Bits[width]
         self.io = IO(I=In(T), CLK=In(Clock), O=Out(T))
 
@@ -34,12 +34,12 @@ class _CoreIRRegister(Generator2):
         if has_async_reset:
             self.io += IO(arst=In(AsyncReset))
             self.name += "R"
-            self.coreir_config_args["arst_posedge"] = True
+            self.coreir_configargs["arst_posedge"] = True
 
         if has_async_resetn:
             self.io += IO(arst=In(AsyncResetN))
             self.name += "R"
-            self.coreir_config_args["arst_posedge"] = False
+            self.coreir_configargs["arst_posedge"] = False
 
         self.stateful = True
         self.default_kwargs = {"init": coreir.type.BitVector[width](init)}

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -6,7 +6,7 @@ import hwtypes
 from magma.bit import Bit
 from magma.bits import Bits
 from magma.circuit import coreir_port_mapping
-from magma.conversions import as_bits
+from magma.conversions import as_bits, from_bits
 from magma.interface import IO
 from magma.generator import Generator2
 from magma.t import Type, Kind, In, Out
@@ -135,9 +135,7 @@ class Register(Generator2):
                               has_async_reset=has_async_reset,
                               has_async_resetn=has_async_resetn)()
         O = reg.O
-        if issubclass(T, Bit):
-            O = O[0]
-        self.io.O @= O
+        self.io.O @= from_bits(T, O)
 
         I = self.io.I
         if (has_reset or has_resetn) and has_enable:
@@ -156,7 +154,4 @@ class Register(Generator2):
             I = Mux(2, T)(name="enable_mux")(O, I, self.io.CE)
         elif has_reset:
             I = Mux(2, T)()(I, init, self.io.RESET)
-        if issubclass(T, Bit):
-            reg.I[0] @= I
-        else:
-            reg.I @= I
+        reg.I @= as_bits(I)

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -82,15 +82,15 @@ class _CoreIRRegister(Generator2):
 
 
 class Register(Generator2):
-    def __init__(self, T: Kind, init: Union[Type, int]=None, reset_type:
-                 AbstractReset=None, has_enable: bool=False,
+    def __init__(self, T: Kind, init: Union[Type, int] = None, reset_type:
+                 AbstractReset = None, has_enable: bool = False,
                  reset_priority=True):
         """
         T: The type of the value that is stored inside the register (e.g.
            Bits[5])
 
         init: (optional) A const value (i.e. init.const() == True) of type T or
-              an int to be used as the initial value of the register.  
+              an int to be used as the initial value of the register.
               If no value is provided, the register will be initialized with 0
 
         reset_type: (optional) The type of the reset port (also specifies the
@@ -116,7 +116,7 @@ class Register(Generator2):
         has_async_resetn = reset_type == AsyncResetN
         has_reset = reset_type == Reset
         has_resetn = reset_type == ResetN
-        self.io += ClockIO(has_enable=has_enable, 
+        self.io += ClockIO(has_enable=has_enable,
                            has_async_reset=has_async_reset,
                            has_async_resetn=has_async_resetn,
                            has_reset=has_reset,

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -1,0 +1,162 @@
+from typing import Union
+
+import coreir
+import hwtypes
+
+from magma.bit import Bit
+from magma.bits import Bits
+from magma.circuit import coreir_port_mapping
+from magma.conversions import as_bits
+from magma.interface import IO
+from magma.generator import Generator2
+from magma.t import Type, Kind, In, Out
+from magma.clock import (AbstractReset, Reset, ResetN, AsyncReset, AsyncResetN,
+                         Clock, Enable)
+from magma.clock_io import ClockIO
+from magma.mux import Mux
+
+
+class _CoreIRRegister(Generator2):
+    """
+    Internally used generator for CoreIR register primitive
+    """
+    def __init__(self, width, init=0, has_async_reset=False,
+                 has_async_resetn=False):
+        self.name = "reg_P"
+        self.coreir_config_args = {"init": coreir.type.BitVector[width](init)}
+        T = Bits[width]
+        self.io = IO(I=In(T), CLK=In(Clock), O=Out(T))
+
+        if has_async_resetn and has_async_reset:
+            raise ValueError("Cannot have posedge and negedge asynchronous "
+                             "reset")
+
+        if has_async_reset:
+            self.io += IO(arst=In(AsyncReset))
+            self.name += "R"
+            self.coreir_config_args["arst_posedge"] = True
+
+        if has_async_resetn:
+            self.io += IO(arst=In(AsyncResetN))
+            self.name += "R"
+            self.coreir_config_args["arst_posedge"] = False
+
+        self.stateful = True
+        self.default_kwargs = {"init": coreir.type.BitVector[width](init)}
+        self.coreir_genargs = {"width": width}
+        self.renamed_ports = coreir_port_mapping
+
+        self.coreir_name = "reg"
+        if (has_async_reset or has_async_resetn):
+            self.coreir_name += "_arst"
+
+        self.verilog_name = "coreir_" + self.coreir_name
+        self.coreir_lib = "coreir"
+
+        def _simulate(self, value_store, state_store):
+            cur_clock = value_store.get_value(self.CLK)
+
+            if not state_store:
+                state_store['prev_clock'] = cur_clock
+                state_store['cur_val'] = hwtypes.BitVector[width](init)
+
+            if has_async_reset or has_async_resetn:
+                cur_reset = value_store.get_value(self.arst)
+
+            prev_clock = state_store['prev_clock']
+            clock_edge = cur_clock and not prev_clock
+
+            new_val = state_store['cur_val'].as_bool_list()
+
+            if clock_edge:
+                new_val = value_store.get_value(self.I)
+
+            if has_async_reset and cur_reset or \
+                    has_async_resetn and not cur_reset:
+                new_val = hwtypes.BitVector[width](init)
+
+            state_store['prev_clock'] = cur_clock
+            state_store['cur_val'] = hwtypes.BitVector[width](new_val)
+            value_store.set_value(self.O, new_val)
+        self.simulate = _simulate
+
+
+class Register(Generator2):
+    def __init__(self, T: Kind, init: Union[Type, int]=None, reset_type:
+                 AbstractReset=None, has_enable: bool=False,
+                 reset_priority=True):
+        """
+        T: The type of the value that is stored inside the register (e.g.
+           Bits[5])
+
+        init: (optional) A const value (i.e. init.const() == True) of type T or
+              an int to be used as the initial value of the register.  
+              If no value is provided, the register will be initialized with 0
+
+        reset_type: (optional) The type of the reset port (also specifies the
+                    semantic behavior of the reset signal)
+
+        reset_priority: (optional) boolean flag choosing whether synchronous
+                        reset (RESET or RESETN) has priority over enable
+        """
+        if not isinstance(T, Kind):
+            raise TypeError(
+                f"Expected instance of Kind for argument T, not {type(T)}")
+        if init is not None and not isinstance(init, (Type, int)):
+            raise TypeError(
+                f"Expected instance of Type or int for argument init, not "
+                f"{type(init)}")
+        if reset_type is not None and not issubclass(reset_type, AbstractReset):
+            raise TypeError(
+                f"Expected subclass of AbstractReset for argument reset_type, "
+                f"not {type(reset_type)}")
+
+        self.io = IO(I=In(T), O=Out(T))
+        has_async_reset = reset_type == AsyncReset
+        has_async_resetn = reset_type == AsyncResetN
+        has_reset = reset_type == Reset
+        has_resetn = reset_type == ResetN
+        self.io += ClockIO(has_enable=has_enable, 
+                           has_async_reset=has_async_reset,
+                           has_async_resetn=has_async_resetn,
+                           has_reset=has_reset,
+                           has_resetn=has_resetn)
+        if init is None:
+            init = 0
+        elif init is int:
+            init = T(init)
+        else:
+            init = as_bits(init)
+            if not init.const():
+                raise TypeError("init must be a const value")
+            init = int(init)
+
+        reg = _CoreIRRegister(T.flat_length(), init=init,
+                              has_async_reset=has_async_reset,
+                              has_async_resetn=has_async_resetn)()
+        O = reg.O
+        if issubclass(T, Bit):
+            O = O[0]
+        self.io.O @= O
+
+        I = self.io.I
+        if (has_reset or has_resetn) and has_enable:
+            if has_reset:
+                reset_port = self.io.RESET
+            else:
+                reset_port = self.io.RESETN
+
+            if reset_priority:
+                I = Mux(2, T)(name="enable_mux")(O, I, self.io.CE)
+                I = Mux(2, T)()([I, init], reset_port)
+            else:
+                I = Mux(2, T)()([I, init], reset_port)
+                I = Mux(2, T)(name="enable_mux")(O, I, self.io.CE)
+        elif has_enable:
+            I = Mux(2, T)(name="enable_mux")(O, I, self.io.CE)
+        elif has_reset:
+            I = Mux(2, T)()(I, init, self.io.RESET)
+        if issubclass(T, Bit):
+            reg.I[0] @= I
+        else:
+            reg.I @= I

--- a/tests/test_primitives/build/.gitignore
+++ b/tests/test_primitives/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_primitives/gold/test_basic_reg.v
+++ b/tests/test_primitives/gold/test_basic_reg.v
@@ -1,0 +1,121 @@
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module coreir_mux #(
+    parameter width = 1
+) (
+    input [width-1:0] in0,
+    input [width-1:0] in1,
+    input sel,
+    output [width-1:0] out
+);
+  assign out = sel ? in1 : in0;
+endmodule
+
+module coreir_const #(
+    parameter width = 1,
+    parameter value = 1
+) (
+    output [width-1:0] out
+);
+  assign out = value;
+endmodule
+
+module commonlib_muxn__N2__width8 (
+    input [7:0] in_data_0,
+    input [7:0] in_data_1,
+    input [0:0] in_sel,
+    output [7:0] out
+);
+wire [7:0] _join_out;
+coreir_mux #(
+    .width(8)
+) _join (
+    .in0(in_data_0),
+    .in1(in_data_1),
+    .sel(in_sel[0]),
+    .out(_join_out)
+);
+assign out = _join_out;
+endmodule
+
+module Mux2xBits8 (
+    input [7:0] I0,
+    input [7:0] I1,
+    input S,
+    output [7:0] O
+);
+wire [7:0] coreir_commonlib_mux2x8_inst0_out;
+commonlib_muxn__N2__width8 coreir_commonlib_mux2x8_inst0 (
+    .in_data_0(I0),
+    .in_data_1(I1),
+    .in_sel(S),
+    .out(coreir_commonlib_mux2x8_inst0_out)
+);
+assign O = coreir_commonlib_mux2x8_inst0_out;
+endmodule
+
+module Register (
+    input [7:0] I,
+    output [7:0] O,
+    input CLK,
+    input RESET
+);
+wire [7:0] Mux2xBits8_inst0_O;
+wire [7:0] const_222_8_out;
+wire [7:0] reg_P_inst0_out;
+Mux2xBits8 Mux2xBits8_inst0 (
+    .I0(I),
+    .I1(const_222_8_out),
+    .S(RESET),
+    .O(Mux2xBits8_inst0_O)
+);
+coreir_const #(
+    .value(8'hde),
+    .width(8)
+) const_222_8 (
+    .out(const_222_8_out)
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(8'hxx),
+    .width(8)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in(Mux2xBits8_inst0_O),
+    .out(reg_P_inst0_out)
+);
+assign O = reg_P_inst0_out;
+endmodule
+
+module test_basic_reg (
+    input [7:0] I,
+    output [7:0] O,
+    input CLK,
+    input RESET
+);
+wire [7:0] Register_inst0_O;
+Register Register_inst0 (
+    .I(I),
+    .O(Register_inst0_O),
+    .CLK(CLK),
+    .RESET(RESET)
+);
+assign O = Register_inst0_O;
+endmodule
+

--- a/tests/test_primitives/gold/test_basic_reg.v
+++ b/tests/test_primitives/gold/test_basic_reg.v
@@ -93,7 +93,7 @@ coreir_const #(
 );
 coreir_reg #(
     .clk_posedge(1'b1),
-    .init(8'hxx),
+    .init(8'h00),
     .width(8)
 ) reg_P_inst0 (
     .clk(CLK),

--- a/tests/test_primitives/gold/test_reg_async_resetn.v
+++ b/tests/test_primitives/gold/test_reg_async_resetn.v
@@ -1,0 +1,60 @@
+module coreir_reg_arst #(
+    parameter width = 1,
+    parameter arst_posedge = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input arst,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg;
+  wire real_rst;
+  assign real_rst = arst_posedge ? arst : ~arst;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk, posedge real_rst) begin
+    if (real_rst) outReg <= init;
+    else outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module Register (
+    input [7:0] I,
+    output [7:0] O,
+    input CLK,
+    input ASYNCRESETN
+);
+wire [7:0] reg_PR_inst0_out;
+coreir_reg_arst #(
+    .arst_posedge(1'b0),
+    .clk_posedge(1'b1),
+    .init(8'hde),
+    .width(8)
+) reg_PR_inst0 (
+    .clk(CLK),
+    .arst(ASYNCRESETN),
+    .in(I),
+    .out(reg_PR_inst0_out)
+);
+assign O = reg_PR_inst0_out;
+endmodule
+
+module test_reg_async_resetn (
+    input [7:0] I,
+    output [7:0] O,
+    input CLK,
+    input ASYNCRESETN
+);
+wire [7:0] Register_inst0_O;
+Register Register_inst0 (
+    .I(I),
+    .O(Register_inst0_O),
+    .CLK(CLK),
+    .ASYNCRESETN(ASYNCRESETN)
+);
+assign O = Register_inst0_O;
+endmodule
+

--- a/tests/test_primitives/gold/test_reg_of_nested_array.v
+++ b/tests/test_primitives/gold/test_reg_of_nested_array.v
@@ -1,0 +1,169 @@
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module coreir_mux #(
+    parameter width = 1
+) (
+    input [width-1:0] in0,
+    input [width-1:0] in1,
+    input sel,
+    output [width-1:0] out
+);
+  assign out = sel ? in1 : in0;
+endmodule
+
+module coreir_const #(
+    parameter width = 1,
+    parameter value = 1
+) (
+    output [width-1:0] out
+);
+  assign out = value;
+endmodule
+
+module commonlib_muxn__N2__width24 (
+    input [23:0] in_data_0,
+    input [23:0] in_data_1,
+    input [0:0] in_sel,
+    output [23:0] out
+);
+wire [23:0] _join_out;
+coreir_mux #(
+    .width(24)
+) _join (
+    .in0(in_data_0),
+    .in1(in_data_1),
+    .sel(in_sel[0]),
+    .out(_join_out)
+);
+assign out = _join_out;
+endmodule
+
+module Mux2xArray3_Bits8 (
+    input [7:0] I0_0,
+    input [7:0] I0_1,
+    input [7:0] I0_2,
+    input [7:0] I1_0,
+    input [7:0] I1_1,
+    input [7:0] I1_2,
+    output [7:0] O_0,
+    output [7:0] O_1,
+    output [7:0] O_2,
+    input S
+);
+wire [23:0] coreir_commonlib_mux2x24_inst0_out;
+commonlib_muxn__N2__width24 coreir_commonlib_mux2x24_inst0 (
+    .in_data_0({I0_2[7],I0_2[6],I0_2[5],I0_2[4],I0_2[3],I0_2[2],I0_2[1],I0_2[0],I0_1[7],I0_1[6],I0_1[5],I0_1[4],I0_1[3],I0_1[2],I0_1[1],I0_1[0],I0_0[7],I0_0[6],I0_0[5],I0_0[4],I0_0[3],I0_0[2],I0_0[1],I0_0[0]}),
+    .in_data_1({I1_2[7],I1_2[6],I1_2[5],I1_2[4],I1_2[3],I1_2[2],I1_2[1],I1_2[0],I1_1[7],I1_1[6],I1_1[5],I1_1[4],I1_1[3],I1_1[2],I1_1[1],I1_1[0],I1_0[7],I1_0[6],I1_0[5],I1_0[4],I1_0[3],I1_0[2],I1_0[1],I1_0[0]}),
+    .in_sel(S),
+    .out(coreir_commonlib_mux2x24_inst0_out)
+);
+assign O_0 = {coreir_commonlib_mux2x24_inst0_out[7],coreir_commonlib_mux2x24_inst0_out[6],coreir_commonlib_mux2x24_inst0_out[5],coreir_commonlib_mux2x24_inst0_out[4],coreir_commonlib_mux2x24_inst0_out[3],coreir_commonlib_mux2x24_inst0_out[2],coreir_commonlib_mux2x24_inst0_out[1],coreir_commonlib_mux2x24_inst0_out[0]};
+assign O_1 = {coreir_commonlib_mux2x24_inst0_out[15],coreir_commonlib_mux2x24_inst0_out[14],coreir_commonlib_mux2x24_inst0_out[13],coreir_commonlib_mux2x24_inst0_out[12],coreir_commonlib_mux2x24_inst0_out[11],coreir_commonlib_mux2x24_inst0_out[10],coreir_commonlib_mux2x24_inst0_out[9],coreir_commonlib_mux2x24_inst0_out[8]};
+assign O_2 = {coreir_commonlib_mux2x24_inst0_out[23],coreir_commonlib_mux2x24_inst0_out[22],coreir_commonlib_mux2x24_inst0_out[21],coreir_commonlib_mux2x24_inst0_out[20],coreir_commonlib_mux2x24_inst0_out[19],coreir_commonlib_mux2x24_inst0_out[18],coreir_commonlib_mux2x24_inst0_out[17],coreir_commonlib_mux2x24_inst0_out[16]};
+endmodule
+
+module Register (
+    input CLK,
+    input [7:0] I_0,
+    input [7:0] I_1,
+    input [7:0] I_2,
+    output [7:0] O_0,
+    output [7:0] O_1,
+    output [7:0] O_2,
+    input RESET
+);
+wire [7:0] Mux2xArray3_Bits8_inst0_O_0;
+wire [7:0] Mux2xArray3_Bits8_inst0_O_1;
+wire [7:0] Mux2xArray3_Bits8_inst0_O_2;
+wire [7:0] const_173_8_out;
+wire [7:0] const_190_8_out;
+wire [7:0] const_222_8_out;
+wire [23:0] reg_P_inst0_out;
+Mux2xArray3_Bits8 Mux2xArray3_Bits8_inst0 (
+    .I0_0(I_0),
+    .I0_1(I_1),
+    .I0_2(I_2),
+    .I1_0(const_222_8_out),
+    .I1_1(const_173_8_out),
+    .I1_2(const_190_8_out),
+    .O_0(Mux2xArray3_Bits8_inst0_O_0),
+    .O_1(Mux2xArray3_Bits8_inst0_O_1),
+    .O_2(Mux2xArray3_Bits8_inst0_O_2),
+    .S(RESET)
+);
+coreir_const #(
+    .value(8'had),
+    .width(8)
+) const_173_8 (
+    .out(const_173_8_out)
+);
+coreir_const #(
+    .value(8'hbe),
+    .width(8)
+) const_190_8 (
+    .out(const_190_8_out)
+);
+coreir_const #(
+    .value(8'hde),
+    .width(8)
+) const_222_8 (
+    .out(const_222_8_out)
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(24'hxxxxxx),
+    .width(24)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in({Mux2xArray3_Bits8_inst0_O_2[7],Mux2xArray3_Bits8_inst0_O_2[6],Mux2xArray3_Bits8_inst0_O_2[5],Mux2xArray3_Bits8_inst0_O_2[4],Mux2xArray3_Bits8_inst0_O_2[3],Mux2xArray3_Bits8_inst0_O_2[2],Mux2xArray3_Bits8_inst0_O_2[1],Mux2xArray3_Bits8_inst0_O_2[0],Mux2xArray3_Bits8_inst0_O_1[7],Mux2xArray3_Bits8_inst0_O_1[6],Mux2xArray3_Bits8_inst0_O_1[5],Mux2xArray3_Bits8_inst0_O_1[4],Mux2xArray3_Bits8_inst0_O_1[3],Mux2xArray3_Bits8_inst0_O_1[2],Mux2xArray3_Bits8_inst0_O_1[1],Mux2xArray3_Bits8_inst0_O_1[0],Mux2xArray3_Bits8_inst0_O_0[7],Mux2xArray3_Bits8_inst0_O_0[6],Mux2xArray3_Bits8_inst0_O_0[5],Mux2xArray3_Bits8_inst0_O_0[4],Mux2xArray3_Bits8_inst0_O_0[3],Mux2xArray3_Bits8_inst0_O_0[2],Mux2xArray3_Bits8_inst0_O_0[1],Mux2xArray3_Bits8_inst0_O_0[0]}),
+    .out(reg_P_inst0_out)
+);
+assign O_0 = {reg_P_inst0_out[7],reg_P_inst0_out[6],reg_P_inst0_out[5],reg_P_inst0_out[4],reg_P_inst0_out[3],reg_P_inst0_out[2],reg_P_inst0_out[1],reg_P_inst0_out[0]};
+assign O_1 = {reg_P_inst0_out[15],reg_P_inst0_out[14],reg_P_inst0_out[13],reg_P_inst0_out[12],reg_P_inst0_out[11],reg_P_inst0_out[10],reg_P_inst0_out[9],reg_P_inst0_out[8]};
+assign O_2 = {reg_P_inst0_out[23],reg_P_inst0_out[22],reg_P_inst0_out[21],reg_P_inst0_out[20],reg_P_inst0_out[19],reg_P_inst0_out[18],reg_P_inst0_out[17],reg_P_inst0_out[16]};
+endmodule
+
+module test_reg_of_nested_array (
+    input CLK,
+    input [7:0] I_0,
+    input [7:0] I_1,
+    input [7:0] I_2,
+    output [7:0] O_0,
+    output [7:0] O_1,
+    output [7:0] O_2,
+    input RESET
+);
+wire [7:0] Register_inst0_O_0;
+wire [7:0] Register_inst0_O_1;
+wire [7:0] Register_inst0_O_2;
+Register Register_inst0 (
+    .CLK(CLK),
+    .I_0(I_0),
+    .I_1(I_1),
+    .I_2(I_2),
+    .O_0(Register_inst0_O_0),
+    .O_1(Register_inst0_O_1),
+    .O_2(Register_inst0_O_2),
+    .RESET(RESET)
+);
+assign O_0 = Register_inst0_O_0;
+assign O_1 = Register_inst0_O_1;
+assign O_2 = Register_inst0_O_2;
+endmodule
+

--- a/tests/test_primitives/gold/test_reg_of_nested_array.v
+++ b/tests/test_primitives/gold/test_reg_of_nested_array.v
@@ -127,7 +127,7 @@ coreir_const #(
 );
 coreir_reg #(
     .clk_posedge(1'b1),
-    .init(24'hxxxxxx),
+    .init(24'h000000),
     .width(24)
 ) reg_P_inst0 (
     .clk(CLK),

--- a/tests/test_primitives/gold/test_reg_of_product.v
+++ b/tests/test_primitives/gold/test_reg_of_product.v
@@ -1,0 +1,145 @@
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module coreir_mux #(
+    parameter width = 1
+) (
+    input [width-1:0] in0,
+    input [width-1:0] in1,
+    input sel,
+    output [width-1:0] out
+);
+  assign out = sel ? in1 : in0;
+endmodule
+
+module coreir_const #(
+    parameter width = 1,
+    parameter value = 1
+) (
+    output [width-1:0] out
+);
+  assign out = value;
+endmodule
+
+module commonlib_muxn__N2__width12 (
+    input [11:0] in_data_0,
+    input [11:0] in_data_1,
+    input [0:0] in_sel,
+    output [11:0] out
+);
+wire [11:0] _join_out;
+coreir_mux #(
+    .width(12)
+) _join (
+    .in0(in_data_0),
+    .in1(in_data_1),
+    .sel(in_sel[0]),
+    .out(_join_out)
+);
+assign out = _join_out;
+endmodule
+
+module Mux2xTuplex_Bits8_y_Bits4 (
+    input [7:0] I0_x,
+    input [3:0] I0_y,
+    input [7:0] I1_x,
+    input [3:0] I1_y,
+    output [7:0] O_x,
+    output [3:0] O_y,
+    input S
+);
+wire [11:0] coreir_commonlib_mux2x12_inst0_out;
+commonlib_muxn__N2__width12 coreir_commonlib_mux2x12_inst0 (
+    .in_data_0({I0_y[3],I0_y[2],I0_y[1],I0_y[0],I0_x[7],I0_x[6],I0_x[5],I0_x[4],I0_x[3],I0_x[2],I0_x[1],I0_x[0]}),
+    .in_data_1({I1_y[3],I1_y[2],I1_y[1],I1_y[0],I1_x[7],I1_x[6],I1_x[5],I1_x[4],I1_x[3],I1_x[2],I1_x[1],I1_x[0]}),
+    .in_sel(S),
+    .out(coreir_commonlib_mux2x12_inst0_out)
+);
+assign O_x = {coreir_commonlib_mux2x12_inst0_out[7],coreir_commonlib_mux2x12_inst0_out[6],coreir_commonlib_mux2x12_inst0_out[5],coreir_commonlib_mux2x12_inst0_out[4],coreir_commonlib_mux2x12_inst0_out[3],coreir_commonlib_mux2x12_inst0_out[2],coreir_commonlib_mux2x12_inst0_out[1],coreir_commonlib_mux2x12_inst0_out[0]};
+assign O_y = {coreir_commonlib_mux2x12_inst0_out[11],coreir_commonlib_mux2x12_inst0_out[10],coreir_commonlib_mux2x12_inst0_out[9],coreir_commonlib_mux2x12_inst0_out[8]};
+endmodule
+
+module Register (
+    input CLK,
+    input [7:0] I_x,
+    input [3:0] I_y,
+    output [7:0] O_x,
+    output [3:0] O_y,
+    input RESET
+);
+wire [7:0] Mux2xTuplex_Bits8_y_Bits4_inst0_O_x;
+wire [3:0] Mux2xTuplex_Bits8_y_Bits4_inst0_O_y;
+wire [3:0] const_10_4_out;
+wire [7:0] const_222_8_out;
+wire [11:0] reg_P_inst0_out;
+Mux2xTuplex_Bits8_y_Bits4 Mux2xTuplex_Bits8_y_Bits4_inst0 (
+    .I0_x(I_x),
+    .I0_y(I_y),
+    .I1_x(const_222_8_out),
+    .I1_y(const_10_4_out),
+    .O_x(Mux2xTuplex_Bits8_y_Bits4_inst0_O_x),
+    .O_y(Mux2xTuplex_Bits8_y_Bits4_inst0_O_y),
+    .S(RESET)
+);
+coreir_const #(
+    .value(4'ha),
+    .width(4)
+) const_10_4 (
+    .out(const_10_4_out)
+);
+coreir_const #(
+    .value(8'hde),
+    .width(8)
+) const_222_8 (
+    .out(const_222_8_out)
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(12'hxxx),
+    .width(12)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in({Mux2xTuplex_Bits8_y_Bits4_inst0_O_y[3],Mux2xTuplex_Bits8_y_Bits4_inst0_O_y[2],Mux2xTuplex_Bits8_y_Bits4_inst0_O_y[1],Mux2xTuplex_Bits8_y_Bits4_inst0_O_y[0],Mux2xTuplex_Bits8_y_Bits4_inst0_O_x[7],Mux2xTuplex_Bits8_y_Bits4_inst0_O_x[6],Mux2xTuplex_Bits8_y_Bits4_inst0_O_x[5],Mux2xTuplex_Bits8_y_Bits4_inst0_O_x[4],Mux2xTuplex_Bits8_y_Bits4_inst0_O_x[3],Mux2xTuplex_Bits8_y_Bits4_inst0_O_x[2],Mux2xTuplex_Bits8_y_Bits4_inst0_O_x[1],Mux2xTuplex_Bits8_y_Bits4_inst0_O_x[0]}),
+    .out(reg_P_inst0_out)
+);
+assign O_x = {reg_P_inst0_out[7],reg_P_inst0_out[6],reg_P_inst0_out[5],reg_P_inst0_out[4],reg_P_inst0_out[3],reg_P_inst0_out[2],reg_P_inst0_out[1],reg_P_inst0_out[0]};
+assign O_y = {reg_P_inst0_out[11],reg_P_inst0_out[10],reg_P_inst0_out[9],reg_P_inst0_out[8]};
+endmodule
+
+module test_reg_of_product (
+    input CLK,
+    input [7:0] I_x,
+    input [3:0] I_y,
+    output [7:0] O_x,
+    output [3:0] O_y,
+    input RESET
+);
+wire [7:0] Register_inst0_O_x;
+wire [3:0] Register_inst0_O_y;
+Register Register_inst0 (
+    .CLK(CLK),
+    .I_x(I_x),
+    .I_y(I_y),
+    .O_x(Register_inst0_O_x),
+    .O_y(Register_inst0_O_y),
+    .RESET(RESET)
+);
+assign O_x = Register_inst0_O_x;
+assign O_y = Register_inst0_O_y;
+endmodule
+

--- a/tests/test_primitives/gold/test_reg_of_product.v
+++ b/tests/test_primitives/gold/test_reg_of_product.v
@@ -110,7 +110,7 @@ coreir_const #(
 );
 coreir_reg #(
     .clk_posedge(1'b1),
-    .init(12'hxxx),
+    .init(12'h000),
     .width(12)
 ) reg_P_inst0 (
     .clk(CLK),

--- a/tests/test_primitives/test_register.py
+++ b/tests/test_primitives/test_register.py
@@ -42,3 +42,45 @@ def test_basic_reg():
     tester.compile_and_run("verilator", skip_compile=True,
                            directory=os.path.join(os.path.dirname(__file__),
                                                   "build"))
+
+
+def test_reg_of_product():
+    class T(m.Product):
+        x = m.Bits[8]
+        y = m.Bits[4]
+        
+    class test_reg_of_product(m.Circuit):
+        io = m.IO(I=m.In(T), O=m.Out(T)) + m.ClockIO(has_reset=True)
+        io.O @= Register(T, T(m.Bits[8](0xDE), m.Bits[4](0xA)),
+                         reset_type=m.Reset)()(io.I)
+
+    m.compile("build/test_reg_of_product", test_reg_of_product)
+
+    assert check_files_equal(__file__, f"build/test_reg_of_product.v",
+                             f"gold/test_reg_of_product.v")
+
+    tester = fault.SynchronousTester(test_reg_of_product, test_reg_of_product.CLK)
+    tester.circuit.I = (0, 1)
+    tester.circuit.RESET = 1
+    tester.advance_cycle()
+    tester.circuit.RESET = 0
+    # Reset val
+    tester.circuit.O.expect((0xDE, 0xA))
+    tester.advance_cycle()
+    tester.circuit.O.expect((0, 1))
+    tester.circuit.I = (2, 3)
+    tester.advance_cycle()
+    tester.circuit.O.expect((2, 3))
+    tester.circuit.I = (4, 5)
+    tester.advance_cycle()
+    tester.circuit.O.expect((4, 5))
+    tester.circuit.RESET = 1
+    tester.advance_cycle()
+    tester.circuit.RESET = 0
+    tester.circuit.I = (6, 7)
+    tester.circuit.O.expect((0xDE, 0xA))
+    tester.advance_cycle()
+    tester.circuit.O.expect((6, 7))
+    tester.compile_and_run("verilator", skip_compile=True,
+                           directory=os.path.join(os.path.dirname(__file__),
+                                                  "build"))

--- a/tests/test_primitives/test_register.py
+++ b/tests/test_primitives/test_register.py
@@ -1,0 +1,44 @@
+import os
+
+import magma as m
+from magma.testing import check_files_equal
+from magma.primitives import Register
+
+import fault
+
+
+def test_basic_reg():
+    class test_basic_reg(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8])) + m.ClockIO(has_reset=True)
+        io.O @= Register(m.Bits[8], m.Bits[8](0xDE), reset_type=m.Reset)()(io.I)
+
+    m.compile("build/test_basic_reg", test_basic_reg)
+
+    assert check_files_equal(__file__, f"build/test_basic_reg.v",
+                             f"gold/test_basic_reg.v")
+
+    tester = fault.SynchronousTester(test_basic_reg, test_basic_reg.CLK)
+    tester.circuit.I = 0
+    tester.circuit.RESET = 1
+    tester.advance_cycle()
+    tester.circuit.RESET = 0
+    # Reset val
+    tester.circuit.O.expect(0xDE)
+    tester.advance_cycle()
+    tester.circuit.O.expect(0)
+    tester.circuit.I = 1
+    tester.advance_cycle()
+    tester.circuit.O.expect(1)
+    tester.circuit.I = 2
+    tester.advance_cycle()
+    tester.circuit.O.expect(2)
+    tester.circuit.RESET = 1
+    tester.advance_cycle()
+    tester.circuit.RESET = 0
+    tester.circuit.I = 3
+    tester.circuit.O.expect(0xDE)
+    tester.advance_cycle()
+    tester.circuit.O.expect(3)
+    tester.compile_and_run("verilator", skip_compile=True,
+                           directory=os.path.join(os.path.dirname(__file__),
+                                                  "build"))


### PR DESCRIPTION
See https://github.com/phanrahan/magma/issues/598 for related discussion.

This is designed to work with any type that implements the from_bits/as_bits interface (via the flatten/unflatten methods).

It also updates the reset interface to accept a type rather than a different flag for each reset type.