### PR TITLE
Improve register getattr logic

### DIFF
--- a/magma/syntax/util.py
+++ b/magma/syntax/util.py
@@ -1,5 +1,6 @@
 from ..t import In, Out
 from ..circuit import Circuit
+from ..wire import wire
 
 
 def build_io_args(annotations):
@@ -30,6 +31,6 @@ def wire_call_result(io, call_result, annotations):
         call_result = call_result.interface.outputs()[0]
     if isinstance(annotations["return"], tuple):
         for i in range(len(annotations["return"])):
-            getattr(io, f"O{i}").wire(call_result[i])
+            wire(getattr(io, f"O{i}"), call_result[i])
     else:
-        io.O.wire(call_result)
+        wire(io.O, call_result)

--- a/tests/test_syntax/gold/TestSequential2Counter.v
+++ b/tests/test_syntax/gold/TestSequential2Counter.v
@@ -1,0 +1,49 @@
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module Register (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(16'h0000),
+    .width(16)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in(I),
+    .out(O)
+);
+endmodule
+
+module Test2 (
+    output [15:0] O,
+    input CLK
+);
+wire [15:0] Register_inst0_O;
+wire [15:0] magma_Bits_16_add_inst0_out;
+Register Register_inst0 (
+    .I(magma_Bits_16_add_inst0_out),
+    .O(Register_inst0_O),
+    .CLK(CLK)
+);
+assign magma_Bits_16_add_inst0_out = 16'(Register_inst0_O + 16'h0001);
+assign O = magma_Bits_16_add_inst0_out;
+endmodule
+

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -126,6 +126,7 @@ END SOURCE_LINES
 
     m.compile("build/TestSequential2NestedLoopUnroll", LoopUnroll)
     assert check_files_equal(__file__, f"build/TestSequential2NestedLoopUnroll.v",
+                                       f"gold/TestSequential2NestedLoopUnroll.v")
 
 
 def test_sequential2_return_tuple():

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -126,7 +126,6 @@ END SOURCE_LINES
 
     m.compile("build/TestSequential2NestedLoopUnroll", LoopUnroll)
     assert check_files_equal(__file__, f"build/TestSequential2NestedLoopUnroll.v",
-                             f"gold/TestSequential2NestedLoopUnroll.v")
 
 
 def test_sequential2_return_tuple():
@@ -167,3 +166,18 @@ def test_sequential2_custom_annotations():
     m.compile("build/TestSequential2CustomAnnotations", Basic, inline=True)
     assert check_files_equal(__file__, f"build/TestSequential2CustomAnnotations.v",
                              f"gold/TestSequential2CustomAnnotations.v")
+
+
+def test_sequential2_counter():
+    @m.sequential2()
+    class Test2:
+        def __init__(self):
+            self.count = m.Register(T=m.SInt[16], init=m.sint(0, 16))()
+
+        def __call__(self) -> m.SInt[16]:
+            self.count = self.count + 1
+            return self.count
+
+    m.compile("build/TestSequential2Counter", Test2, inline=True)
+    assert check_files_equal(__file__, f"build/TestSequential2Counter.v",
+                             f"gold/TestSequential2Counter.v")

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -126,7 +126,7 @@ END SOURCE_LINES
 
     m.compile("build/TestSequential2NestedLoopUnroll", LoopUnroll)
     assert check_files_equal(__file__, f"build/TestSequential2NestedLoopUnroll.v",
-                                       f"gold/TestSequential2NestedLoopUnroll.v")
+                             f"gold/TestSequential2NestedLoopUnroll.v")
 
 
 def test_sequential2_return_tuple():


### PR DESCRIPTION
Pulling into peak-seq2 to avoid merge conflicts (depends on some of those changes).

This augments the sequential2 getattr logic to support both the standard circuit pattern (calling syntax) and the setattr/getattr syntax for referencing the current value of the register and updating the next value.

For https://github.com/phanrahan/magma/issues/731

The way it works is:
When calling getattr, check if its an instance of the register primitive, if so, wrap it in a special magma protocol type that will implement a __call__ method that supports the circuit call style syntax, while otherwise behaving as the output of the register (i.e. register.O is the underlying magma value).  The main annoyance in the implementation is having to pass through things like operators to the underlying magma value, but I'm not sure if there's an alternative to doing this if we want to support both styles.