### PR TITLE
Prune infeasible paths

### DIFF
--- a/tests/test_syntax/test_coroutine/test_uart.py
+++ b/tests/test_syntax/test_coroutine/test_uart.py
@@ -35,7 +35,7 @@ def test_uart():
                         if self.i == 7:
                             break
 
-    m.compile("build/UART", UART)
+    m.compile("build/UART", UART, inline=True)
 
     tester = fault.Tester(UART, UART.CLK)
     tester.poke(UART.CLK, 0)


### PR DESCRIPTION
Related to https://github.com/phanrahan/magma/pull/710

This adds a primitive logic in the coroutine compiler to prune infeasible paths.  In this case, it merely searches the condition list for the inverse of the condition to be added (e.g. `if tms` and `if ~tms`).  Eventually we'll want to generalize this to a more sophisticated algorithm, e.g. using SMT to check for a possible solution to the current set of conditions.