### PR TITLE
Add bind file listings logic

### DIFF
--- a/magma/backend/coreir_compiler.py
+++ b/magma/backend/coreir_compiler.py
@@ -91,11 +91,17 @@ class CoreIRCompiler(Compiler):
     def _compile_verilog_epilogue(self):
         self._process_header_footer()
 
+        bind_files = []
         # TODO(leonardt): We need fresh bind_files for each compile call.
         for name, file in self.backend.sv_bind_files.items():
+            bind_files.append(f"{name}.sv")
             filename = os.path.join(os.path.dirname(self.basename), name)
             with open(f"{filename}.sv", "w") as f:
                 f.write(file)
+
+        bind_listings_file = self.basename + "_bind_files.list"
+        with open(bind_listings_file, "w") as f:
+            f.write("\n".join(bind_files))
 
         if self.opts.get("sv", False):
             if self.opts.get("split", False):

--- a/tests/test_verilog/test_bind.py
+++ b/tests/test_verilog/test_bind.py
@@ -46,6 +46,13 @@ def test_bind_multi_unique_name():
                                        f"build/RTLMonitor_unq1.sv",
                                        f"gold/RTLMonitor_unq1.sv")
 
+    listings_file = "tests/test_verilog/build/bind_uniq_test_bind_files.list"
+    with open(listings_file, "r") as f:
+        assert f.read() == """\
+RTLMonitor.sv
+RTLMonitor_unq1.sv\
+"""
+
     result = run('verilator --version', shell=True, capture_output=True)
     version = float(result.stdout.split()[1])
     if version >= 4.016:


### PR DESCRIPTION
Adds a step to emit a listings file containing the bind modules generated during the compilation process.  Useful for capturing bind modules for uniquified modules (hard to predict what the generated bind file names will be or how many there will be).  This way the user can just collect all the bind modules generated and include them in their downstream tool flow.