### PR TITLE
Allow concat to use Bit

### DIFF
--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -192,7 +192,7 @@ def concat(*arrays):
         if isinstance(a, hwtypes.BitVector):
             ts.extend(a.bits())
         elif isinstance(a, Bit):
-            ts.extend(bits(a).ts)
+            ts.extend([a])
         else:
             ts.extend(a.ts)
     return array(ts)

--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -191,6 +191,8 @@ def concat(*arrays):
     for a in arrays:
         if isinstance(a, hwtypes.BitVector):
             ts.extend(a.bits())
+        elif isinstance(a, Bit):
+            ts.extend(bits(a).ts)
         else:
             ts.extend(a.ts)
     return array(ts)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,10 @@
+import magma as m
+
+
+def test_concat():
+    b0 = m.bit(1)
+    b1 = m.bits(1, 1)
+    bits0 = m.concat(b0, b1)
+    bits1 = m.concat(m.bits(b0), b1)
+    assert bits0 == bits1
+    assert type(bits0) == m.Out(m.Bits[2])


### PR DESCRIPTION
`concat` doesn't allow to use `Bit`, it requires `bits` cast.

    bits0 = m.concat(m.bit(0), m.bit(1))
    
            def concat(*arrays):
    >               ts.extend(a.ts)
    E               AttributeError: 'Bit' object has no attribute 'ts'

    bits0 = m.concat(m.bits(m.bit(0)), m.bits(m.bit(1)))

whereas `repeat` supports `Bit`, also Verilog concatenate `{}` supports scalar.