### PR TITLE
Fix Seq2 product bug

### DIFF
--- a/magma/primitives/mux.py
+++ b/magma/primitives/mux.py
@@ -81,3 +81,7 @@ def mux(I, S, **kwargs):
         return I[S]
     T = type(I[0])
     return Mux(len(I), T, **kwargs)()(*I, S)
+
+
+# Monkey patch for ite impl without circular dependency
+Bit._Mux = Mux

--- a/tests/test_syntax/gold/TestSequential2CounterIf.v
+++ b/tests/test_syntax/gold/TestSequential2CounterIf.v
@@ -16,6 +16,15 @@ module coreir_reg #(
   assign out = outReg;
 endmodule
 
+module commonlib_muxn__N2__width16 (
+    input [15:0] in_data_0,
+    input [15:0] in_data_1,
+    input [0:0] in_sel,
+    output [15:0] out
+);
+assign out = in_sel[0] ? in_data_1 : in_data_0;
+endmodule
+
 module Register (
     input [15:0] I,
     output [15:0] O,
@@ -32,19 +41,36 @@ coreir_reg #(
 );
 endmodule
 
+module Mux2xOutSInt16 (
+    input [15:0] I0,
+    input [15:0] I1,
+    input S,
+    output [15:0] O
+);
+commonlib_muxn__N2__width16 coreir_commonlib_mux2x16_inst0 (
+    .in_data_0(I0),
+    .in_data_1(I1),
+    .in_sel(S),
+    .out(O)
+);
+endmodule
+
 module Test2 (
     input sel,
     output [15:0] O,
     input CLK
 );
 wire [15:0] Register_inst0_O;
-wire [15:0] magma_Bit_ite_Out_SInt_16_inst0_out;
+Mux2xOutSInt16 Mux2xOutSInt16_inst0 (
+    .I0(Register_inst0_O),
+    .I1(16'(Register_inst0_O + 16'h0001)),
+    .S(sel),
+    .O(O)
+);
 Register Register_inst0 (
-    .I(magma_Bit_ite_Out_SInt_16_inst0_out),
+    .I(O),
     .O(Register_inst0_O),
     .CLK(CLK)
 );
-assign magma_Bit_ite_Out_SInt_16_inst0_out = sel ? 16'(Register_inst0_O + 16'h0001) : Register_inst0_O;
-assign O = magma_Bit_ite_Out_SInt_16_inst0_out;
 endmodule
 

--- a/tests/test_syntax/gold/TestSequential2Product.v
+++ b/tests/test_syntax/gold/TestSequential2Product.v
@@ -1,0 +1,38 @@
+module commonlib_muxn__N2__width1 (
+    input [0:0] in_data_0,
+    input [0:0] in_data_1,
+    input [0:0] in_sel,
+    output [0:0] out
+);
+assign out = in_sel[0] ? in_data_1 : in_data_0;
+endmodule
+
+module Mux2xTuplea_OutBit (
+    input I0_a,
+    input I1_a,
+    output O_a,
+    input S
+);
+wire [0:0] coreir_commonlib_mux2x1_inst0_out;
+commonlib_muxn__N2__width1 coreir_commonlib_mux2x1_inst0 (
+    .in_data_0(I0_a),
+    .in_data_1(I1_a),
+    .in_sel(S),
+    .out(coreir_commonlib_mux2x1_inst0_out)
+);
+assign O_a = coreir_commonlib_mux2x1_inst0_out[0];
+endmodule
+
+module Test (
+    input CLK,
+    output O_a,
+    input sel
+);
+Mux2xTuplea_OutBit Mux2xTuplea_OutBit_inst0 (
+    .I0_a(1'b1),
+    .I1_a(1'b0),
+    .O_a(O_a),
+    .S(sel)
+);
+endmodule
+

--- a/tests/test_syntax/gold/TestSequential2ReturnTuple.v
+++ b/tests/test_syntax/gold/TestSequential2ReturnTuple.v
@@ -16,6 +16,29 @@ module coreir_reg #(
   assign out = outReg;
 endmodule
 
+module commonlib_muxn__N2__width4 (
+    input [3:0] in_data_0,
+    input [3:0] in_data_1,
+    input [0:0] in_sel,
+    output [3:0] out
+);
+assign out = in_sel[0] ? in_data_1 : in_data_0;
+endmodule
+
+module Mux2xOutBits4 (
+    input [3:0] I0,
+    input [3:0] I1,
+    input S,
+    output [3:0] O
+);
+commonlib_muxn__N2__width4 coreir_commonlib_mux2x4_inst0 (
+    .in_data_0(I0),
+    .in_data_1(I1),
+    .in_sel(S),
+    .out(O)
+);
+endmodule
+
 module Basic (
     input [3:0] I,
     input S,
@@ -23,15 +46,41 @@ module Basic (
     output [3:0] O1,
     input CLK
 );
+wire [3:0] Mux2xOutBits4_inst0_O;
+wire [3:0] Mux2xOutBits4_inst1_O;
 wire [3:0] reg_P_inst0_out;
 wire [3:0] reg_P_inst1_out;
+Mux2xOutBits4 Mux2xOutBits4_inst0 (
+    .I0(reg_P_inst0_out),
+    .I1(reg_P_inst0_out),
+    .S(S),
+    .O(Mux2xOutBits4_inst0_O)
+);
+Mux2xOutBits4 Mux2xOutBits4_inst1 (
+    .I0(I),
+    .I1(I),
+    .S(S),
+    .O(Mux2xOutBits4_inst1_O)
+);
+Mux2xOutBits4 Mux2xOutBits4_inst2 (
+    .I0(reg_P_inst0_out),
+    .I1(I),
+    .S(S),
+    .O(O0)
+);
+Mux2xOutBits4 Mux2xOutBits4_inst3 (
+    .I0(I),
+    .I1(reg_P_inst0_out),
+    .S(S),
+    .O(O1)
+);
 coreir_reg #(
     .clk_posedge(1'b1),
     .init(4'h0),
     .width(4)
 ) reg_P_inst0 (
     .clk(CLK),
-    .in(S ? I : I),
+    .in(Mux2xOutBits4_inst1_O),
     .out(reg_P_inst0_out)
 );
 coreir_reg #(
@@ -40,10 +89,8 @@ coreir_reg #(
     .width(4)
 ) reg_P_inst1 (
     .clk(CLK),
-    .in(S ? reg_P_inst0_out : reg_P_inst0_out),
+    .in(Mux2xOutBits4_inst0_O),
     .out(reg_P_inst1_out)
 );
-assign O0 = S ? I : reg_P_inst0_out;
-assign O1 = S ? reg_P_inst0_out : I;
 endmodule
 

--- a/tests/test_syntax/gold/test_562.v
+++ b/tests/test_syntax/gold/test_562.v
@@ -9,21 +9,53 @@ module coreir_mux #(
   assign out = sel ? in1 : in0;
 endmodule
 
+module commonlib_muxn__N2__width1 (
+    input [0:0] in_data_0,
+    input [0:0] in_data_1,
+    input [0:0] in_sel,
+    output [0:0] out
+);
+wire [0:0] _join_out;
+coreir_mux #(
+    .width(1)
+) _join (
+    .in0(in_data_0),
+    .in1(in_data_1),
+    .sel(in_sel[0]),
+    .out(_join_out)
+);
+assign out = _join_out;
+endmodule
+
+module Mux2xOutBits1 (
+    input [0:0] I0,
+    input [0:0] I1,
+    input S,
+    output [0:0] O
+);
+wire [0:0] coreir_commonlib_mux2x1_inst0_out;
+commonlib_muxn__N2__width1 coreir_commonlib_mux2x1_inst0 (
+    .in_data_0(I0),
+    .in_data_1(I1),
+    .in_sel(S),
+    .out(coreir_commonlib_mux2x1_inst0_out)
+);
+assign O = coreir_commonlib_mux2x1_inst0_out;
+endmodule
+
 module A_comb (
     input a,
     input [1:0] b,
     output [0:0] O
 );
-wire [0:0] magma_Bit_ite_Out_Bits_1_inst0_out;
-coreir_mux #(
-    .width(1)
-) magma_Bit_ite_Out_Bits_1_inst0 (
-    .in0(b[0]),
-    .in1(a),
-    .sel(a),
-    .out(magma_Bit_ite_Out_Bits_1_inst0_out)
+wire [0:0] Mux2xOutBits1_inst0_O;
+Mux2xOutBits1 Mux2xOutBits1_inst0 (
+    .I0(b[0]),
+    .I1(a),
+    .S(a),
+    .O(Mux2xOutBits1_inst0_O)
 );
-assign O = magma_Bit_ite_Out_Bits_1_inst0_out;
+assign O = Mux2xOutBits1_inst0_O;
 endmodule
 
 module A (

--- a/tests/test_syntax/gold/test_combinational2_basic_if.v
+++ b/tests/test_syntax/gold/test_combinational2_basic_if.v
@@ -1,10 +1,46 @@
-module corebit_mux (
-    input in0,
-    input in1,
+module coreir_mux #(
+    parameter width = 1
+) (
+    input [width-1:0] in0,
+    input [width-1:0] in1,
     input sel,
-    output out
+    output [width-1:0] out
 );
   assign out = sel ? in1 : in0;
+endmodule
+
+module commonlib_muxn__N2__width1 (
+    input [0:0] in_data_0,
+    input [0:0] in_data_1,
+    input [0:0] in_sel,
+    output [0:0] out
+);
+wire [0:0] _join_out;
+coreir_mux #(
+    .width(1)
+) _join (
+    .in0(in_data_0),
+    .in1(in_data_1),
+    .sel(in_sel[0]),
+    .out(_join_out)
+);
+assign out = _join_out;
+endmodule
+
+module Mux2xOutBit (
+    input I0,
+    input I1,
+    input S,
+    output O
+);
+wire [0:0] coreir_commonlib_mux2x1_inst0_out;
+commonlib_muxn__N2__width1 coreir_commonlib_mux2x1_inst0 (
+    .in_data_0(I0),
+    .in_data_1(I1),
+    .in_sel(S),
+    .out(coreir_commonlib_mux2x1_inst0_out)
+);
+assign O = coreir_commonlib_mux2x1_inst0_out[0];
 endmodule
 
 module basic_if (
@@ -12,14 +48,14 @@ module basic_if (
     input S,
     output O
 );
-wire magma_Bit_ite_Out_Bit_inst0_out;
-corebit_mux magma_Bit_ite_Out_Bit_inst0 (
-    .in0(I[1]),
-    .in1(I[0]),
-    .sel(S),
-    .out(magma_Bit_ite_Out_Bit_inst0_out)
+wire Mux2xOutBit_inst0_O;
+Mux2xOutBit Mux2xOutBit_inst0 (
+    .I0(I[1]),
+    .I1(I[0]),
+    .S(S),
+    .O(Mux2xOutBit_inst0_O)
 );
-assign O = magma_Bit_ite_Out_Bit_inst0_out;
+assign O = Mux2xOutBit_inst0_O;
 endmodule
 
 module Main (

--- a/tests/test_syntax/gold/test_combinational2_pre_post_passes.v
+++ b/tests/test_syntax/gold/test_combinational2_pre_post_passes.v
@@ -1,7 +1,49 @@
+module commonlib_muxn__N2__width3 (
+    input [2:0] in_data_0,
+    input [2:0] in_data_1,
+    input [0:0] in_sel,
+    output [2:0] out
+);
+assign out = in_sel[0] ? in_data_1 : in_data_0;
+endmodule
+
+module Mux2xOutBits3 (
+    input [2:0] I0,
+    input [2:0] I1,
+    input S,
+    output [2:0] O
+);
+commonlib_muxn__N2__width3 coreir_commonlib_mux2x3_inst0 (
+    .in_data_0(I0),
+    .in_data_1(I1),
+    .in_sel(S),
+    .out(O)
+);
+endmodule
+
 module pre_unroll (
     input [2:0] I,
     output [2:0] O
 );
-assign O = I[0] ? 3'h0 : I[1] ? 3'h1 : I[2] ? 3'h2 : 3'h4;
+wire [2:0] Mux2xOutBits3_inst0_O;
+wire [2:0] Mux2xOutBits3_inst1_O;
+Mux2xOutBits3 Mux2xOutBits3_inst0 (
+    .I0(3'h4),
+    .I1(3'h2),
+    .S(I[2]),
+    .O(Mux2xOutBits3_inst0_O)
+);
+Mux2xOutBits3 Mux2xOutBits3_inst1 (
+    .I0(Mux2xOutBits3_inst0_O),
+    .I1(3'h1),
+    .S(I[1]),
+    .O(Mux2xOutBits3_inst1_O)
+);
+Mux2xOutBits3 Mux2xOutBits3_inst2 (
+    .I0(Mux2xOutBits3_inst1_O),
+    .I1(3'h0),
+    .S(I[0]),
+    .O(O)
+);
 endmodule
 

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -242,6 +242,7 @@ def test_sequential2_counter():
     assert check_files_equal(__file__, f"build/TestSequential2Counter.v",
                              f"gold/TestSequential2Counter.v")
 
+
 def test_sequential2_counter_if():
     @m.sequential2()
     class Test2:
@@ -256,3 +257,17 @@ def test_sequential2_counter_if():
     m.compile("build/TestSequential2CounterIf", Test2, inline=True)
     assert check_files_equal(__file__, f"build/TestSequential2CounterIf.v",
                              f"gold/TestSequential2CounterIf.v")
+
+
+def test_sequential2_product():
+    @m.sequential2()
+    class Test:
+        def __call__(self, sel: m.Bit) -> m.AnonProduct[dict(a=m.Bit)]:
+            if sel:
+                return m.namedtuple(a=m.bit(0))
+            else:
+                return m.namedtuple(a=m.bit(1))
+
+    m.compile("build/TestSequential2Product", Test, inline=True)
+    assert check_files_equal(__file__, f"build/TestSequential2Product.v",
+                             f"gold/TestSequential2Product.v")

--- a/tests/test_type/gold/TestBitite.v
+++ b/tests/test_type/gold/TestBitite.v
@@ -1,10 +1,46 @@
-module corebit_mux (
-    input in0,
-    input in1,
+module coreir_mux #(
+    parameter width = 1
+) (
+    input [width-1:0] in0,
+    input [width-1:0] in1,
     input sel,
-    output out
+    output [width-1:0] out
 );
   assign out = sel ? in1 : in0;
+endmodule
+
+module commonlib_muxn__N2__width1 (
+    input [0:0] in_data_0,
+    input [0:0] in_data_1,
+    input [0:0] in_sel,
+    output [0:0] out
+);
+wire [0:0] _join_out;
+coreir_mux #(
+    .width(1)
+) _join (
+    .in0(in_data_0),
+    .in1(in_data_1),
+    .sel(in_sel[0]),
+    .out(_join_out)
+);
+assign out = _join_out;
+endmodule
+
+module Mux2xOutBit (
+    input I0,
+    input I1,
+    input S,
+    output O
+);
+wire [0:0] coreir_commonlib_mux2x1_inst0_out;
+commonlib_muxn__N2__width1 coreir_commonlib_mux2x1_inst0 (
+    .in_data_0(I0),
+    .in_data_1(I1),
+    .in_sel(S),
+    .out(coreir_commonlib_mux2x1_inst0_out)
+);
+assign O = coreir_commonlib_mux2x1_inst0_out[0];
 endmodule
 
 module TestITE (
@@ -13,13 +49,13 @@ module TestITE (
     input S,
     output O
 );
-wire magma_Bit_ite_Out_Bit_inst0_out;
-corebit_mux magma_Bit_ite_Out_Bit_inst0 (
-    .in0(I1),
-    .in1(I0),
-    .sel(S),
-    .out(magma_Bit_ite_Out_Bit_inst0_out)
+wire Mux2xOutBit_inst0_O;
+Mux2xOutBit Mux2xOutBit_inst0 (
+    .I0(I1),
+    .I1(I0),
+    .S(S),
+    .O(Mux2xOutBit_inst0_O)
 );
-assign O = magma_Bit_ite_Out_Bit_inst0_out;
+assign O = Mux2xOutBit_inst0_O;
 endmodule
 

--- a/tests/test_type/test_bit.py
+++ b/tests/test_type/test_bit.py
@@ -352,13 +352,13 @@ def test_ite():
     assert repr(TestITE) == """\
 TestITE = DefineCircuit("TestITE", "I0", In(Bit), "I1", In(Bit), "S", In(Bit), \
 "O", Out(Bit))
-magma_Bit_ite_Out_Bit_inst0 = magma_Bit_ite_Out_Bit()
-wire(TestITE.I1, magma_Bit_ite_Out_Bit_inst0.in0)
-wire(TestITE.I0, magma_Bit_ite_Out_Bit_inst0.in1)
-wire(TestITE.S, magma_Bit_ite_Out_Bit_inst0.sel)
-wire(magma_Bit_ite_Out_Bit_inst0.out, TestITE.O)
+Mux2xOutBit_inst0 = Mux2xOutBit()
+wire(TestITE.I1, Mux2xOutBit_inst0.I0)
+wire(TestITE.I0, Mux2xOutBit_inst0.I1)
+wire(TestITE.S, Mux2xOutBit_inst0.S)
+wire(Mux2xOutBit_inst0.O, TestITE.O)
 EndCircuit()\
-"""
+""", repr(TestITE)
     m.compile(f"build/TestBitite", TestITE, output="coreir-verilog")
     assert check_files_equal(__file__, f"build/TestBitite.v",
                              f"gold/TestBitite.v")


### PR DESCRIPTION
Fix for https://github.com/phanrahan/magma/pull/744

To make this work, I had to generalize the Bit.ite implementation to be generic over T.  Rather than duplicate this logic, I chose to use the Mux primitive instead, but this means there's a circular dependency between bit.py and mux.py, so I have mux.py monkey patch the Mux primitive generator onto the Bit class.  Not sure if there's a better way to do this since I think the mux implementation depends on Bit/Bits