### PR TITLE
Run inline verilog logic after uniquification

### DIFF
--- a/magma/compile.py
+++ b/magma/compile.py
@@ -45,11 +45,11 @@ def compile(basename, main, output="coreir-verilog", **kwargs):
     opts = kwargs.copy()
     compiler = _make_compiler(output, main, basename, opts)
 
-    # Steps to process inline verilog generation.
-    ProcessInlineVerilogPass(main).run()
-
     # Default behavior is to perform uniquification, but can be overriden.
     uniquification_pass(main, opts.get("uniquify", "UNIQUIFY"))
+
+    # Steps to process inline verilog generation.
+    ProcessInlineVerilogPass(main).run()
 
     # Bind after uniquification so the bind logic works on unique modules
     BindPass(main, compile).run()

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -48,7 +48,7 @@ def compile(basename, main, output="coreir-verilog", **kwargs):
     # Default behavior is to perform uniquification, but can be overriden.
     uniquification_pass(main, opts.get("uniquify", "UNIQUIFY"))
 
-    # Steps to process inline verilog generation.
+    # Steps to process inline verilog generation. Required to be run after uniquification.
     ProcessInlineVerilogPass(main).run()
 
     # Bind after uniquification so the bind logic works on unique modules

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -37,16 +37,6 @@ def _hash(definition):
     return hash(hash_struct)
 
 
-def _rename_inline_verilog(definition, new_name):
-    # Inline modules use a naming scheme based on the container
-    # name, so we update their names by replacing the name
-    # substring
-    modules = getattr(definition, "inline_verilog_modules", [])
-    for module in modules:
-        new_name = module.name.replace(definition.name, new_name)
-        type(module).rename(module, new_name)
-
-
 class UniquificationPass(DefinitionPass):
     def __init__(self, main, mode):
         super().__init__(main)
@@ -64,7 +54,6 @@ class UniquificationPass(DefinitionPass):
                 suffix = "_unq" + str(len(seen))
                 new_name = name + suffix
                 type(definition).rename(definition, new_name)
-                _rename_inline_verilog(definition, new_name)
                 for module in definition.bind_modules:
                     type(module).rename(module, module.name + suffix)
             seen[key] = [definition]
@@ -74,7 +63,6 @@ class UniquificationPass(DefinitionPass):
             elif name != seen[key][0].name:
                 new_name = seen[key][0].name
                 type(definition).rename(definition, new_name)
-                _rename_inline_verilog(definition, new_name)
                 for x, y in zip(seen[key][0].bind_modules,
                                 definition.bind_modules):
                     type(y).rename(y, x.name)


### PR DESCRIPTION
There was an issue where inline verilog modules were not being renamed properly in the uniquification flow.  This simplifies the logic (and fixes the bug) by just running the inline verilog logic after uniquification (so the generated inline verilog modules use the already uniquified name)