### PR TITLE
Add sequential2 test with Product

### DIFF
--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -242,6 +242,7 @@ def test_sequential2_counter():
     assert check_files_equal(__file__, f"build/TestSequential2Counter.v",
                              f"gold/TestSequential2Counter.v")
 
+
 def test_sequential2_counter_if():
     @m.sequential2()
     class Test2:
@@ -256,3 +257,17 @@ def test_sequential2_counter_if():
     m.compile("build/TestSequential2CounterIf", Test2, inline=True)
     assert check_files_equal(__file__, f"build/TestSequential2CounterIf.v",
                              f"gold/TestSequential2CounterIf.v")
+
+
+def test_sequential2_product():
+    @m.sequential2()
+    class Test:
+        def __call__(self, sel: m.Bit) -> m.AnonProduct[dict(a=m.Bit)]:
+            if sel:
+                return m.namedtuple(a=m.bit(0))
+            else:
+                return m.namedtuple(a=m.bit(1))
+
+    m.compile("build/TestSequential2Product", Test, inline=True)
+    assert check_files_equal(__file__, f"build/TestSequential2Product.v",
+                             f"gold/TestSequential2Product.v")


### PR DESCRIPTION
coreir aborts with this error.

> ERROR: magma_Bit_ite_Tuple_a=Out_Bit_inst0 21 is not a valid coreIR name!. Needs to be = ^[a-zA-Z_\-\$][a-zA-Z0-9_\-\$]*

pycoreir: 2.0.81
coreir: master (https://github.com/rdaly525/coreir/commit/9642814dd847dc82ff99c1c83670e6087dcd934a)
verilogAST: blacklist-slice-inline