### PR TITLE
Use is instead of == in equality check

### DIFF
--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -441,7 +441,7 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
             return not rhs.is_bound
 
         for k, v in cls.field_dict.items():
-            if getattr(rhs, k) != v:
+            if getattr(rhs, k) is not v:
                 return False
 
         return True


### PR DESCRIPTION
We are cacheing types so we can and should be using `is` instead of __eq__ (this is for comparing type equality)