### PR TITLE
Avoid repr call in backend

### DIFF
--- a/magma/backend/coreir_transformer.py
+++ b/magma/backend/coreir_transformer.py
@@ -100,7 +100,7 @@ class InstanceTransformer(LeafTransformer):
 
     def run_self_impl(self):
         _logger.debug(
-          f"Compiling instance {(self.inst.name, type(self.inst).name)}"
+            f"Compiling instance {(self.inst.name, type(self.inst).name)}"
         )
         defn = type(self.inst)
         lib = self.backend.libs[self.inst.coreir_lib]

--- a/magma/backend/coreir_transformer.py
+++ b/magma/backend/coreir_transformer.py
@@ -99,7 +99,9 @@ class InstanceTransformer(LeafTransformer):
         self.coreir_inst_gen = self.run_self_impl()
 
     def run_self_impl(self):
-        _logger.debug(f"Compiling instance {(self.inst.name, type(self.inst).name)}")
+        _logger.debug(
+          f"Compiling instance {(self.inst.name, type(self.inst).name)}"
+        )
         defn = type(self.inst)
         lib = self.backend.libs[self.inst.coreir_lib]
         if self.inst.coreir_genargs is None:

--- a/magma/backend/coreir_transformer.py
+++ b/magma/backend/coreir_transformer.py
@@ -99,7 +99,7 @@ class InstanceTransformer(LeafTransformer):
         self.coreir_inst_gen = self.run_self_impl()
 
     def run_self_impl(self):
-        _logger.debug(f"Compiling instance {(self.inst.name, type(self.inst))}")
+        _logger.debug(f"Compiling instance {(self.inst.name, type(self.inst).name)}")
         defn = type(self.inst)
         lib = self.backend.libs[self.inst.coreir_lib]
         if self.inst.coreir_genargs is None:


### PR DESCRIPTION
When we generate the logging debug string, we're actually invoking repr on the type of the circuit (possibly many times for multiple instances).  For now, I think it's okay if we simply just log the name of the instance type.  