### PR TITLE
Add helpful warning message for working with undirected values

### DIFF
--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -33,7 +33,7 @@ class Wire:
         Connect two wires, self should be an input and other should be an
         output, or both should be inouts
         """
-        if self._driver is not None and self._bit.is_input():
+        if self._driver is not None:
             _logger.warning(
                 "Wiring multiple outputs to same wire, using last connection."
                 f" Input: {self._bit.debug_name}, "

--- a/tests/test_wire/test_undirected_error.py
+++ b/tests/test_wire/test_undirected_error.py
@@ -1,20 +1,19 @@
 import magma as m
-from magma.testing.utils import has_warning
+from magma.testing.utils import has_warning, magma_debug_section
 
 
 def test_undirected_value_warning_1(caplog):
-    m.config.set_debug_mode(True)
-    class Main(m.Circuit):
-        io = m.IO(I=m.In(m.Bits[5]), O=m.Out(m.Bits[5]))
-        x = m.Bits[5](name="x")
-        y = m.Bits[5](name="y")
-        x @= io.I
-        # Backwards, should be wiring x to drive y
-        # This produces a warning that you're overwriting the previous driver
-        # of x
-        m.wire(y, x)
-        io.O @= y
-    m.config.set_debug_mode(False)
+    with magma_debug_section():
+        class Main(m.Circuit):
+            io = m.IO(I=m.In(m.Bits[5]), O=m.Out(m.Bits[5]))
+            x = m.Bits[5](name="x")
+            y = m.Bits[5](name="y")
+            x @= io.I
+            # Backwards, should be wiring x to drive y
+            # This produces a warning that you're overwriting the previous driver
+            # of x
+            m.wire(y, x)
+            io.O @= y
     msg = """\
 \033[1mtests/test_wire/test_undirected_error.py:15\033[0m: Wiring multiple outputs to same wire, using last connection. Input: x[0],  Old Output: LazyCircuit.I[0],  New Output: y[0]
 >>         m.wire(y, x)\
@@ -23,18 +22,17 @@ def test_undirected_value_warning_1(caplog):
 
 
 def test_undirected_value_error_2(caplog):
-    m.config.set_debug_mode(True)
-    class Main(m.Circuit):
-        io = m.IO(I=m.In(m.Bits[5]), O=m.Out(m.Bits[5]))
-        x = m.Bits[5](name="x")
-        y = m.Bits[5](name="y")
-        # Backwards, should be wiring x to drive y
-        m.wire(y, x)
-        # This produces a warning that you're overwriting the previous driver
-        # of x
-        x @= io.I
-        io.O @= y
-    m.config.set_debug_mode(False)
+    with magma_debug_section():
+        class Main(m.Circuit):
+            io = m.IO(I=m.In(m.Bits[5]), O=m.Out(m.Bits[5]))
+            x = m.Bits[5](name="x")
+            y = m.Bits[5](name="y")
+            # Backwards, should be wiring x to drive y
+            m.wire(y, x)
+            # This produces a warning that you're overwriting the previous driver
+            # of x
+            x @= io.I
+            io.O @= y
     msg = """\
 \033[1mtests/test_wire/test_undirected_error.py:35\033[0m: Wiring multiple outputs to same wire, using last connection. Input: x[0],  Old Output: y[0],  New Output: LazyCircuit.I[0]
 >>         x @= io.I\

--- a/tests/test_wire/test_undirected_error.py
+++ b/tests/test_wire/test_undirected_error.py
@@ -1,0 +1,42 @@
+import magma as m
+from magma.testing.utils import has_warning
+
+
+def test_undirected_value_warning_1(caplog):
+    m.config.set_debug_mode(True)
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[5]), O=m.Out(m.Bits[5]))
+        x = m.Bits[5](name="x")
+        y = m.Bits[5](name="y")
+        x @= io.I
+        # Backwards, should be wiring x to drive y
+        # This produces a warning that you're overwriting the previous driver
+        # of x
+        m.wire(y, x)
+        io.O @= y
+    m.config.set_debug_mode(False)
+    msg = """\
+\033[1mtests/test_wire/test_undirected_error.py:15\033[0m: Wiring multiple outputs to same wire, using last connection. Input: x[0],  Old Output: LazyCircuit.I[0],  New Output: y[0]
+>>         m.wire(y, x)\
+"""
+    assert has_warning(caplog, msg)
+
+
+def test_undirected_value_error_2(caplog):
+    m.config.set_debug_mode(True)
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[5]), O=m.Out(m.Bits[5]))
+        x = m.Bits[5](name="x")
+        y = m.Bits[5](name="y")
+        # Backwards, should be wiring x to drive y
+        m.wire(y, x)
+        # This produces a warning that you're overwriting the previous driver
+        # of x
+        x @= io.I
+        io.O @= y
+    m.config.set_debug_mode(False)
+    msg = """\
+\033[1mtests/test_wire/test_undirected_error.py:35\033[0m: Wiring multiple outputs to same wire, using last connection. Input: x[0],  Old Output: y[0],  New Output: LazyCircuit.I[0]
+>>         x @= io.I\
+"""
+    assert has_warning(caplog, msg)

--- a/tests/test_wire/test_undirected_error.py
+++ b/tests/test_wire/test_undirected_error.py
@@ -34,7 +34,7 @@ def test_undirected_value_error_2(caplog):
             x @= io.I
             io.O @= y
     msg = """\
-\033[1mtests/test_wire/test_undirected_error.py:35\033[0m: Wiring multiple outputs to same wire, using last connection. Input: x[0],  Old Output: y[0],  New Output: LazyCircuit.I[0]
+\033[1mtests/test_wire/test_undirected_error.py:34\033[0m: Wiring multiple outputs to same wire, using last connection. Input: x[0],  Old Output: y[0],  New Output: LazyCircuit.I[0]
 >>         x @= io.I\
 """
     assert has_warning(caplog, msg)

--- a/tests/test_wire/test_undirected_error.py
+++ b/tests/test_wire/test_undirected_error.py
@@ -16,7 +16,7 @@ def test_undirected_value_warning_1(caplog):
             io.O @= y
     msg = """\
 \033[1mtests/test_wire/test_undirected_error.py:15\033[0m: Wiring multiple outputs to same wire, using last connection. Input: x[0],  Old Output: LazyCircuit.I[0],  New Output: y[0]
->>         m.wire(y, x)\
+>>             m.wire(y, x)\
 """
     assert has_warning(caplog, msg)
 
@@ -35,6 +35,6 @@ def test_undirected_value_error_2(caplog):
             io.O @= y
     msg = """\
 \033[1mtests/test_wire/test_undirected_error.py:34\033[0m: Wiring multiple outputs to same wire, using last connection. Input: x[0],  Old Output: y[0],  New Output: LazyCircuit.I[0]
->>         x @= io.I\
+>>             x @= io.I\
 """
     assert has_warning(caplog, msg)


### PR DESCRIPTION
This enables a warning message that should've been on in the first place (the error guard was too conservative).  Basically, there's cases when people use `m.wire` that don't respect the `m.wire(driver, drivee)` pattern when working with undirected values.  This ensures that there is a useful error message reported (was not the case before).  For now, we tell the user that they are overriding the previous driver, which should be quick to indicate that their wiring of the undirected values was not working as intended.

We may consider a way to trace back to the original wiring command and report some suggestion such as "maybe reverse this wiring statement?", but I think for now at least you get something useful.  Note that this is a more rare case, because when using `x @= y` to indicate y drives x, it's a more natural/common pattern to handle the wiring relationship between undirected values.