### PR TITLE
Replace 'if not True' with 'pass'

### DIFF
--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -15,11 +15,19 @@ from ..bitutils import clog2
 class RemoveIfTrues(ast.NodeTransformer):
     """
     Remove `if True:` nodes by replacing them with their body
+    Remove `if not True:` nodes by replacing them with `pass`
     """
     def visit_If(self, node):
         node = self.generic_visit(node)
         if isinstance(node.test, ast.NameConstant) and node.test.value is True:
             return node.body
+        elif (
+            isinstance(node.test, ast.UnaryOp)
+            and isinstance(node.test.op, ast.Not)
+            and isinstance(node.test.operand, ast.NameConstant)
+            and node.test.operand.value is True
+        ):
+            return ast.Pass()
         return node
 
 


### PR DESCRIPTION
I encountered an error on coroutine code with Python 3.8.

    > E       TypeError: unsupported operand type(s) for &: 'bool' and 'Bit[Out]'

looks like it is because the bit was compared with `not True`

    >       O0 = phi([O0, __magma_ssa_return_value_5[0]], (not True) & ~(
            self_yield_state_I_0 == 0) & ~(self_yield_state_I_0 == 1) & (
            self_i_I_3 != 7))

which was generated by coroutine like this

    if self.i != 7:
        if not True:
            self.tx = m.bit(1)
            self.yield_state = m.bits(0, 2)
            return self.tx.prev()

The cause is `if not True`, the code block would be never used. So we can replace it with `pass` safely.

    if self.i != 7:
        pass

Tested with
- pytest tests/test_syntax/test_coroutine/test_uart.py
- pytest tests/test_syntax/test_coroutine/test_sdram.py