### PR TITLE
Adding sequential2 test

### DIFF
--- a/tests/test_syntax/gold/TestSequential2CounterIf.v
+++ b/tests/test_syntax/gold/TestSequential2CounterIf.v
@@ -1,0 +1,50 @@
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module Register (
+    input [15:0] I,
+    output [15:0] O,
+    input CLK
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(16'h0000),
+    .width(16)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in(I),
+    .out(O)
+);
+endmodule
+
+module Test2 (
+    input sel,
+    output [15:0] O,
+    input CLK
+);
+wire [15:0] Register_inst0_O;
+wire [15:0] magma_Bit_ite_Out_SInt_16_inst0_out;
+Register Register_inst0 (
+    .I(magma_Bit_ite_Out_SInt_16_inst0_out),
+    .O(Register_inst0_O),
+    .CLK(CLK)
+);
+assign magma_Bit_ite_Out_SInt_16_inst0_out = sel ? 16'(Register_inst0_O + 16'h0001) : Register_inst0_O;
+assign O = magma_Bit_ite_Out_SInt_16_inst0_out;
+endmodule
+

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -241,3 +241,18 @@ def test_sequential2_counter():
     m.compile("build/TestSequential2Counter", Test2, inline=True)
     assert check_files_equal(__file__, f"build/TestSequential2Counter.v",
                              f"gold/TestSequential2Counter.v")
+
+def test_sequential2_counter_if():
+    @m.sequential2()
+    class Test2:
+        def __init__(self):
+            self.count = m.Register(T=m.SInt[16], init=m.sint(0, 16))()
+
+        def __call__(self, sel: m.Bit) -> m.SInt[16]:
+            if sel:
+                self.count = self.count + 1
+            return self.count
+
+    m.compile("build/TestSequential2CounterIf", Test2, inline=True)
+    assert check_files_equal(__file__, f"build/TestSequential2CounterIf.v",
+                             f"gold/TestSequential2CounterIf.v")


### PR DESCRIPTION
Encountered type mismatch error on seq2

    if sel:
        self.count = self.count + 1

    E           TypeError: ite expects same type for both branches: Out(SInt[16]) != <class 'magma.syntax.sequential2._SequentialRegisterWrapperOut(SInt[16])'>