### PR TITLE
Add Memory(T) (RAM) primitive

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -97,4 +97,4 @@ from .log import info, debug, warning, error
 from .syntax.sequential2 import sequential2
 from .syntax.combinational2 import combinational2
 
-from magma.primitives import LUT, Mux, mux, Register, slice, reduce
+from magma.primitives import LUT, Mux, mux, Register, slice, reduce, Memory

--- a/magma/primitives/__init__.py
+++ b/magma/primitives/__init__.py
@@ -1,4 +1,5 @@
 from magma.primitives.lut import LUT
+from magma.primitives.memory import Memory
 from magma.primitives.mux import Mux, mux
 from magma.primitives.register import Register
 from magma.primitives.reduce import reduce

--- a/magma/primitives/memory.py
+++ b/magma/primitives/memory.py
@@ -1,0 +1,105 @@
+from hwtypes import BitVector
+
+from magma.bit import Bit
+from magma.bits import Bits
+from magma.bitutils import clog2
+from magma.clock import Clock, Enable
+from magma.clock_io import ClockIO
+from magma.conversions import from_bits, as_bits
+from magma.generator import Generator2
+from magma.interface import IO
+from magma.primitives.register import Register
+from magma.t import In, Out, Kind
+
+
+class CoreIRMemory(Generator2):
+    def __init__(self, depth, width, init=None):
+        self.name = f"coreir_mem{depth}x{width}"
+        addr_width = clog2(depth)
+        self.io = IO(
+            raddr=In(Bits[addr_width]),
+            rdata=Out(Bits[width]),
+            waddr=In(Bits[addr_width]),
+            wdata=In(Bits[width]),
+            clk=In(Clock),
+            wen=In(Enable)
+        )
+        self.verilog_name = "coreir_mem"
+        self.coreir_name = "mem"
+        self.coreir_lib = "coreir"
+        self.coreir_genargs = {"width": width, "depth": depth,
+                               "has_init": init is not None}
+        self.coreir_configargs = {}
+        if init is not None:
+            raise NotImplementedError("CoreIR's memory primitive does not "
+                                      "compile init arg to verilog yet")
+            # self.coreir_configargs["init"] = <convert to json arg>
+
+        def _simulate(self, value_store, state_store):
+            cur_clk = value_store.get_value(self.clk)
+
+            if not state_store:
+                state_store['mem'] = [
+                    BitVector[width](0) for _ in range(depth)
+                ]
+                state_store['prev_clk'] = cur_clk
+
+            prev_clk = state_store['prev_clk']
+            clk_edge = cur_clk and not prev_clk
+            rdata = value_store.get_value(self.rdata)
+
+            if clk_edge:
+                index = int(
+                    BitVector[addr_width](value_store.get_value(self.raddr))
+                )
+                rdata = state_store['mem'][index].as_bool_list()
+
+            if clk_edge:
+                if value_store.get_value(self.wen):
+                    index = int(
+                        BitVector[addr_width](value_store.get_value(self.waddr))
+                    )
+                    state_store['mem'][index] = BitVector[width](
+                        value_store.get_value(self.wdata)
+                    )
+
+            state_store['prev_clk'] = cur_clk
+            value_store.set_value(self.rdata, rdata)
+
+        self.simulate = _simulate
+
+
+class Memory(Generator2):
+    def __init__(self, height, T: Kind,
+                 read_latency: int = 0, read_only: bool = False):
+        if read_latency < 0:
+            raise ValueError("read_latency cannot be negative")
+        addr_width = clog2(height)
+        data_width = T.flat_length()
+        # For ROM, we use coreir's generic mem and tie off the write signals
+        self.io = IO(
+            RADDR=In(Bits[addr_width]),
+            RDATA=Out(T),
+        ) + ClockIO()
+        if not read_only:
+            self.io += IO(
+                WADDR=In(Bits[addr_width]),
+                WDATA=In(T),
+                WE=In(Enable)
+            )
+            waddr = self.io.WADDR
+            wdata = as_bits(self.io.WDATA)
+            wen = self.io.WE
+        else:
+            waddr = Bits[addr_width](0)
+            wdata = Bits[data_width](0)
+            wen = Bit(0)
+        coreir_mem = CoreIRMemory(height, data_width)()
+        coreir_mem.waddr @= waddr
+        coreir_mem.wdata @= wdata
+        coreir_mem.wen @= wen
+        coreir_mem.raddr @= self.io.RADDR
+        rdata = from_bits(T, coreir_mem.rdata)
+        for _ in range(read_latency):
+            rdata = Register(T)()(rdata)
+        self.io.RDATA @= rdata

--- a/tests/test_primitives/gold/test_memory_arr.v
+++ b/tests/test_primitives/gold/test_memory_arr.v
@@ -1,0 +1,92 @@
+module coreir_mem #(
+    parameter has_init = 1'b0,
+    parameter depth = 1,
+    parameter width = 1
+) (
+    input clk,
+    input [width-1:0] wdata,
+    input [$clog2(depth)-1:0] waddr,
+    input wen,
+    output [width-1:0] rdata,
+    input [$clog2(depth)-1:0] raddr
+);
+  reg [width-1:0] data[depth-1:0];
+  always @(posedge clk) begin
+    if (wen) begin
+      data[waddr] <= wdata;
+    end
+  end
+  assign rdata = data[raddr];
+endmodule
+
+module Memory (
+    input CLK,
+    input [1:0] RADDR,
+    output RDATA_0_X,
+    output [4:0] RDATA_0_Y,
+    output RDATA_1_X,
+    output [4:0] RDATA_1_Y,
+    input [1:0] WADDR,
+    input WDATA_0_X,
+    input [4:0] WDATA_0_Y,
+    input WDATA_1_X,
+    input [4:0] WDATA_1_Y,
+    input WE
+);
+wire [11:0] coreir_mem4x12_inst0_rdata;
+coreir_mem #(
+    .depth(4),
+    .has_init(1'b0),
+    .width(12)
+) coreir_mem4x12_inst0 (
+    .clk(CLK),
+    .wdata({WDATA_1_Y[4],WDATA_1_Y[3],WDATA_1_Y[2],WDATA_1_Y[1],WDATA_1_Y[0],WDATA_1_X,WDATA_0_Y[4],WDATA_0_Y[3],WDATA_0_Y[2],WDATA_0_Y[1],WDATA_0_Y[0],WDATA_0_X}),
+    .waddr(WADDR),
+    .wen(WE),
+    .rdata(coreir_mem4x12_inst0_rdata),
+    .raddr(RADDR)
+);
+assign RDATA_0_X = coreir_mem4x12_inst0_rdata[0];
+assign RDATA_0_Y = {coreir_mem4x12_inst0_rdata[5],coreir_mem4x12_inst0_rdata[4],coreir_mem4x12_inst0_rdata[3],coreir_mem4x12_inst0_rdata[2],coreir_mem4x12_inst0_rdata[1]};
+assign RDATA_1_X = coreir_mem4x12_inst0_rdata[6];
+assign RDATA_1_Y = {coreir_mem4x12_inst0_rdata[11],coreir_mem4x12_inst0_rdata[10],coreir_mem4x12_inst0_rdata[9],coreir_mem4x12_inst0_rdata[8],coreir_mem4x12_inst0_rdata[7]};
+endmodule
+
+module test_memory_arr (
+    input clk,
+    input [1:0] raddr,
+    output rdata_0_X,
+    output [4:0] rdata_0_Y,
+    output rdata_1_X,
+    output [4:0] rdata_1_Y,
+    input [1:0] waddr,
+    input wdata_0_X,
+    input [4:0] wdata_0_Y,
+    input wdata_1_X,
+    input [4:0] wdata_1_Y,
+    input wen
+);
+wire Memory_inst0_RDATA_0_X;
+wire [4:0] Memory_inst0_RDATA_0_Y;
+wire Memory_inst0_RDATA_1_X;
+wire [4:0] Memory_inst0_RDATA_1_Y;
+Memory Memory_inst0 (
+    .CLK(clk),
+    .RADDR(raddr),
+    .RDATA_0_X(Memory_inst0_RDATA_0_X),
+    .RDATA_0_Y(Memory_inst0_RDATA_0_Y),
+    .RDATA_1_X(Memory_inst0_RDATA_1_X),
+    .RDATA_1_Y(Memory_inst0_RDATA_1_Y),
+    .WADDR(waddr),
+    .WDATA_0_X(wdata_0_X),
+    .WDATA_0_Y(wdata_0_Y),
+    .WDATA_1_X(wdata_1_X),
+    .WDATA_1_Y(wdata_1_Y),
+    .WE(wen)
+);
+assign rdata_0_X = Memory_inst0_RDATA_0_X;
+assign rdata_0_Y = Memory_inst0_RDATA_0_Y;
+assign rdata_1_X = Memory_inst0_RDATA_1_X;
+assign rdata_1_Y = Memory_inst0_RDATA_1_Y;
+endmodule
+

--- a/tests/test_primitives/gold/test_memory_basic.v
+++ b/tests/test_primitives/gold/test_memory_basic.v
@@ -1,0 +1,65 @@
+module coreir_mem #(
+    parameter has_init = 1'b0,
+    parameter depth = 1,
+    parameter width = 1
+) (
+    input clk,
+    input [width-1:0] wdata,
+    input [$clog2(depth)-1:0] waddr,
+    input wen,
+    output [width-1:0] rdata,
+    input [$clog2(depth)-1:0] raddr
+);
+  reg [width-1:0] data[depth-1:0];
+  always @(posedge clk) begin
+    if (wen) begin
+      data[waddr] <= wdata;
+    end
+  end
+  assign rdata = data[raddr];
+endmodule
+
+module Memory (
+    input [1:0] RADDR,
+    output [4:0] RDATA,
+    input CLK,
+    input [1:0] WADDR,
+    input [4:0] WDATA,
+    input WE
+);
+wire [4:0] coreir_mem4x5_inst0_rdata;
+coreir_mem #(
+    .depth(4),
+    .has_init(1'b0),
+    .width(5)
+) coreir_mem4x5_inst0 (
+    .clk(CLK),
+    .wdata(WDATA),
+    .waddr(WADDR),
+    .wen(WE),
+    .rdata(coreir_mem4x5_inst0_rdata),
+    .raddr(RADDR)
+);
+assign RDATA = coreir_mem4x5_inst0_rdata;
+endmodule
+
+module test_memory_basic (
+    input [1:0] raddr,
+    output [4:0] rdata,
+    input [1:0] waddr,
+    input [4:0] wdata,
+    input clk,
+    input wen
+);
+wire [4:0] Memory_inst0_RDATA;
+Memory Memory_inst0 (
+    .RADDR(raddr),
+    .RDATA(Memory_inst0_RDATA),
+    .CLK(clk),
+    .WADDR(waddr),
+    .WDATA(wdata),
+    .WE(wen)
+);
+assign rdata = Memory_inst0_RDATA;
+endmodule
+

--- a/tests/test_primitives/gold/test_memory_product.v
+++ b/tests/test_primitives/gold/test_memory_product.v
@@ -1,0 +1,74 @@
+module coreir_mem #(
+    parameter has_init = 1'b0,
+    parameter depth = 1,
+    parameter width = 1
+) (
+    input clk,
+    input [width-1:0] wdata,
+    input [$clog2(depth)-1:0] waddr,
+    input wen,
+    output [width-1:0] rdata,
+    input [$clog2(depth)-1:0] raddr
+);
+  reg [width-1:0] data[depth-1:0];
+  always @(posedge clk) begin
+    if (wen) begin
+      data[waddr] <= wdata;
+    end
+  end
+  assign rdata = data[raddr];
+endmodule
+
+module Memory (
+    input CLK,
+    input [1:0] RADDR,
+    output RDATA_X,
+    output [4:0] RDATA_Y,
+    input [1:0] WADDR,
+    input WDATA_X,
+    input [4:0] WDATA_Y,
+    input WE
+);
+wire [5:0] coreir_mem4x6_inst0_rdata;
+coreir_mem #(
+    .depth(4),
+    .has_init(1'b0),
+    .width(6)
+) coreir_mem4x6_inst0 (
+    .clk(CLK),
+    .wdata({WDATA_Y[4],WDATA_Y[3],WDATA_Y[2],WDATA_Y[1],WDATA_Y[0],WDATA_X}),
+    .waddr(WADDR),
+    .wen(WE),
+    .rdata(coreir_mem4x6_inst0_rdata),
+    .raddr(RADDR)
+);
+assign RDATA_X = coreir_mem4x6_inst0_rdata[0];
+assign RDATA_Y = {coreir_mem4x6_inst0_rdata[5],coreir_mem4x6_inst0_rdata[4],coreir_mem4x6_inst0_rdata[3],coreir_mem4x6_inst0_rdata[2],coreir_mem4x6_inst0_rdata[1]};
+endmodule
+
+module test_memory_product (
+    input clk,
+    input [1:0] raddr,
+    output rdata_X,
+    output [4:0] rdata_Y,
+    input [1:0] waddr,
+    input wdata_X,
+    input [4:0] wdata_Y,
+    input wen
+);
+wire Memory_inst0_RDATA_X;
+wire [4:0] Memory_inst0_RDATA_Y;
+Memory Memory_inst0 (
+    .CLK(clk),
+    .RADDR(raddr),
+    .RDATA_X(Memory_inst0_RDATA_X),
+    .RDATA_Y(Memory_inst0_RDATA_Y),
+    .WADDR(waddr),
+    .WDATA_X(wdata_X),
+    .WDATA_Y(wdata_Y),
+    .WE(wen)
+);
+assign rdata_X = Memory_inst0_RDATA_X;
+assign rdata_Y = Memory_inst0_RDATA_Y;
+endmodule
+

--- a/tests/test_primitives/gold/test_memory_read_latency.v
+++ b/tests/test_primitives/gold/test_memory_read_latency.v
@@ -1,0 +1,113 @@
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module coreir_mem #(
+    parameter has_init = 1'b0,
+    parameter depth = 1,
+    parameter width = 1
+) (
+    input clk,
+    input [width-1:0] wdata,
+    input [$clog2(depth)-1:0] waddr,
+    input wen,
+    output [width-1:0] rdata,
+    input [$clog2(depth)-1:0] raddr
+);
+  reg [width-1:0] data[depth-1:0];
+  always @(posedge clk) begin
+    if (wen) begin
+      data[waddr] <= wdata;
+    end
+  end
+  assign rdata = data[raddr];
+endmodule
+
+module Register (
+    input [4:0] I,
+    output [4:0] O,
+    input CLK
+);
+wire [4:0] reg_P_inst0_out;
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(5'h00),
+    .width(5)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in(I),
+    .out(reg_P_inst0_out)
+);
+assign O = reg_P_inst0_out;
+endmodule
+
+module Memory (
+    input [1:0] RADDR,
+    output [4:0] RDATA,
+    input CLK,
+    input [1:0] WADDR,
+    input [4:0] WDATA,
+    input WE
+);
+wire [4:0] Register_inst0_O;
+wire [4:0] Register_inst1_O;
+wire [4:0] coreir_mem4x5_inst0_rdata;
+Register Register_inst0 (
+    .I(coreir_mem4x5_inst0_rdata),
+    .O(Register_inst0_O),
+    .CLK(CLK)
+);
+Register Register_inst1 (
+    .I(Register_inst0_O),
+    .O(Register_inst1_O),
+    .CLK(CLK)
+);
+coreir_mem #(
+    .depth(4),
+    .has_init(1'b0),
+    .width(5)
+) coreir_mem4x5_inst0 (
+    .clk(CLK),
+    .wdata(WDATA),
+    .waddr(WADDR),
+    .wen(WE),
+    .rdata(coreir_mem4x5_inst0_rdata),
+    .raddr(RADDR)
+);
+assign RDATA = Register_inst1_O;
+endmodule
+
+module test_memory_read_latency (
+    input [1:0] raddr,
+    output [4:0] rdata,
+    input [1:0] waddr,
+    input [4:0] wdata,
+    input clk,
+    input wen
+);
+wire [4:0] Memory_inst0_RDATA;
+Memory Memory_inst0 (
+    .RADDR(raddr),
+    .RDATA(Memory_inst0_RDATA),
+    .CLK(clk),
+    .WADDR(waddr),
+    .WDATA(wdata),
+    .WE(wen)
+);
+assign rdata = Memory_inst0_RDATA;
+endmodule
+

--- a/tests/test_primitives/test_memory.py
+++ b/tests/test_primitives/test_memory.py
@@ -1,0 +1,178 @@
+import os
+
+import fault
+from hwtypes import BitVector, Bit
+
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_memory_basic():
+    class test_memory_basic(m.Circuit):
+        io = m.IO(
+            raddr=m.In(m.Bits[2]),
+            rdata=m.Out(m.Bits[5]),
+            waddr=m.In(m.Bits[2]),
+            wdata=m.In(m.Bits[5]),
+            clk=m.In(m.Clock),
+            wen=m.In(m.Enable)
+
+        )
+        Mem4x5 = m.Memory(4, m.Bits[5])()
+        Mem4x5.RADDR @= io.raddr
+        io.rdata @= Mem4x5.RDATA
+        Mem4x5.WADDR @= io.waddr
+        Mem4x5.WDATA @= io.wdata
+
+    m.compile("build/test_memory_basic", test_memory_basic)
+
+    assert check_files_equal(__file__, f"build/test_memory_basic.v",
+                             f"gold/test_memory_basic.v")
+    tester = fault.SynchronousTester(test_memory_basic, test_memory_basic.clk)
+    expected = []
+    for i in range(4):
+        tester.circuit.waddr = i
+        tester.circuit.wdata = wdata = BitVector.random(5)
+        expected.append(wdata)
+        tester.circuit.wen = 1
+        tester.advance_cycle()
+    tester.circuit.wen = 0
+    for i in range(4):
+        tester.circuit.raddr = i
+        tester.advance_cycle()
+        tester.circuit.rdata.expect(expected[i])
+    tester.compile_and_run("verilator", skip_compile=True,
+                           directory=os.path.join(os.path.dirname(__file__),
+                                                  "build"))
+
+
+def test_memory_product():
+    class T(m.Product):
+        X = m.Bit
+        Y = m.Bits[5]
+
+    class test_memory_product(m.Circuit):
+        io = m.IO(
+            raddr=m.In(m.Bits[2]),
+            rdata=m.Out(T),
+            waddr=m.In(m.Bits[2]),
+            wdata=m.In(T),
+            clk=m.In(m.Clock),
+            wen=m.In(m.Enable)
+
+        )
+        Mem4xT = m.Memory(4, T)()
+        Mem4xT.RADDR @= io.raddr
+        io.rdata @= Mem4xT.RDATA
+        Mem4xT.WADDR @= io.waddr
+        Mem4xT.WDATA @= io.wdata
+
+    m.compile("build/test_memory_product", test_memory_product)
+
+    assert check_files_equal(__file__, f"build/test_memory_product.v",
+                             f"gold/test_memory_product.v")
+    tester = fault.SynchronousTester(test_memory_product,
+                                     test_memory_product.clk)
+    expected = []
+    for i in range(4):
+        tester.circuit.waddr = i
+        tester.circuit.wdata = wdata = (BitVector.random(1),
+                                        BitVector.random(5))
+        expected.append(wdata)
+        tester.circuit.wen = 1
+        tester.advance_cycle()
+    tester.circuit.WEN = 0
+    for i in range(4):
+        tester.circuit.raddr = i
+        tester.advance_cycle()
+        tester.circuit.rdata.expect(expected[i])
+    tester.compile_and_run("verilator", skip_compile=True,
+                           directory=os.path.join(os.path.dirname(__file__),
+                                                  "build"))
+
+
+def test_memory_arr():
+    class T(m.Product):
+        X = m.Bit
+        Y = m.Bits[5]
+
+    class test_memory_arr(m.Circuit):
+        io = m.IO(
+            raddr=m.In(m.Bits[2]),
+            rdata=m.Out(m.Array[2, T]),
+            waddr=m.In(m.Bits[2]),
+            wdata=m.In(m.Array[2, T]),
+            clk=m.In(m.Clock),
+            wen=m.In(m.Enable)
+
+        )
+        Mem4xT = m.Memory(4, m.Array[2, T])()
+        Mem4xT.RADDR @= io.raddr
+        io.rdata @= Mem4xT.RDATA
+        Mem4xT.WADDR @= io.waddr
+        Mem4xT.WDATA @= io.wdata
+
+    m.compile("build/test_memory_arr", test_memory_arr)
+
+    assert check_files_equal(__file__, f"build/test_memory_arr.v",
+                             f"gold/test_memory_arr.v")
+    tester = fault.SynchronousTester(test_memory_arr,
+                                     test_memory_arr.clk)
+    expected = []
+    for i in range(4):
+        tester.circuit.waddr = i
+        tester.circuit.wdata = wdata = [
+            (BitVector.random(1), BitVector.random(5)) for _ in range(2)
+        ]
+        expected.append(wdata)
+        tester.circuit.wen = 1
+        tester.advance_cycle()
+    tester.circuit.WEN = 0
+    for i in range(4):
+        tester.circuit.raddr = i
+        tester.advance_cycle()
+        tester.circuit.rdata.expect(expected[i])
+    tester.compile_and_run("verilator", skip_compile=True,
+                           directory=os.path.join(os.path.dirname(__file__),
+                                                  "build"))
+
+
+def test_memory_read_latency():
+    class test_memory_read_latency(m.Circuit):
+        io = m.IO(
+            raddr=m.In(m.Bits[2]),
+            rdata=m.Out(m.Bits[5]),
+            waddr=m.In(m.Bits[2]),
+            wdata=m.In(m.Bits[5]),
+            clk=m.In(m.Clock),
+            wen=m.In(m.Enable)
+
+        )
+        Mem4x5 = m.Memory(4, m.Bits[5], read_latency=2)()
+        Mem4x5.RADDR @= io.raddr
+        io.rdata @= Mem4x5.RDATA
+        Mem4x5.WADDR @= io.waddr
+        Mem4x5.WDATA @= io.wdata
+
+    m.compile("build/test_memory_read_latency", test_memory_read_latency)
+
+    assert check_files_equal(__file__, f"build/test_memory_read_latency.v",
+                             f"gold/test_memory_read_latency.v")
+    tester = fault.SynchronousTester(test_memory_read_latency,
+                                     test_memory_read_latency.clk)
+    expected = []
+    for i in range(4):
+        tester.circuit.waddr = i
+        tester.circuit.wdata = wdata = BitVector.random(5)
+        expected.append(wdata)
+        tester.circuit.wen = 1
+        tester.advance_cycle()
+    tester.circuit.wen = 0
+    expected = [expected[0]] + expected
+    for i in range(5):
+        tester.circuit.raddr = i
+        tester.advance_cycle()
+        tester.circuit.rdata.expect(expected[i])
+    tester.compile_and_run("verilator", skip_compile=True,
+                           directory=os.path.join(os.path.dirname(__file__),
+                                                  "build"))


### PR DESCRIPTION
Adds a generic memory primitive based on the coreir.mem

The init (and therefor ROMs) parameter is not supported by coreir yet (the verilog codegen for coreir.mem will ignore the init parameter).  Will follow up with a second PR for the ROM variant after adding the feature to CoreIR.  For now we will throw an exception if readonly is set to True.