### PR TITLE
Use single return statement in coroutine generated code

### DIFF
--- a/magma/syntax/coroutine.py
+++ b/magma/syntax/coroutine.py
@@ -187,7 +187,7 @@ def _coroutine(defn_env, fn):
         return_target = [f"__magma_coroutine_return_value_{i}"
                          for i in range(len(return_type))]
     else:
-        return_target = ["__magma_coroutine_return_value"]
+        return_target = "__magma_coroutine_return_value"
 
     # add yield state register declaration
     yield_state_width = clog2(len(yield_encoding_map))
@@ -264,7 +264,7 @@ def _coroutine(defn_env, fn):
     call_method = RemoveIfTrues().visit(call_method)
     # Merge `if cond:` with `if not cond` for readability
     call_method = MergeInverseIf().visit(call_method)
-    if len(return_target) > 1:
+    if isinstance(return_target, list):
         call_method.body.append(
             ast.Return(ast.Tuple([ast.Name(x, ast.Load())
                                   for x in return_target], ast.Load())))


### PR DESCRIPTION
This was done to address the performance issue here: https://github.com/phanrahan/magma/issues/735

Basically, a majority of time was in dealing with some complex code generated for handling return statements inside if statements.  This simplifies the coroutine code to simply assign the return value and return it at the end.  This avoids the complexity of handling return statements (speeding up the code), but also improves the complexity of the generated hardware (simpler phi logic).  We can do this because we know that only one control flow path will be taken in the coroutine body (so we won't get clobbered by another assignment to the return values).