### PR TITLE
optimize get clock logic

### DIFF
--- a/magma/backend/coreir_utils.py
+++ b/magma/backend/coreir_utils.py
@@ -3,7 +3,7 @@ import json
 from hwtypes import BitVector
 from ..array import Array
 from ..bit import Digital
-from ..clock import Clock, AsyncReset, AsyncResetN
+from ..clock import Clock, AsyncReset, AsyncResetN, ClockTypes
 from ..ref import ArrayRef, DefnRef, TupleRef, InstRef, NamedRef, PortViewRef
 from ..tuple import Tuple
 from ..protocol_type import MagmaProtocol
@@ -137,7 +137,7 @@ def make_cparams(context, params):
 
 
 def is_clock_or_nested_clock(p):
-    if issubclass(p, Clock):
+    if issubclass(p, ClockTypes):
         return True
     if issubclass(p, Array):
         return is_clock_or_nested_clock(p.T)


### PR DESCRIPTION
This changes the coreir backend logic to only do the wire default clock logic when a signal is not driven.  This should improve performance in the case where the clocks are already wired by the user (don't need to iterate over every instance interface ports up front, only do it on demand when we encounter an undriven signal).  A further improvement might be to only lookup clock types on the definition on demand and memoize (aka a lazy version of the self.clocks dict), but I think this should help in the main case which is large interfaces with non-clock ports and manually wired clocks.

