### PR TITLE
Deprecate array of bits sequential test

### DIFF
--- a/tests/test_primitives/gold/test_reg_of_product_zero_init.v
+++ b/tests/test_primitives/gold/test_reg_of_product_zero_init.v
@@ -1,0 +1,252 @@
+module mantle_wire__typeBitIn8 (
+    output [7:0] in,
+    input [7:0] out
+);
+assign in = out;
+endmodule
+
+module mantle_wire__typeBitIn4 (
+    output [3:0] in,
+    input [3:0] out
+);
+assign in = out;
+endmodule
+
+module mantle_wire__typeBitIn12 (
+    output [11:0] in,
+    input [11:0] out
+);
+assign in = out;
+endmodule
+
+module mantle_wire__typeBit8 (
+    input [7:0] in,
+    output [7:0] out
+);
+assign out = in;
+endmodule
+
+module mantle_wire__typeBit4 (
+    input [3:0] in,
+    output [3:0] out
+);
+assign out = in;
+endmodule
+
+module mantle_wire__typeBit12 (
+    input [11:0] in,
+    output [11:0] out
+);
+assign out = in;
+endmodule
+
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module coreir_mux #(
+    parameter width = 1
+) (
+    input [width-1:0] in0,
+    input [width-1:0] in1,
+    input sel,
+    output [width-1:0] out
+);
+  assign out = sel ? in1 : in0;
+endmodule
+
+module coreir_const #(
+    parameter width = 1,
+    parameter value = 1
+) (
+    output [width-1:0] out
+);
+  assign out = value;
+endmodule
+
+module commonlib_muxn__N2__width12 (
+    input [11:0] in_data_0,
+    input [11:0] in_data_1,
+    input [0:0] in_sel,
+    output [11:0] out
+);
+wire [11:0] _join_out;
+coreir_mux #(
+    .width(12)
+) _join (
+    .in0(in_data_0),
+    .in1(in_data_1),
+    .sel(in_sel[0]),
+    .out(_join_out)
+);
+assign out = _join_out;
+endmodule
+
+module Mux2xTuplex_Bits8_y_Bits4 (
+    input [7:0] I0_x,
+    input [3:0] I0_y,
+    input [7:0] I1_x,
+    input [3:0] I1_y,
+    output [7:0] O_x,
+    output [3:0] O_y,
+    input S
+);
+wire [11:0] _$0_in;
+wire [11:0] _$1_in;
+wire [11:0] _$2_out;
+wire [7:0] _$3_out;
+wire [3:0] _$4_out;
+wire [7:0] _$5_out;
+wire [3:0] _$6_out;
+wire [7:0] _$7_in;
+wire [3:0] _$8_in;
+wire [11:0] coreir_commonlib_mux2x12_inst0_out;
+mantle_wire__typeBitIn12 _$0 (
+    .in(_$0_in),
+    .out({_$4_out[3:0],_$3_out[7:0]})
+);
+mantle_wire__typeBitIn12 _$1 (
+    .in(_$1_in),
+    .out({_$6_out[3:0],_$5_out[7:0]})
+);
+mantle_wire__typeBit12 _$2 (
+    .in(coreir_commonlib_mux2x12_inst0_out),
+    .out(_$2_out)
+);
+mantle_wire__typeBit8 _$3 (
+    .in(I0_x),
+    .out(_$3_out)
+);
+mantle_wire__typeBit4 _$4 (
+    .in(I0_y),
+    .out(_$4_out)
+);
+mantle_wire__typeBit8 _$5 (
+    .in(I1_x),
+    .out(_$5_out)
+);
+mantle_wire__typeBit4 _$6 (
+    .in(I1_y),
+    .out(_$6_out)
+);
+mantle_wire__typeBitIn8 _$7 (
+    .in(_$7_in),
+    .out(_$2_out[7:0])
+);
+mantle_wire__typeBitIn4 _$8 (
+    .in(_$8_in),
+    .out(_$2_out[11:8])
+);
+commonlib_muxn__N2__width12 coreir_commonlib_mux2x12_inst0 (
+    .in_data_0(_$0_in),
+    .in_data_1(_$1_in),
+    .in_sel(S),
+    .out(coreir_commonlib_mux2x12_inst0_out)
+);
+assign O_x = _$7_in;
+assign O_y = _$8_in;
+endmodule
+
+module Register (
+    input CLK,
+    input [7:0] I_x,
+    input [3:0] I_y,
+    output [7:0] O_x,
+    output [3:0] O_y,
+    input RESET
+);
+wire [7:0] Mux2xTuplex_Bits8_y_Bits4_inst0_O_x;
+wire [3:0] Mux2xTuplex_Bits8_y_Bits4_inst0_O_y;
+wire [7:0] _$0_out;
+wire [3:0] _$1_out;
+wire [7:0] _$2_in;
+wire [3:0] _$3_in;
+wire [3:0] const_0_4_out;
+wire [7:0] const_0_8_out;
+wire [11:0] reg_P_inst0_out;
+Mux2xTuplex_Bits8_y_Bits4 Mux2xTuplex_Bits8_y_Bits4_inst0 (
+    .I0_x(I_x),
+    .I0_y(I_y),
+    .I1_x(const_0_8_out),
+    .I1_y(const_0_4_out),
+    .O_x(Mux2xTuplex_Bits8_y_Bits4_inst0_O_x),
+    .O_y(Mux2xTuplex_Bits8_y_Bits4_inst0_O_y),
+    .S(RESET)
+);
+mantle_wire__typeBit8 _$0 (
+    .in(Mux2xTuplex_Bits8_y_Bits4_inst0_O_x),
+    .out(_$0_out)
+);
+mantle_wire__typeBit4 _$1 (
+    .in(Mux2xTuplex_Bits8_y_Bits4_inst0_O_y),
+    .out(_$1_out)
+);
+mantle_wire__typeBitIn8 _$2 (
+    .in(_$2_in),
+    .out(reg_P_inst0_out[7:0])
+);
+mantle_wire__typeBitIn4 _$3 (
+    .in(_$3_in),
+    .out(reg_P_inst0_out[11:8])
+);
+coreir_const #(
+    .value(4'h0),
+    .width(4)
+) const_0_4 (
+    .out(const_0_4_out)
+);
+coreir_const #(
+    .value(8'h00),
+    .width(8)
+) const_0_8 (
+    .out(const_0_8_out)
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(12'h000),
+    .width(12)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in({_$1_out[3:0],_$0_out[7:0]}),
+    .out(reg_P_inst0_out)
+);
+assign O_x = _$2_in;
+assign O_y = _$3_in;
+endmodule
+
+module test_reg_of_product_zero_init (
+    input CLK,
+    input [7:0] I_x,
+    input [3:0] I_y,
+    output [7:0] O_x,
+    output [3:0] O_y,
+    input RESET
+);
+wire [7:0] Register_inst0_O_x;
+wire [3:0] Register_inst0_O_y;
+Register Register_inst0 (
+    .CLK(CLK),
+    .I_x(I_x),
+    .I_y(I_y),
+    .O_x(Register_inst0_O_x),
+    .O_y(Register_inst0_O_y),
+    .RESET(RESET)
+);
+assign O_x = Register_inst0_O_x;
+assign O_y = Register_inst0_O_y;
+endmodule
+

--- a/tests/test_syntax/gold/TestSequential2ArrOfBits.v
+++ b/tests/test_syntax/gold/TestSequential2ArrOfBits.v
@@ -1,0 +1,280 @@
+module mantle_wire__typeBitIn7 (
+    output [6:0] in,
+    input [6:0] out
+);
+assign in = out;
+endmodule
+
+module mantle_wire__typeBit7 (
+    input [6:0] in,
+    output [6:0] out
+);
+assign out = in;
+endmodule
+
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module Register (
+    input CLK,
+    input [6:0] I_0,
+    input [6:0] I_1,
+    input [6:0] I_10,
+    input [6:0] I_11,
+    input [6:0] I_12,
+    input [6:0] I_13,
+    input [6:0] I_14,
+    input [6:0] I_2,
+    input [6:0] I_3,
+    input [6:0] I_4,
+    input [6:0] I_5,
+    input [6:0] I_6,
+    input [6:0] I_7,
+    input [6:0] I_8,
+    input [6:0] I_9,
+    output [6:0] O_0,
+    output [6:0] O_1,
+    output [6:0] O_10,
+    output [6:0] O_11,
+    output [6:0] O_12,
+    output [6:0] O_13,
+    output [6:0] O_14,
+    output [6:0] O_2,
+    output [6:0] O_3,
+    output [6:0] O_4,
+    output [6:0] O_5,
+    output [6:0] O_6,
+    output [6:0] O_7,
+    output [6:0] O_8,
+    output [6:0] O_9
+);
+wire [6:0] _$0_out;
+wire [6:0] _$1_out;
+wire [6:0] _$10_out;
+wire [6:0] _$11_out;
+wire [6:0] _$12_out;
+wire [6:0] _$13_out;
+wire [6:0] _$14_out;
+wire [6:0] _$2_out;
+wire [6:0] _$3_out;
+wire [6:0] _$4_out;
+wire [6:0] _$5_out;
+wire [6:0] _$6_out;
+wire [6:0] _$7_out;
+wire [6:0] _$8_out;
+wire [6:0] _$9_out;
+wire [104:0] reg_P_inst0_out;
+mantle_wire__typeBit7 _$0 (
+    .in(I_0),
+    .out(_$0_out)
+);
+mantle_wire__typeBit7 _$1 (
+    .in(I_1),
+    .out(_$1_out)
+);
+mantle_wire__typeBit7 _$10 (
+    .in(I_5),
+    .out(_$10_out)
+);
+mantle_wire__typeBit7 _$11 (
+    .in(I_6),
+    .out(_$11_out)
+);
+mantle_wire__typeBit7 _$12 (
+    .in(I_7),
+    .out(_$12_out)
+);
+mantle_wire__typeBit7 _$13 (
+    .in(I_8),
+    .out(_$13_out)
+);
+mantle_wire__typeBit7 _$14 (
+    .in(I_9),
+    .out(_$14_out)
+);
+mantle_wire__typeBitIn7 _$15 (
+    .in(O_0),
+    .out(reg_P_inst0_out[6:0])
+);
+mantle_wire__typeBitIn7 _$16 (
+    .in(O_1),
+    .out(reg_P_inst0_out[13:7])
+);
+mantle_wire__typeBitIn7 _$17 (
+    .in(O_10),
+    .out(reg_P_inst0_out[76:70])
+);
+mantle_wire__typeBitIn7 _$18 (
+    .in(O_11),
+    .out(reg_P_inst0_out[83:77])
+);
+mantle_wire__typeBitIn7 _$19 (
+    .in(O_12),
+    .out(reg_P_inst0_out[90:84])
+);
+mantle_wire__typeBit7 _$2 (
+    .in(I_10),
+    .out(_$2_out)
+);
+mantle_wire__typeBitIn7 _$20 (
+    .in(O_13),
+    .out(reg_P_inst0_out[97:91])
+);
+mantle_wire__typeBitIn7 _$21 (
+    .in(O_14),
+    .out(reg_P_inst0_out[104:98])
+);
+mantle_wire__typeBitIn7 _$22 (
+    .in(O_2),
+    .out(reg_P_inst0_out[20:14])
+);
+mantle_wire__typeBitIn7 _$23 (
+    .in(O_3),
+    .out(reg_P_inst0_out[27:21])
+);
+mantle_wire__typeBitIn7 _$24 (
+    .in(O_4),
+    .out(reg_P_inst0_out[34:28])
+);
+mantle_wire__typeBitIn7 _$25 (
+    .in(O_5),
+    .out(reg_P_inst0_out[41:35])
+);
+mantle_wire__typeBitIn7 _$26 (
+    .in(O_6),
+    .out(reg_P_inst0_out[48:42])
+);
+mantle_wire__typeBitIn7 _$27 (
+    .in(O_7),
+    .out(reg_P_inst0_out[55:49])
+);
+mantle_wire__typeBitIn7 _$28 (
+    .in(O_8),
+    .out(reg_P_inst0_out[62:56])
+);
+mantle_wire__typeBitIn7 _$29 (
+    .in(O_9),
+    .out(reg_P_inst0_out[69:63])
+);
+mantle_wire__typeBit7 _$3 (
+    .in(I_11),
+    .out(_$3_out)
+);
+mantle_wire__typeBit7 _$4 (
+    .in(I_12),
+    .out(_$4_out)
+);
+mantle_wire__typeBit7 _$5 (
+    .in(I_13),
+    .out(_$5_out)
+);
+mantle_wire__typeBit7 _$6 (
+    .in(I_14),
+    .out(_$6_out)
+);
+mantle_wire__typeBit7 _$7 (
+    .in(I_2),
+    .out(_$7_out)
+);
+mantle_wire__typeBit7 _$8 (
+    .in(I_3),
+    .out(_$8_out)
+);
+mantle_wire__typeBit7 _$9 (
+    .in(I_4),
+    .out(_$9_out)
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(105'h000000000000000000000000000),
+    .width(105)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in({_$6_out[6:0],_$5_out[6:0],_$4_out[6:0],_$3_out[6:0],_$2_out[6:0],_$14_out[6:0],_$13_out[6:0],_$12_out[6:0],_$11_out[6:0],_$10_out[6:0],_$9_out[6:0],_$8_out[6:0],_$7_out[6:0],_$1_out[6:0],_$0_out[6:0]}),
+    .out(reg_P_inst0_out)
+);
+endmodule
+
+module Test2 (
+    input CLK,
+    input [6:0] I_0,
+    input [6:0] I_1,
+    input [6:0] I_10,
+    input [6:0] I_11,
+    input [6:0] I_12,
+    input [6:0] I_13,
+    input [6:0] I_14,
+    input [6:0] I_2,
+    input [6:0] I_3,
+    input [6:0] I_4,
+    input [6:0] I_5,
+    input [6:0] I_6,
+    input [6:0] I_7,
+    input [6:0] I_8,
+    input [6:0] I_9,
+    output [6:0] O_0,
+    output [6:0] O_1,
+    output [6:0] O_10,
+    output [6:0] O_11,
+    output [6:0] O_12,
+    output [6:0] O_13,
+    output [6:0] O_14,
+    output [6:0] O_2,
+    output [6:0] O_3,
+    output [6:0] O_4,
+    output [6:0] O_5,
+    output [6:0] O_6,
+    output [6:0] O_7,
+    output [6:0] O_8,
+    output [6:0] O_9
+);
+Register Register_inst0 (
+    .CLK(CLK),
+    .I_0(I_0),
+    .I_1(I_1),
+    .I_10(I_10),
+    .I_11(I_11),
+    .I_12(I_12),
+    .I_13(I_13),
+    .I_14(I_14),
+    .I_2(I_2),
+    .I_3(I_3),
+    .I_4(I_4),
+    .I_5(I_5),
+    .I_6(I_6),
+    .I_7(I_7),
+    .I_8(I_8),
+    .I_9(I_9),
+    .O_0(O_0),
+    .O_1(O_1),
+    .O_10(O_10),
+    .O_11(O_11),
+    .O_12(O_12),
+    .O_13(O_13),
+    .O_14(O_14),
+    .O_2(O_2),
+    .O_3(O_3),
+    .O_4(O_4),
+    .O_5(O_5),
+    .O_6(O_6),
+    .O_7(O_7),
+    .O_8(O_8),
+    .O_9(O_9)
+);
+endmodule
+

--- a/tests/test_syntax/test_sequential.py
+++ b/tests/test_syntax/test_sequential.py
@@ -414,22 +414,6 @@ def test_multiple_return(target, async_reset):
         "RegisterMode" + ("ARST" if async_reset else ""), RegisterMode, target)
 
 
-def test_array_of_bits(target):
-    @m.circuit.sequential(async_reset=True)
-    class ArrayOfBitsSeq:
-        def __init__(self):
-            self.register_array: m.Array[15, m.Bits[1024]] = \
-                m.array([m.bits(0, 1024) for _ in range(15)])
-
-        def __call__(self, I: m.Array[15, m.Bits[1024]]) -> \
-                m.Array[15, m.Bits[1024]]:
-            O = self.register_array
-            self.register_array = I
-            return O
-
-    compile_and_check("ArrayOfBitsSeq", ArrayOfBitsSeq, target)
-
-
 def test_rd_ptr(target):
     @m.circuit.sequential(async_reset=True)
     class RdPtr:

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -224,7 +224,8 @@ def test_sequential2_custom_annotations():
             return O
 
     m.compile("build/TestSequential2CustomAnnotations", Basic, inline=True)
-    assert check_files_equal(__file__, f"build/TestSequential2CustomAnnotations.v",
+    assert check_files_equal(__file__,
+                             f"build/TestSequential2CustomAnnotations.v",
                              f"gold/TestSequential2CustomAnnotations.v")
 
 
@@ -242,6 +243,7 @@ def test_sequential2_counter():
     assert check_files_equal(__file__, f"build/TestSequential2Counter.v",
                              f"gold/TestSequential2Counter.v")
 
+
 def test_sequential2_counter_if():
     @m.sequential2()
     class Test2:
@@ -256,3 +258,20 @@ def test_sequential2_counter_if():
     m.compile("build/TestSequential2CounterIf", Test2, inline=True)
     assert check_files_equal(__file__, f"build/TestSequential2CounterIf.v",
                              f"gold/TestSequential2CounterIf.v")
+
+
+def test_sequential2_arr_of_bits():
+    T = m.Array[15, m.Bits[7]]
+    @m.sequential2()
+    class Test2:
+        def __init__(self):
+            self.reg_arr = m.Register(T=T)()
+
+        def __call__(self, I: T) -> T:
+            O = self.reg_arr
+            self.reg_arr = I
+            return O
+
+    m.compile("build/TestSequential2ArrOfBits", Test2, inline=True)
+    assert check_files_equal(__file__, f"build/TestSequential2ArrOfBits.v",
+                             f"gold/TestSequential2ArrOfBits.v")


### PR DESCRIPTION
For https://github.com/phanrahan/magma/issues/735

Removes old slow tests, replaces them with new tests for sequential2 of the same functionality.  Also adds improved init logic for register primitive (required for the test).

The new test is much faster:

```
❯ pytest tests/test_syntax/test_sequential2.py -k test_sequential2_arr_of_bits --profile
========================================================================================================== test session starts ===========================================================================================================
platform darwin -- Python 3.7.2, pytest-4.2.0, py-1.8.0, pluggy-0.9.0
rootdir: /Users/lenny/repos/magma, inifile: setup.cfg
plugins: profiling-1.7.0, parallel-0.0.9, cov-2.6.1, codestyle-2.0.0
collected 10 items / 9 deselected / 1 selected

tests/test_syntax/test_sequential2.py .                                                                                                                                                                                            [100%]
Profiling (from /Users/lenny/repos/magma/prof/combined.prof):
Fri Jun 26 10:55:30 2020    /Users/lenny/repos/magma/prof/combined.prof

         227071 function calls (215575 primitive calls) in 0.656 seconds
```