### PR TITLE
Fix issue with binding of inlined signal

### DIFF
--- a/tests/test_verilog/gold/RTLMonitor.sv
+++ b/tests/test_verilog/gold/RTLMonitor.sv
@@ -31,6 +31,7 @@ module RTLMonitor (
     input handshake_valid,
     input [3:0] in1,
     input [3:0] in2,
+    input [3:0] inst_input,
     input intermediate_tuple__0,
     input intermediate_tuple__1,
     input mon_temp1,
@@ -42,11 +43,6 @@ wire [3:0] _magma_inline_wire1;
 wire [3:0] _magma_inline_wire2;
 wire [3:0] arr_2d_0;
 wire [3:0] arr_2d_1;
-assign _magma_inline_wire0 = arr_2d_0[1];
-assign _magma_inline_wire1 = arr_2d_1;
-assign _magma_inline_wire2 = arr_2d_0;
-assign arr_2d_0 = in1;
-assign arr_2d_1 = in2;
 
 logic temp1, temp2;
 logic temp3;
@@ -56,7 +52,13 @@ assign temp3 = temp1 ^ temp2 & _magma_inline_wire0;
 assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
 logic [3:0] temp4 [1:0];
 assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
+always @(*) $display("%x", inst_input);
                                    
+assign _magma_inline_wire0 = arr_2d_0[1];
+assign _magma_inline_wire1 = arr_2d_1;
+assign _magma_inline_wire2 = arr_2d_0;
+assign arr_2d_0 = in1;
+assign arr_2d_1 = in2;
 endmodule
 
 
@@ -76,5 +78,6 @@ bind RTL RTLMonitor RTLMonitor_inst (
     .mon_temp1(orr_4_inst0_O),
     .mon_temp2(andr_4_inst0_O),
     .intermediate_tuple__0(orr_4_inst0_O),
-    .intermediate_tuple__1(andr_4_inst0_O)
+    .intermediate_tuple__1(andr_4_inst0_O),
+    .inst_input(magma_Bits_4_xor_inst0_out)
 );

--- a/tests/test_verilog/gold/RTLMonitor.sv
+++ b/tests/test_verilog/gold/RTLMonitor.sv
@@ -43,6 +43,11 @@ wire [3:0] _magma_inline_wire1;
 wire [3:0] _magma_inline_wire2;
 wire [3:0] arr_2d_0;
 wire [3:0] arr_2d_1;
+assign _magma_inline_wire0 = arr_2d_0[1];
+assign _magma_inline_wire1 = arr_2d_1;
+assign _magma_inline_wire2 = arr_2d_0;
+assign arr_2d_0 = in1;
+assign arr_2d_1 = in2;
 
 logic temp1, temp2;
 logic temp3;
@@ -54,11 +59,6 @@ logic [3:0] temp4 [1:0];
 assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
 always @(*) $display("%x", inst_input);
                                    
-assign _magma_inline_wire0 = arr_2d_0[1];
-assign _magma_inline_wire1 = arr_2d_1;
-assign _magma_inline_wire2 = arr_2d_0;
-assign arr_2d_0 = in1;
-assign arr_2d_1 = in2;
 endmodule
 
 

--- a/tests/test_verilog/gold/RTLMonitor_unq1.sv
+++ b/tests/test_verilog/gold/RTLMonitor_unq1.sv
@@ -43,6 +43,11 @@ wire [4:0] _magma_inline_wire1;
 wire [4:0] _magma_inline_wire2;
 wire [4:0] arr_2d_0;
 wire [4:0] arr_2d_1;
+assign _magma_inline_wire0 = arr_2d_0[1];
+assign _magma_inline_wire1 = arr_2d_1;
+assign _magma_inline_wire2 = arr_2d_0;
+assign arr_2d_0 = in1;
+assign arr_2d_1 = in2;
 
 logic temp1, temp2;
 logic temp3;
@@ -54,11 +59,6 @@ logic [4:0] temp4 [1:0];
 assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
 always @(*) $display("%x", inst_input);
                                    
-assign _magma_inline_wire0 = arr_2d_0[1];
-assign _magma_inline_wire1 = arr_2d_1;
-assign _magma_inline_wire2 = arr_2d_0;
-assign arr_2d_0 = in1;
-assign arr_2d_1 = in2;
 endmodule
 
 

--- a/tests/test_verilog/gold/RTLMonitor_unq1.sv
+++ b/tests/test_verilog/gold/RTLMonitor_unq1.sv
@@ -31,6 +31,7 @@ module RTLMonitor_unq1 (
     input handshake_valid,
     input [4:0] in1,
     input [4:0] in2,
+    input [4:0] inst_input,
     input intermediate_tuple__0,
     input intermediate_tuple__1,
     input mon_temp1,
@@ -42,11 +43,6 @@ wire [4:0] _magma_inline_wire1;
 wire [4:0] _magma_inline_wire2;
 wire [4:0] arr_2d_0;
 wire [4:0] arr_2d_1;
-assign _magma_inline_wire0 = arr_2d_0[1];
-assign _magma_inline_wire1 = arr_2d_1;
-assign _magma_inline_wire2 = arr_2d_0;
-assign arr_2d_0 = in1;
-assign arr_2d_1 = in2;
 
 logic temp1, temp2;
 logic temp3;
@@ -56,7 +52,13 @@ assign temp3 = temp1 ^ temp2 & _magma_inline_wire0;
 assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
 logic [4:0] temp4 [1:0];
 assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
+always @(*) $display("%x", inst_input);
                                    
+assign _magma_inline_wire0 = arr_2d_0[1];
+assign _magma_inline_wire1 = arr_2d_1;
+assign _magma_inline_wire2 = arr_2d_0;
+assign arr_2d_0 = in1;
+assign arr_2d_1 = in2;
 endmodule
 
 
@@ -76,5 +78,6 @@ bind RTL_unq1 RTLMonitor_unq1 RTLMonitor_unq1_inst (
     .mon_temp1(orr_5_inst0_O),
     .mon_temp2(andr_5_inst0_O),
     .intermediate_tuple__0(orr_5_inst0_O),
-    .intermediate_tuple__1(andr_5_inst0_O)
+    .intermediate_tuple__1(andr_5_inst0_O),
+    .inst_input(magma_Bits_5_xor_inst0_out)
 );

--- a/tests/test_verilog/gold/bind_test.v
+++ b/tests/test_verilog/gold/bind_test.v
@@ -4,9 +4,33 @@
             module logical_and (input I0, input I1, output O);
             assign O = I0 && I1;
             endmodule
+module coreir_term #(
+    parameter width = 1
+) (
+    input [width-1:0] in
+);
+
+endmodule
+
+module corebit_term (
+    input in
+);
+
+endmodule
+
             module andr_4 (input [3:0] I, output O);
             assign O = &(I);
             endmodule
+module SomeCircuit (
+    input [3:0] I
+);
+coreir_term #(
+    .width(4)
+) term_inst0 (
+    .in(I)
+);
+endmodule
+
 module RTL (
     input CLK,
     input handshake_arr_0_ready,
@@ -22,19 +46,35 @@ module RTL (
     output out
 );
 wire andr_4_inst0_O;
+wire [3:0] magma_Bits_4_xor_inst0_out;
 wire orr_4_inst0_O;
+SomeCircuit SomeCircuit_inst0 (
+    .I(magma_Bits_4_xor_inst0_out)
+);
 andr_4 andr_4_inst0 (
     .I(in1),
     .O(andr_4_inst0_O)
+);
+corebit_term corebit_term_inst0 (
+    .in(orr_4_inst0_O)
+);
+corebit_term corebit_term_inst1 (
+    .in(andr_4_inst0_O)
 );
 logical_and logical_and_inst0 (
     .I0(orr_4_inst0_O),
     .I1(andr_4_inst0_O),
     .O(out)
 );
+assign magma_Bits_4_xor_inst0_out = in1 ^ in2;
 orr_4 orr_4_inst0 (
     .I(in1),
     .O(orr_4_inst0_O)
+);
+coreir_term #(
+    .width(4)
+) term_inst0 (
+    .in(magma_Bits_4_xor_inst0_out)
 );
 assign handshake_arr_0_valid = handshake_arr_2_ready;
 assign handshake_arr_1_valid = handshake_arr_1_ready;

--- a/tests/test_verilog/gold/bind_uniq_test.v
+++ b/tests/test_verilog/gold/bind_uniq_test.v
@@ -48,6 +48,26 @@ endmodule
             module andr_4 (input [3:0] I, output O);
             assign O = &(I);
             endmodule
+module SomeCircuit_unq1 (
+    input [4:0] I
+);
+coreir_term #(
+    .width(5)
+) term_inst0 (
+    .in(I)
+);
+endmodule
+
+module SomeCircuit (
+    input [3:0] I
+);
+coreir_term #(
+    .width(4)
+) term_inst0 (
+    .in(I)
+);
+endmodule
+
 module RTL_unq1 (
     input CLK,
     input handshake_arr_0_ready,
@@ -64,12 +84,22 @@ module RTL_unq1 (
 );
 wire andr_5_inst0_O;
 wire coreir_wrapInClock_inst0_out;
+wire [4:0] magma_Bits_5_xor_inst0_out;
 wire orr_5_inst0_O;
+SomeCircuit_unq1 SomeCircuit_inst0 (
+    .I(magma_Bits_5_xor_inst0_out)
+);
 andr_5 andr_5_inst0 (
     .I(in1),
     .O(andr_5_inst0_O)
 );
 corebit_term corebit_term_inst0 (
+    .in(orr_5_inst0_O)
+);
+corebit_term corebit_term_inst1 (
+    .in(andr_5_inst0_O)
+);
+corebit_term corebit_term_inst2 (
     .in(coreir_wrapInClock_inst0_out)
 );
 coreir_wrap coreir_wrapInClock_inst0 (
@@ -81,6 +111,7 @@ logical_and logical_and_inst0 (
     .I1(andr_5_inst0_O),
     .O(out)
 );
+assign magma_Bits_5_xor_inst0_out = in1 ^ in2;
 orr_5 orr_5_inst0 (
     .I(in1),
     .O(orr_5_inst0_O)
@@ -88,7 +119,7 @@ orr_5 orr_5_inst0 (
 coreir_term #(
     .width(5)
 ) term_inst0 (
-    .in(in2)
+    .in(magma_Bits_5_xor_inst0_out)
 );
 assign handshake_arr_0_valid = handshake_arr_2_ready;
 assign handshake_arr_1_valid = handshake_arr_1_ready;
@@ -112,12 +143,22 @@ module RTL (
 );
 wire andr_4_inst0_O;
 wire coreir_wrapInClock_inst0_out;
+wire [3:0] magma_Bits_4_xor_inst0_out;
 wire orr_4_inst0_O;
+SomeCircuit SomeCircuit_inst0 (
+    .I(magma_Bits_4_xor_inst0_out)
+);
 andr_4 andr_4_inst0 (
     .I(in1),
     .O(andr_4_inst0_O)
 );
 corebit_term corebit_term_inst0 (
+    .in(orr_4_inst0_O)
+);
+corebit_term corebit_term_inst1 (
+    .in(andr_4_inst0_O)
+);
+corebit_term corebit_term_inst2 (
     .in(coreir_wrapInClock_inst0_out)
 );
 coreir_wrap coreir_wrapInClock_inst0 (
@@ -129,6 +170,7 @@ logical_and logical_and_inst0 (
     .I1(andr_4_inst0_O),
     .O(out)
 );
+assign magma_Bits_4_xor_inst0_out = in1 ^ in2;
 orr_4 orr_4_inst0 (
     .I(in1),
     .O(orr_4_inst0_O)
@@ -136,7 +178,7 @@ orr_4 orr_4_inst0 (
 coreir_term #(
     .width(4)
 ) term_inst0 (
-    .in(in2)
+    .in(magma_Bits_4_xor_inst0_out)
 );
 assign handshake_arr_0_valid = handshake_arr_2_ready;
 assign handshake_arr_1_valid = handshake_arr_1_ready;

--- a/tests/test_verilog/rtl.py
+++ b/tests/test_verilog/rtl.py
@@ -22,6 +22,10 @@ class RTL(m.Generator):
             ready = m.In(m.Bit)
             valid = m.Out(m.Bit)
 
+        class SomeCircuit(m.Circuit):
+            io = m.IO(I=m.In(m.Bits[width]))
+            io.I.unused()
+
         class RTL(m.Circuit):
             io = m.IO(CLK=m.In(m.Clock),
                       in1=m.In(m.Bits[width]),
@@ -39,4 +43,7 @@ class RTL(m.Generator):
             for i in range(3):
                 m.wire(io.handshake_arr[i].valid,
                        io.handshake_arr[2 - i].ready)
+
+            some_circ = SomeCircuit()
+            some_circ.I @= io.in1 ^ io.in2
         return RTL

--- a/tests/test_verilog/rtl_monitor.py
+++ b/tests/test_verilog/rtl_monitor.py
@@ -11,7 +11,8 @@ class RTLMonitor(m.MonitorGenerator):
             io = m.IO(**m.make_monitor_ports(circuit),
                       mon_temp1=m.In(m.Bit),
                       mon_temp2=m.In(m.Bit),
-                      intermediate_tuple=m.In(m.Tuple[m.Bit, m.Bit]))
+                      intermediate_tuple=m.In(m.Tuple[m.Bit, m.Bit]),
+                      inst_input=m.In(m.Bits[width]))
 
             # NOTE: Needs to have a name
             arr_2d = m.Array[2, m.Bits[width]](name="arr_2d")
@@ -26,11 +27,12 @@ assign temp3 = temp1 ^ temp2 & {arr_2d[0][1]};
 assert property (@(posedge {io.CLK}) {valid} -> {io.out} === temp1 && temp2);
 logic [{width-1}:0] temp4 [1:0];
 assign temp4 = {arr_2d};
+always @(*) $display("%x", {io.inst_input});
                                    """,
                                    valid=io.handshake.valid)
 
         circuit.bind(RTLMonitor, circuit.temp1, circuit.temp2,
-                     circuit.intermediate_tuple)
+                     circuit.intermediate_tuple, circuit.some_circ.I)
 
 
 RTL.bind(RTLMonitor)

--- a/tests/test_verilog/test_bind.py
+++ b/tests/test_verilog/test_bind.py
@@ -22,7 +22,7 @@ def test_bind():
     if version >= 4.016:
         assert not os.system('cd tests/test_verilog/build && '
                              'verilator --lint-only bind_test.v RTLMonitor.sv '
-                             '--top-module RTL')
+                             '--top-module RTL -Wno-MODDUP')
 
 
 def test_bind_multi_unique_name():


### PR DESCRIPTION
This got resolved in the new inline verilog logic, but the bind logic doesn't use that yet so we need to replicate the logic here.  Basically, we wire up bound signals to a unused module so the inlining logic doesn't remove signals referred to in the bind statement.

This is a temporary hotfix for an existing issue but will be resolved once we represent the bind explicitly in the graph (we can then prevent inlining when we see a connection from a value to a bind node)