### PR TITLE
Inline verilog bug fixes

### DIFF
--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -126,7 +126,7 @@ def _inline_verilog(cls, inline_str, inline_value_map, **kwargs):
 
     class _InlineVerilog(Circuit):
         # Unique name (hash) since uniquify doesn't check inline_verilog
-        name = f"{cls.name}_{len(cls.inline_verilog_modules)}"
+        name = f"{cls.name}_inline_verilog_{len(cls.inline_verilog_modules)}"
 
         io = _build_io(inline_value_map)
 

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -57,7 +57,8 @@ class UniquificationPass(DefinitionPass):
                 # Inline modules use a naming scheme based on the container
                 # name, so we update their names by replacing the name
                 # substring
-                for module in definition.inline_verilog_modules:
+                for module in getattr(definition, "inline_verilog_modules",
+                                      []):
                     module.name = module.name.replace(name, new_name)
                 for module in definition.bind_modules:
                     type(module).rename(module, module.name + suffix)
@@ -71,7 +72,8 @@ class UniquificationPass(DefinitionPass):
                 # Inline modules use a naming scheme based on the container
                 # name, so we update their names by replacing the name
                 # substring
-                for module in definition.inline_verilog_modules:
+                for module in getattr(definition, "inline_verilog_modules",
+                                      []):
                     module.name = module.name.replace(name, new_name)
                 for x, y in zip(seen[key][0].bind_modules,
                                 definition.bind_modules):

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -43,7 +43,8 @@ def _rename_inline_verilog(definition, new_name):
     # substring
     for module in getattr(definition, "inline_verilog_modules",
                           []):
-        type(module).rename(module, module.name.replace(new_name))
+        type(module).rename(module, module.name.replace(definition.name,
+                                                        new_name))
 
 
 class UniquificationPass(DefinitionPass):

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -37,6 +37,15 @@ def _hash(definition):
     return hash(hash_struct)
 
 
+def _rename_inline_verilog(definition, new_name):
+    # Inline modules use a naming scheme based on the container
+    # name, so we update their names by replacing the name
+    # substring
+    for module in getattr(definition, "inline_verilog_modules",
+                          []):
+        type(module).rename(module, module.name.replace(new_name))
+
+
 class UniquificationPass(DefinitionPass):
     def __init__(self, main, mode):
         super().__init__(main)
@@ -54,12 +63,7 @@ class UniquificationPass(DefinitionPass):
                 suffix = "_unq" + str(len(seen))
                 new_name = name + suffix
                 type(definition).rename(definition, new_name)
-                # Inline modules use a naming scheme based on the container
-                # name, so we update their names by replacing the name
-                # substring
-                for module in getattr(definition, "inline_verilog_modules",
-                                      []):
-                    type(module).rename(module, module.name.replace(new_name))
+                _rename_inline_verilog(definition, new_name)
                 for module in definition.bind_modules:
                     type(module).rename(module, module.name + suffix)
             seen[key] = [definition]
@@ -69,12 +73,7 @@ class UniquificationPass(DefinitionPass):
             elif name != seen[key][0].name:
                 new_name = seen[key][0].name
                 type(definition).rename(definition, new_name)
-                # Inline modules use a naming scheme based on the container
-                # name, so we update their names by replacing the name
-                # substring
-                for module in getattr(definition, "inline_verilog_modules",
-                                      []):
-                    type(module).rename(module, module.name.replace(new_name))
+                _rename_inline_verilog(definition, new_name)
                 for x, y in zip(seen[key][0].bind_modules,
                                 definition.bind_modules):
                     type(y).rename(y, x.name)

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -59,7 +59,7 @@ class UniquificationPass(DefinitionPass):
                 # substring
                 for module in getattr(definition, "inline_verilog_modules",
                                       []):
-                    type(module).rename(module, new_name)
+                    type(module).rename(module, module.name.replace(new_name))
                 for module in definition.bind_modules:
                     type(module).rename(module, module.name + suffix)
             seen[key] = [definition]
@@ -74,7 +74,7 @@ class UniquificationPass(DefinitionPass):
                 # substring
                 for module in getattr(definition, "inline_verilog_modules",
                                       []):
-                    type(module).rename(module, new_name)
+                    type(module).rename(module, module.name.replace(new_name))
                 for x, y in zip(seen[key][0].bind_modules,
                                 definition.bind_modules):
                     type(y).rename(y, x.name)

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -41,10 +41,10 @@ def _rename_inline_verilog(definition, new_name):
     # Inline modules use a naming scheme based on the container
     # name, so we update their names by replacing the name
     # substring
-    for module in getattr(definition, "inline_verilog_modules",
-                          []):
-        type(module).rename(module, module.name.replace(definition.name,
-                                                        new_name))
+    modules = getattr(definition, "inline_verilog_modules", [])
+    for module in modules:
+        new_name = module.name.replace(definition.name, new_name)
+        type(module).rename(module, new_name)
 
 
 class UniquificationPass(DefinitionPass):

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -59,7 +59,7 @@ class UniquificationPass(DefinitionPass):
                 # substring
                 for module in getattr(definition, "inline_verilog_modules",
                                       []):
-                    module.rename(new_name)
+                    type(module).rename(module, new_name)
                 for module in definition.bind_modules:
                     type(module).rename(module, module.name + suffix)
             seen[key] = [definition]
@@ -74,7 +74,7 @@ class UniquificationPass(DefinitionPass):
                 # substring
                 for module in getattr(definition, "inline_verilog_modules",
                                       []):
-                    module.rename(new_name)
+                    type(module).rename(module, new_name)
                 for x, y in zip(seen[key][0].bind_modules,
                                 definition.bind_modules):
                     type(y).rename(y, x.name)

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -59,7 +59,7 @@ class UniquificationPass(DefinitionPass):
                 # substring
                 for module in getattr(definition, "inline_verilog_modules",
                                       []):
-                    module.name = module.name.replace(name, new_name)
+                    module.rename(new_name)
                 for module in definition.bind_modules:
                     type(module).rename(module, module.name + suffix)
             seen[key] = [definition]
@@ -74,7 +74,7 @@ class UniquificationPass(DefinitionPass):
                 # substring
                 for module in getattr(definition, "inline_verilog_modules",
                                       []):
-                    module.name = module.name.replace(name, new_name)
+                    module.rename(new_name)
                 for x, y in zip(seen[key][0].bind_modules,
                                 definition.bind_modules):
                     type(y).rename(y, x.name)


### PR DESCRIPTION
Uses default getattr logic for backwards compatability with old-style circuits that don't have inline_verilog_modules fields.

Fixes uniquification of inline verilog modules to use rename API instead of just setting the name field.

Appends _inline_verilog_ to module name for easier debug/readability