### PR TITLE
Add option to add user-level namespace for coreir compilation

### DIFF
--- a/magma/backend/coreir_.py
+++ b/magma/backend/coreir_.py
@@ -46,9 +46,9 @@ _context_to_modules = {}
 
 class CoreIRBackend:
     def __init__(self, context=None):
-        self.__init(context)
+        self._init(context)
 
-    def __init(self, context):
+    def _init(self, context):
         singleton = CoreIRContextSingleton().get_instance()
         if context is None:
             context = singleton
@@ -63,11 +63,12 @@ class CoreIRBackend:
         self.sv_bind_files = {}
 
     def reset(self):
-        self.__init(context=None)
+        self._init(context=None)
 
-    def compile(self, defn_or_decl):
+    def compile(self, defn_or_decl, opts=None):
         _logger.debug(f"Compiling: {defn_or_decl.name}")
-        transformer = DefnOrDeclTransformer(self, defn_or_decl)
+        opts = opts if opts is not None else {}
+        transformer = DefnOrDeclTransformer(self, opts, defn_or_decl)
         transformer.run()
         self.modules[defn_or_decl.name] = transformer.coreir_module
         return self.modules

--- a/magma/backend/coreir_compiler.py
+++ b/magma/backend/coreir_compiler.py
@@ -33,6 +33,14 @@ def _make_verilog_cmd(deps, basename, opts):
     return cmd
 
 
+def _make_opts(backend, opts):
+    out = {}
+    user_namespace = opts.get("user_namespace", None)
+    if user_namespace is not None:
+        out["user_namespace"] = backend.context.new_namespace(user_namespace)
+    return out
+
+
 class CoreIRCompiler(Compiler):
     def __init__(self, main, basename, opts):
         super().__init__(main, basename, opts)
@@ -47,7 +55,8 @@ class CoreIRCompiler(Compiler):
         InsertCoreIRWires(self.main).run()
         InsertWrapCasts(self.main).run()
         backend = self.backend
-        backend.compile(self.main)
+        opts = _make_opts(backend, self.opts)
+        backend.compile(self.main, opts)
         backend.context.run_passes(self.passes, self.namespaces)
         output_json = (self.opts.get("output_intermediate", False) or
                        not self.opts.get("output_verilog", False) or

--- a/tests/test_compile/gold/test_user_namespace_basic.json
+++ b/tests/test_compile/gold/test_user_namespace_basic.json
@@ -1,0 +1,32 @@
+{"top":"my_namespace.Foo",
+"namespaces":{
+  "my_namespace":{
+    "modules":{
+      "Bar":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"]
+        ]],
+        "connections":[
+          ["self.O","self.I"]
+        ]
+      },
+      "Foo":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "Bar_inst0":{
+            "modref":"my_namespace.Bar"
+          }
+        },
+        "connections":[
+          ["self.I","Bar_inst0.I"],
+          ["self.O","Bar_inst0.O"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_compile/gold/test_user_namespace_passes.json
+++ b/tests/test_compile/gold/test_user_namespace_passes.json
@@ -1,0 +1,39 @@
+{"top":"my_namespace.Foo",
+"namespaces":{
+  "my_namespace":{
+    "modules":{
+      "Bar":{
+        "type":["Record",[
+          ["I_x","BitIn"],
+          ["I_y","BitIn"],
+          ["O_x","Bit"],
+          ["O_y","Bit"]
+        ]],
+        "connections":[
+          ["self.O_x","self.I_x"],
+          ["self.O_y","self.I_y"]
+        ]
+      },
+      "Foo":{
+        "type":["Record",[
+          ["I_x","BitIn"],
+          ["I_y","BitIn"],
+          ["O_x","Bit"],
+          ["O_y","Bit"]
+        ]],
+        "instances":{
+          "Bar_inst0":{
+            "modref":"my_namespace.Bar"
+          }
+        },
+        "connections":[
+          ["self.I_x","Bar_inst0.I_x"],
+          ["self.I_y","Bar_inst0.I_y"],
+          ["self.O_x","Bar_inst0.O_x"],
+          ["self.O_y","Bar_inst0.O_y"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_compile/gold/test_user_namespace_verilog_prefix.v
+++ b/tests/test_compile/gold/test_user_namespace_verilog_prefix.v
@@ -1,0 +1,28 @@
+module my_namespace_Bar (
+    input I_x,
+    input I_y,
+    output O_x,
+    output O_y
+);
+assign O_x = I_x;
+assign O_y = I_y;
+endmodule
+
+module my_namespace_Foo (
+    input I_x,
+    input I_y,
+    output O_x,
+    output O_y
+);
+wire Bar_inst0_O_x;
+wire Bar_inst0_O_y;
+Bar Bar_inst0 (
+    .I_x(I_x),
+    .I_y(I_y),
+    .O_x(Bar_inst0_O_x),
+    .O_y(Bar_inst0_O_y)
+);
+assign O_x = Bar_inst0_O_x;
+assign O_y = Bar_inst0_O_y;
+endmodule
+

--- a/tests/test_compile/test_user_namespace.py
+++ b/tests/test_compile/test_user_namespace.py
@@ -1,0 +1,52 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def _make_top(T):
+
+    def _make_io():
+        return m.IO(I=m.In(T), O=m.Out(T))
+
+    class _Bar(m.Circuit):
+        name = "Bar"
+        io = _make_io()
+        io.O @= io.I
+
+    class _Foo(m.Circuit):
+        name = "Foo"
+        io = _make_io()
+        io.O @= _Bar()(io.I)
+
+    return _Foo
+
+
+def test_basic():
+    top = _make_top(m.Bit)
+    name = "test_user_namespace_basic"
+    m.compile(f"build/{name}", top, output="coreir",
+              user_namespace="my_namespace")
+    assert check_files_equal(__file__,
+                             f"build/{name}.json",
+                             f"gold/{name}.json")
+
+
+def test_passes():
+    T = m.Product.from_fields("anonymous", dict(x=m.Bit, y=m.Bit))
+    top = _make_top(T)
+    name = "test_user_namespace_passes"
+    passes = ["flattentypes"]
+    m.compile(f"build/{name}", top, output="coreir",
+              passes=passes,
+              user_namespace="my_namespace")
+    assert check_files_equal(__file__,
+                             f"build/{name}.json",
+                             f"gold/{name}.json")
+
+
+def test_verilog_prefix():
+    T = m.Product.from_fields("anonymous", dict(x=m.Bit, y=m.Bit))
+    top = _make_top(T)
+    name = "test_user_namespace_verilog_prefix"
+    m.compile(f"build/{name}", top, output="coreir-verilog",
+              user_namespace="my_namespace")
+    assert check_files_equal(__file__, f"build/{name}.v", f"gold/{name}.v")


### PR DESCRIPTION
This passes introduces all user modules into a new user-specified namespace. Therefore, if specified (as a top-level compile option ala `m.compile("foo", foo, user_namespace="my_namespace")`), the output coreir will be structured as:

```
namespace my_namespace {
    Circuit foo;
    Circuit bar;
    ...
}

namespace some_external_lib {
    ...
}
```

This effectively replaces namespace `global` with namespace `my_namespace`. Furthermore, this will result in the verilog circuits having the namespace as a prefix (for free, per CoreIR verilog codegen spec).

I think this is a more robust and more "correct" way to achieve #714. It also has added benefits of avoiding name collisions even at the CoreIR level (#714 was to avoid name collisions at generated verilog level). As future work, we could allow specifying namespaces at a finer granularity, i.e. per python file or per verilog file. Then namespaces could even be a magma-level construct (right now it's just at CoreIR level). Further work could be to even support nested namespaces.

Issues/Concerns:
* Do we need to pass down the user_namespace to other parts of the compiler? `test_passes` was meant to make sure that the passes are run on the user namespace. I'm concerned because it seems to work even though we do not include that namespace when we specify on what namespace to run the pass (see inline comment).