### PR TITLE
Fix zext bug

### DIFF
--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -124,7 +124,7 @@ def convertbits(value, n, totype, checkbit):
             ts = n * [value]
         else:
             # zext
-            ts = [Bit(0) for _ in range(n - 1)] + [value]
+            ts = [value] + [Bit(0) for _ in range(n - 1)]
     else:
         ts = [value[i] for i in range(len(value))]
 

--- a/tests/test_primitives/gold/test_add_1_bit.v
+++ b/tests/test_primitives/gold/test_add_1_bit.v
@@ -1,0 +1,8 @@
+module test_add_1_bit (
+    input [4:0] I,
+    input C,
+    output [4:0] O
+);
+assign O = 5'(({1'b0,1'b0,1'b0,1'b0,C}) + I);
+endmodule
+

--- a/tests/test_primitives/test_add.py
+++ b/tests/test_primitives/test_add.py
@@ -1,0 +1,32 @@
+import os
+
+import magma as m
+from magma.testing import check_files_equal
+
+import fault
+
+
+def test_add_1_bit():
+    class test_add_1_bit(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[5]), C=m.In(m.Bit), O=m.Out(m.Bits[5]))
+
+        io.O @= m.uint(io.C, 5) + m.uint(io.I)
+
+    m.compile('build/test_add_1_bit', test_add_1_bit, inline=True)
+
+    assert check_files_equal(__file__, f"build/test_add_1_bit.v",
+                             f"gold/test_add_1_bit.v")
+
+    tester = fault.Tester(test_add_1_bit)
+    tester.circuit.I = 2
+    tester.circuit.C = 1
+    tester.eval()
+    tester.circuit.O.expect(3)
+    tester.circuit.I = 4
+    tester.circuit.C = 0
+    tester.eval()
+    tester.circuit.O.expect(4)
+
+    tester.compile_and_run("verilator", skip_compile=True,
+                           directory=os.path.join(os.path.dirname(__file__),
+                                                  "build"))

--- a/tests/test_type/gold/test_foo_magma_protocol.v
+++ b/tests/test_type/gold/test_foo_magma_protocol.v
@@ -99,7 +99,7 @@ coreir_or #(
     .width(8)
 ) magma_Bits_8_or_inst1 (
     .in0(magma_Bits_8_or_inst0_out),
-    .in1({foo[0],bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out}),
+    .in1({bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,foo[0]}),
     .out(magma_Bits_8_or_inst1_out)
 );
 coreir_shl #(
@@ -112,7 +112,7 @@ coreir_shl #(
 coreir_shl #(
     .width(8)
 ) magma_Bits_8_shl_inst1 (
-    .in0({foo[0],bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out}),
+    .in0({bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,foo[0]}),
     .in1(const_1_8_out),
     .out(magma_Bits_8_shl_inst1_out)
 );

--- a/tests/test_type/test_conversions.py
+++ b/tests/test_type/test_conversions.py
@@ -161,11 +161,11 @@ def test_extension_no_error(op):
 
 
 def test_bits_of_bit():
-    assert repr(m.bits(m.Bit(1), 2)) == "bits([GND, VCC])"
+    assert repr(m.bits(m.Bit(1), 2)) == "bits([VCC, GND])"
 
 
 def test_uint_of_bit():
-    assert repr(m.uint(m.Bit(1), 2)) == "bits([GND, VCC])"
+    assert repr(m.uint(m.Bit(1), 2)) == "bits([VCC, GND])"
 
 
 def test_sint_of_bit():


### PR DESCRIPTION
Magma uses last index ([-1]) for msb (see https://github.com/phanrahan/magma/blob/master/magma/conversions.py#L241)