### PR TITLE
coroutine2 test

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -96,5 +96,6 @@ from .log import info, debug, warning, error
 
 from .syntax.sequential2 import sequential2
 from .syntax.combinational2 import combinational2
+from .syntax.coroutine import coroutine2
 
 from magma.primitives import LUT, Mux, mux, Register, slice, reduce, Memory

--- a/magma/syntax/sequential2.py
+++ b/magma/syntax/sequential2.py
@@ -134,6 +134,10 @@ class _SequentialRegisterWrapper(MagmaProtocol,
     def __call__(self, *args, **kwargs):
         return self.circuit(*args, **kwargs)
 
+    def __getitem__(self, i):
+        key = i._get_magma_value_() if isinstance(i, MagmaProtocol) else i
+        return self._get_magma_value_()[key]
+
 
 def sequential_getattribute(self, key):
     """

--- a/tests/test_syntax/gold/TestSequential2GetItem.v
+++ b/tests/test_syntax/gold/TestSequential2GetItem.v
@@ -1,0 +1,317 @@
+module mantle_wire__typeBitIn7 (
+    output [6:0] in,
+    input [6:0] out
+);
+assign in = out;
+endmodule
+
+module mantle_wire__typeBit7 (
+    input [6:0] in,
+    output [6:0] out
+);
+assign out = in;
+endmodule
+
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module commonlib_muxn__N2__width7 (
+    input [6:0] in_data_0,
+    input [6:0] in_data_1,
+    input [0:0] in_sel,
+    output [6:0] out
+);
+assign out = in_sel[0] ? in_data_1 : in_data_0;
+endmodule
+
+module commonlib_muxn__N4__width7 (
+    input [6:0] in_data_0,
+    input [6:0] in_data_1,
+    input [6:0] in_data_2,
+    input [6:0] in_data_3,
+    input [1:0] in_sel,
+    output [6:0] out
+);
+wire [6:0] muxN_0_out;
+wire [6:0] muxN_1_out;
+commonlib_muxn__N2__width7 muxN_0 (
+    .in_data_0(in_data_0),
+    .in_data_1(in_data_1),
+    .in_sel(in_sel[1 - 1:0]),
+    .out(muxN_0_out)
+);
+commonlib_muxn__N2__width7 muxN_1 (
+    .in_data_0(in_data_2),
+    .in_data_1(in_data_3),
+    .in_sel(in_sel[1 - 1:0]),
+    .out(muxN_1_out)
+);
+assign out = in_sel[1] ? muxN_1_out : muxN_0_out;
+endmodule
+
+module commonlib_muxn__N8__width7 (
+    input [6:0] in_data_0,
+    input [6:0] in_data_1,
+    input [6:0] in_data_2,
+    input [6:0] in_data_3,
+    input [6:0] in_data_4,
+    input [6:0] in_data_5,
+    input [6:0] in_data_6,
+    input [6:0] in_data_7,
+    input [2:0] in_sel,
+    output [6:0] out
+);
+wire [6:0] muxN_0_out;
+wire [6:0] muxN_1_out;
+commonlib_muxn__N4__width7 muxN_0 (
+    .in_data_0(in_data_0),
+    .in_data_1(in_data_1),
+    .in_data_2(in_data_2),
+    .in_data_3(in_data_3),
+    .in_sel(in_sel[2 - 1:0]),
+    .out(muxN_0_out)
+);
+commonlib_muxn__N4__width7 muxN_1 (
+    .in_data_0(in_data_4),
+    .in_data_1(in_data_5),
+    .in_data_2(in_data_6),
+    .in_data_3(in_data_7),
+    .in_sel(in_sel[2 - 1:0]),
+    .out(muxN_1_out)
+);
+assign out = in_sel[2] ? muxN_1_out : muxN_0_out;
+endmodule
+
+module Register_unq1 (
+    input [2:0] I,
+    output [2:0] O,
+    input CLK
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(3'h0),
+    .width(3)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in(I),
+    .out(O)
+);
+endmodule
+
+module Register (
+    input CLK,
+    input [6:0] I_0,
+    input [6:0] I_1,
+    input [6:0] I_2,
+    input [6:0] I_3,
+    input [6:0] I_4,
+    input [6:0] I_5,
+    input [6:0] I_6,
+    input [6:0] I_7,
+    output [6:0] O_0,
+    output [6:0] O_1,
+    output [6:0] O_2,
+    output [6:0] O_3,
+    output [6:0] O_4,
+    output [6:0] O_5,
+    output [6:0] O_6,
+    output [6:0] O_7
+);
+wire [6:0] _$0_out;
+wire [6:0] _$1_out;
+wire [6:0] _$2_out;
+wire [6:0] _$3_out;
+wire [6:0] _$4_out;
+wire [6:0] _$5_out;
+wire [6:0] _$6_out;
+wire [6:0] _$7_out;
+wire [55:0] reg_P_inst0_out;
+mantle_wire__typeBit7 _$0 (
+    .in(I_0),
+    .out(_$0_out)
+);
+mantle_wire__typeBit7 _$1 (
+    .in(I_1),
+    .out(_$1_out)
+);
+mantle_wire__typeBitIn7 _$10 (
+    .in(O_2),
+    .out(reg_P_inst0_out[20:14])
+);
+mantle_wire__typeBitIn7 _$11 (
+    .in(O_3),
+    .out(reg_P_inst0_out[27:21])
+);
+mantle_wire__typeBitIn7 _$12 (
+    .in(O_4),
+    .out(reg_P_inst0_out[34:28])
+);
+mantle_wire__typeBitIn7 _$13 (
+    .in(O_5),
+    .out(reg_P_inst0_out[41:35])
+);
+mantle_wire__typeBitIn7 _$14 (
+    .in(O_6),
+    .out(reg_P_inst0_out[48:42])
+);
+mantle_wire__typeBitIn7 _$15 (
+    .in(O_7),
+    .out(reg_P_inst0_out[55:49])
+);
+mantle_wire__typeBit7 _$2 (
+    .in(I_2),
+    .out(_$2_out)
+);
+mantle_wire__typeBit7 _$3 (
+    .in(I_3),
+    .out(_$3_out)
+);
+mantle_wire__typeBit7 _$4 (
+    .in(I_4),
+    .out(_$4_out)
+);
+mantle_wire__typeBit7 _$5 (
+    .in(I_5),
+    .out(_$5_out)
+);
+mantle_wire__typeBit7 _$6 (
+    .in(I_6),
+    .out(_$6_out)
+);
+mantle_wire__typeBit7 _$7 (
+    .in(I_7),
+    .out(_$7_out)
+);
+mantle_wire__typeBitIn7 _$8 (
+    .in(O_0),
+    .out(reg_P_inst0_out[6:0])
+);
+mantle_wire__typeBitIn7 _$9 (
+    .in(O_1),
+    .out(reg_P_inst0_out[13:7])
+);
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(56'h00000000000000),
+    .width(56)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in({_$7_out[6:0],_$6_out[6:0],_$5_out[6:0],_$4_out[6:0],_$3_out[6:0],_$2_out[6:0],_$1_out[6:0],_$0_out[6:0]}),
+    .out(reg_P_inst0_out)
+);
+endmodule
+
+module Mux8xOutBits7 (
+    input [6:0] I0,
+    input [6:0] I1,
+    input [6:0] I2,
+    input [6:0] I3,
+    input [6:0] I4,
+    input [6:0] I5,
+    input [6:0] I6,
+    input [6:0] I7,
+    input [2:0] S,
+    output [6:0] O
+);
+commonlib_muxn__N8__width7 coreir_commonlib_mux8x7_inst0 (
+    .in_data_0(I0),
+    .in_data_1(I1),
+    .in_data_2(I2),
+    .in_data_3(I3),
+    .in_data_4(I4),
+    .in_data_5(I5),
+    .in_data_6(I6),
+    .in_data_7(I7),
+    .in_sel(S),
+    .out(O)
+);
+endmodule
+
+module Test2 (
+    input CLK,
+    input [6:0] I_0,
+    input [6:0] I_1,
+    input [6:0] I_2,
+    input [6:0] I_3,
+    input [6:0] I_4,
+    input [6:0] I_5,
+    input [6:0] I_6,
+    input [6:0] I_7,
+    output [6:0] O_0,
+    output [6:0] O_1,
+    input [2:0] index
+);
+wire [6:0] Register_inst0_O_0;
+wire [6:0] Register_inst0_O_1;
+wire [6:0] Register_inst0_O_2;
+wire [6:0] Register_inst0_O_3;
+wire [6:0] Register_inst0_O_4;
+wire [6:0] Register_inst0_O_5;
+wire [6:0] Register_inst0_O_6;
+wire [6:0] Register_inst0_O_7;
+wire [2:0] Register_inst1_O;
+Mux8xOutBits7 Mux8xOutBits7_inst0 (
+    .I0(Register_inst0_O_0),
+    .I1(Register_inst0_O_1),
+    .I2(Register_inst0_O_2),
+    .I3(Register_inst0_O_3),
+    .I4(Register_inst0_O_4),
+    .I5(Register_inst0_O_5),
+    .I6(Register_inst0_O_6),
+    .I7(Register_inst0_O_7),
+    .S(index),
+    .O(O_0)
+);
+Mux8xOutBits7 Mux8xOutBits7_inst1 (
+    .I0(Register_inst0_O_0),
+    .I1(Register_inst0_O_1),
+    .I2(Register_inst0_O_2),
+    .I3(Register_inst0_O_3),
+    .I4(Register_inst0_O_4),
+    .I5(Register_inst0_O_5),
+    .I6(Register_inst0_O_6),
+    .I7(Register_inst0_O_7),
+    .S(Register_inst1_O),
+    .O(O_1)
+);
+Register Register_inst0 (
+    .CLK(CLK),
+    .I_0(I_0),
+    .I_1(I_1),
+    .I_2(I_2),
+    .I_3(I_3),
+    .I_4(I_4),
+    .I_5(I_5),
+    .I_6(I_6),
+    .I_7(I_7),
+    .O_0(Register_inst0_O_0),
+    .O_1(Register_inst0_O_1),
+    .O_2(Register_inst0_O_2),
+    .O_3(Register_inst0_O_3),
+    .O_4(Register_inst0_O_4),
+    .O_5(Register_inst0_O_5),
+    .O_6(Register_inst0_O_6),
+    .O_7(Register_inst0_O_7)
+);
+Register_unq1 Register_inst1 (
+    .I(index),
+    .O(Register_inst1_O),
+    .CLK(CLK)
+);
+endmodule
+

--- a/tests/test_syntax/test_coroutine2/build/.gitignore
+++ b/tests/test_syntax/test_coroutine2/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_syntax/test_coroutine2/test_jtag2.py
+++ b/tests/test_syntax/test_coroutine2/test_jtag2.py
@@ -1,0 +1,234 @@
+import tempfile
+import os
+import sys
+
+import magma as m
+import fault
+
+TEST_SYNTAX_PATH = os.path.join(os.path.dirname(__file__), '../')
+
+sys.path.append(TEST_SYNTAX_PATH)
+
+from test_sequential import DefineRegister
+
+
+def test_jtag():
+    TEST_LOGIC_RESET = m.bits(15, 4)
+    RUN_TEST_IDLE = m.bits(12, 4)
+    SELECT_DR_SCAN = m.bits(7, 4)
+    CAPTURE_DR = m.bits(6, 4)
+    SHIFT_DR = m.bits(2, 4)
+    EXIT1_DR = m.bits(1, 4)
+    PAUSE_DR = m.bits(3, 4)
+    EXIT2_DR = m.bits(0, 4)
+    UPDATE_DR = m.bits(5, 4)
+    SELECT_IR_SCAN = m.bits(4, 4)
+    CAPTURE_IR = m.bits(14, 4)
+    SHIFT_IR = m.bits(10, 4)
+    EXIT1_IR = m.bits(9, 4)
+    PAUSE_IR = m.bits(11, 4)
+    EXIT2_IR = m.bits(8, 4)
+    UPDATE_IR = m.bits(13, 4)
+
+    @m.coroutine2
+    class JTAG:
+        _manual_encoding_ = True
+
+        def __init__(self):
+            self.yield_state = m.Register(
+                T=m.Bits[4], init=TEST_LOGIC_RESET, reset_type=m.AsyncReset
+            )()
+
+        def __call__(self, tms: m.Bit) -> m.Bits[4]:
+            # TODO: Prune infeasible paths (or check if synthesis optimizes
+            # them out)
+            while True:
+                while True:
+                    self.yield_state = TEST_LOGIC_RESET
+                    yield self.yield_state.prev()
+                    if tms == 0:
+                        break
+                while tms == 0:
+                    self.yield_state = RUN_TEST_IDLE
+                    yield self.yield_state.prev()
+                while tms == 1:
+                    self.yield_state = SELECT_DR_SCAN
+                    yield self.yield_state.prev()
+                    if tms == 0:
+                        # dr
+                        yield from self.make_scan(CAPTURE_DR, SHIFT_DR,
+                                                  EXIT1_DR, PAUSE_DR, EXIT2_DR,
+                                                  UPDATE_DR)
+                    else:
+                        self.yield_state = SELECT_IR_SCAN
+                        yield self.yield_state.prev()
+                        if tms == 0:
+                            # ir
+                            yield from self.make_scan(CAPTURE_IR, SHIFT_IR,
+                                                      EXIT1_IR, PAUSE_IR,
+                                                      EXIT2_IR, UPDATE_IR)
+                        else:
+                            break
+
+        def make_scan(self, capture, shift, exit_1, pause, exit_2, update):
+            def scan(self, tms: m.Bit) -> m.Bits[4]:
+                self.yield_state = capture
+                yield self.yield_state.prev()
+                while True:
+                    if tms == 0:
+                        while True:
+                            self.yield_state = shift
+                            yield self.yield_state.prev()
+                            if tms != 0:
+                                break
+                    self.yield_state = exit_1
+                    yield self.yield_state.prev()
+                    if tms == 0:
+                        while True:
+                            self.yield_state = pause
+                            yield self.yield_state.prev()
+                            if tms != 0:
+                                break
+                        self.yield_state = exit_2
+                        yield self.yield_state.prev()
+                        if tms != 0:
+                            break
+                    else:
+                        break
+                self.yield_state = update
+                yield self.yield_state.prev()
+                return tms
+            return scan()
+
+    m.compile("build/JTAG", JTAG, inline=True)
+
+    tester = fault.Tester(JTAG, JTAG.CLK)
+    tester.circuit.tms = 1
+    tester.circuit.ASYNCRESET = 0
+    tester.eval()
+    tester.circuit.ASYNCRESET = 1
+    tester.eval()
+    tester.circuit.ASYNCRESET = 0
+    tester.eval()
+    tester.step(2)
+    tester.circuit.O.expect(int(TEST_LOGIC_RESET))
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(TEST_LOGIC_RESET))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(RUN_TEST_IDLE))
+
+    tester.step(2)
+    tester.circuit.O.expect(int(RUN_TEST_IDLE))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_DR_SCAN))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(CAPTURE_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT1_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(PAUSE_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(PAUSE_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT2_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_DR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT1_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(UPDATE_DR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_DR_SCAN))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_IR_SCAN))
+
+    # BEGIN REPEAT FOR IR
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(CAPTURE_IR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT1_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(PAUSE_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(PAUSE_IR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT2_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_IR))
+
+    tester.circuit.tms = 0
+    tester.step(2)
+    tester.circuit.O.expect(int(SHIFT_IR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(EXIT1_IR))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(UPDATE_IR))
+    # END REPEAT FOR IR
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_DR_SCAN))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(SELECT_IR_SCAN))
+
+    tester.circuit.tms = 1
+    tester.step(2)
+    tester.circuit.O.expect(int(TEST_LOGIC_RESET))
+
+    directory = f"{os.path.abspath(os.path.dirname(__file__))}/build/"
+    tester.compile_and_run(target="verilator", directory=directory,
+                           flags=['-Wno-fatal', "--trace"], skip_compile=True)

--- a/tests/test_syntax/test_coroutine2/test_sdram2.py
+++ b/tests/test_syntax/test_coroutine2/test_sdram2.py
@@ -1,0 +1,279 @@
+import tempfile
+import os
+import sys
+
+import magma as m
+import fault
+
+TEST_SYNTAX_PATH = os.path.join(os.path.dirname(__file__), '../')
+
+sys.path.append(TEST_SYNTAX_PATH)
+
+from test_sequential import DefineRegister
+
+
+def test_sdram():
+    CLK_FREQUENCY = 133   # Mhz
+    REFRESH_TIME = 32     # ms     (how often we need to refresh)
+    REFRESH_COUNT = 8192  # cycles (how many refreshes required per refresh time)
+
+    # clk / refresh =  clk / sec
+    #                , sec / refbatch
+    #                , ref / refbatch
+    CYCLES_BETWEEN_REFRESH = \
+        (CLK_FREQUENCY * 1_000 * REFRESH_TIME) // REFRESH_COUNT
+
+    # IDLE = "5'b00000"
+    IDLE = m.bits(0, 5)
+
+    # INIT_NOP1 = "5'b01000"
+    # INIT_PRE1 = "5'b01001"
+    # INIT_NOP1_1 = "5'b00101"
+    # INIT_REF1 = "5'b01010"
+    # INIT_NOP2 = "5'b01011"
+    # INIT_REF2 = "5'b01100"
+    # INIT_NOP3 = "5'b01101"
+    # INIT_LOAD = "5'b01110"
+    # INIT_NOP4 = "5'b01111"
+
+    # REF_PRE = "5'b00001"
+    # REF_NOP1 = "5'b00010"
+    # REF_REF = "5'b00011"
+    # REF_NOP2 = "5'b00100"
+
+    # READ_ACT = "5'b10000"
+    # READ_NOP1 = "5'b10001"
+    # READ_CAS = "5'b10010"
+    # READ_NOP2 = "5'b10011"
+    # READ_READ = "5'b10100"
+
+    # WRIT_ACT = "5'b11000"
+    # WRIT_NOP1 = "5'b11001"
+    # WRIT_CAS = "5'b11010"
+    # WRIT_NOP2 = "5'b11011"
+
+    INIT_NOP1 = m.bits(0b01000, 5)
+    INIT_PRE1 = m.bits(0b01001, 5)
+    INIT_NOP1_1 = m.bits(0b00101, 5)
+    INIT_REF1 = m.bits(0b01010, 5)
+    INIT_NOP2 = m.bits(0b01011, 5)
+    INIT_REF2 = m.bits(0b01100, 5)
+    INIT_NOP3 = m.bits(0b01101, 5)
+    INIT_LOAD = m.bits(0b01110, 5)
+    INIT_NOP4 = m.bits(0b01111, 5)
+    
+    REF_PRE = m.bits(0b00001, 5)
+    REF_NOP1 = m.bits(0b00010, 5)
+    REF_REF = m.bits(0b00011, 5)
+    REF_NOP2 = m.bits(0b00100, 5)
+    
+    READ_ACT = m.bits(0b10000, 5)
+    READ_NOP1 = m.bits(0b10001, 5)
+    READ_CAS = m.bits(0b10010, 5)
+    READ_NOP2 = m.bits(0b10011, 5)
+    READ_READ = m.bits(0b10100, 5)
+    
+    WRIT_ACT = m.bits(0b11000, 5)
+    WRIT_NOP1 = m.bits(0b11001, 5)
+    WRIT_CAS = m.bits(0b11010, 5)
+    WRIT_NOP2 = m.bits(0b11011, 5)
+
+    # CMD_PALL = "8'b10010001"
+    # CMD_REF = "8'b10001000"
+    # CMD_NOP = "8'b10111000"
+    # CMD_MRS = "8'b1000000x"
+    # CMD_BACT = "8'b10011xxx"
+    # CMD_READ = "8'b10101xx1"
+    # CMD_WRIT = "8'b10100xx1"
+
+    CMD_PALL = m.bits(0b10010001, 8)
+    CMD_REF = m.bits(0b10001000, 8)
+    CMD_NOP = m.bits(0b10111000, 8)
+    CMD_MRS = m.bits(0b10000000, 8)
+    CMD_BACT = m.bits(0b10011000, 8)
+    CMD_READ = m.bits(0b10101001, 8)
+    CMD_WRIT = m.bits(0b10100001, 8)
+
+    @m.coroutine2
+    class SDRAMController:
+        _manual_encoding_ = True
+        _reset_type_ = m.AsyncResetN
+
+        def __init__(self):
+            self.yield_state = m.Register(T=m.Bits[5], init=INIT_NOP1, reset_type=m.AsyncResetN)()
+            self.command = m.Register(T=m.Bits[8], init=CMD_NOP, reset_type=m.AsyncResetN)()
+            self.i = m.Register(T=m.UInt[4], init=m.uint(15, 4), reset_type=m.AsyncResetN)()
+
+        def __call__(self, refresh_cnt: m.UInt[10], rd_enable: m.Bit, wr_enable: m.Bit) -> (m.Bits[5], m.Bits[8]):
+            yield from self.init()
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = IDLE
+                yield self.yield_state.prev(), self.command.prev()
+                if refresh_cnt >= CYCLES_BETWEEN_REFRESH:
+                    yield from self.refresh()
+                elif wr_enable:
+                    yield from self.write()
+                elif rd_enable:
+                    yield from self.read()
+
+        def init(self, refresh_cnt: m.UInt[10], rd_enable: m.Bit, wr_enable: m.Bit) -> (m.Bits[5], m.Bits[8]):
+            # TODO: Desugar for loops
+            # for _ in range(15, -1, -1):
+            # Loop started by self.i init value
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = INIT_NOP1
+                yield self.yield_state.prev(), self.command.prev()
+                if self.i == 0:
+                    break
+                self.i = self.i - 1
+            self.command = CMD_PALL
+            self.yield_state = INIT_PRE1
+            yield self.yield_state.prev(), self.command.prev()
+            self.command = CMD_NOP
+            self.yield_state = INIT_NOP1_1
+            yield self.yield_state.prev(), self.command.prev()
+            self.command = CMD_REF
+            self.yield_state = INIT_REF1
+            yield self.yield_state.prev(), self.command.prev()
+            # for _ in range(7, -1, -1):
+            self.i = m.uint(7, 4)
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = INIT_NOP2
+                yield self.yield_state.prev(), self.command.prev()
+                if self.i == 0:
+                    break
+                self.i = self.i - 1
+            self.command = CMD_REF
+            self.yield_state = INIT_REF2
+            yield self.yield_state.prev(), self.command.prev()
+            # for _ in range(7, -1, -1):
+            self.i = m.uint(7, 4)
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = INIT_NOP3
+                yield self.yield_state.prev(), self.command.prev()
+                if self.i == 0:
+                    break
+                self.i = self.i - 1
+            self.command = CMD_MRS
+            self.yield_state = INIT_LOAD
+            yield self.yield_state.prev(), self.command.prev()
+            # for _ in range(1, -1, -1):
+            self.i = m.uint(1, 4)
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = INIT_NOP4
+                yield self.yield_state.prev(), self.command.prev()
+                if self.i == 0:
+                    break
+                self.i = self.i - 1
+            return refresh_cnt, rd_enable, wr_enable
+
+        def refresh(self, refresh_cnt: m.UInt[10], rd_enable: m.Bit, wr_enable: m.Bit) -> (m.Bits[5], m.Bits[8]):
+            self.command = CMD_PALL
+            self.yield_state = REF_PRE
+            yield self.yield_state.prev(), self.command.prev()
+            self.command = CMD_NOP
+            self.yield_state = REF_NOP1
+            yield self.yield_state.prev(), self.command.prev()
+            self.command = CMD_REF
+            self.yield_state = REF_REF
+            yield self.yield_state.prev(), self.command.prev()
+            # for _ in range(7, -1, -1):
+            self.i = m.uint(7, 4)
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = REF_NOP2
+                yield self.yield_state.prev(), self.command.prev()
+                if self.i == 0:
+                    break
+                self.i = self.i - 1
+            return refresh_cnt, rd_enable, wr_enable
+
+        def write(self, refresh_cnt: m.UInt[10], rd_enable: m.Bit, wr_enable: m.Bit) -> (m.Bits[5], m.Bits[8]):
+            self.command = CMD_BACT
+            self.yield_state = WRIT_ACT
+            yield self.yield_state.prev(), self.command.prev()
+            # for _ in range(1, -1, -1):
+            self.i = m.uint(1, 4)
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = WRIT_NOP1
+                yield self.yield_state.prev(), self.command.prev()
+                if self.i == 0:
+                    break
+                self.i = self.i - 1
+            self.command = CMD_WRIT
+            self.yield_state = WRIT_CAS
+            yield self.yield_state.prev(), self.command.prev()
+            # for _ in range(1, -1, -1):
+            self.i = m.uint(1, 4)
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = WRIT_NOP2
+                yield self.yield_state.prev(), self.command.prev()
+                if self.i == 0:
+                    break
+                self.i = self.i - 1
+            return refresh_cnt, rd_enable, wr_enable
+
+        def read(self, refresh_cnt: m.UInt[10], rd_enable: m.Bit, wr_enable: m.Bit) -> (m.Bits[5], m.Bits[8]):
+            self.command = CMD_BACT
+            self.yield_state = READ_ACT
+            yield self.yield_state.prev(), self.command.prev()
+            # for _ in range(1, -1, -1):
+            self.i = m.uint(1, 4)
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = READ_NOP1
+                yield self.yield_state.prev(), self.command.prev()
+                if self.i == 0:
+                    break
+                self.i = self.i - 1
+            self.command = CMD_READ
+            self.yield_state = READ_CAS
+            yield self.yield_state.prev(), self.command.prev()
+            # for _ in range(1, -1, -1):
+            self.i = m.uint(1, 4)
+            while True:
+                self.command = CMD_NOP
+                self.yield_state = READ_NOP2
+                yield self.yield_state.prev(), self.command.prev()
+                if self.i == 0:
+                    break
+                self.i = self.i - 1
+            self.command = CMD_NOP
+            self.yield_state = READ_READ
+            yield self.yield_state.prev(), self.command.prev()
+            return refresh_cnt, rd_enable, wr_enable
+
+
+    m.compile("build/SDRAMController", SDRAMController, inline=True)
+
+    tester = fault.Tester(SDRAMController, SDRAMController.CLK)
+    tester.circuit.ASYNCRESETN = 1
+    tester.eval()
+    tester.circuit.ASYNCRESETN = 0
+    tester.eval()
+    tester.circuit.ASYNCRESETN = 1
+    tester.eval()
+    for i in range(16):
+        tester.circuit.O0.expect(0b01000)
+        tester.circuit.O1.expect(0b10111000)
+        tester.step(2)
+    tester.circuit.O0.expect(0b01001)
+    tester.circuit.O1.expect(0b10010001)
+    tester.step(2)
+    tester.circuit.O0.expect(0b00101)
+    tester.circuit.O1.expect(0b10111000)
+    tester.step(2)
+    tester.circuit.O0.expect(0b01010)
+    tester.circuit.O1.expect(0b10001000)
+    tester.step(2)
+
+    directory = f"{os.path.abspath(os.path.dirname(__file__))}/build/"
+    tester.compile_and_run("verilator", directory=directory,
+                           flags=['-Wno-fatal', "--trace"], skip_compile=True)

--- a/tests/test_syntax/test_coroutine2/test_uart2.py
+++ b/tests/test_syntax/test_coroutine2/test_uart2.py
@@ -1,0 +1,80 @@
+import os
+import tempfile
+import sys
+
+import magma as m
+import fault
+
+TEST_SYNTAX_PATH = os.path.join(os.path.dirname(__file__), '../')
+
+sys.path.append(TEST_SYNTAX_PATH)
+
+from test_sequential import DefineRegister
+
+
+def test_uart():
+    @m.coroutine2
+    class UART:
+        def __init__(self):
+            self.message = m.Register(T=m.Bits[8], init=0, reset_type=m.AsyncReset)()
+            self.i = m.Register(T=m.UInt[3], init=7, reset_type=m.AsyncReset)()
+            self.tx = m.Register(T=m.Bit, init=1, reset_type=m.AsyncReset)()
+
+        def __call__(self, run: m.Bit, message: m.Bits[8]) -> m.Bit:
+            while True:
+                self.tx = m.bit(1)  # end bit or idle
+                yield self.tx.prev()
+                if run:
+                    self.message = message
+                    self.tx = m.bit(0)  # start bit
+                    yield self.tx.prev()
+                    while True:
+                        self.i = self.i - 1
+                        self.tx = self.message[self.i.prev()]
+                        yield self.tx.prev()
+                        if self.i == 7:
+                            break
+
+    m.compile("build/UART", UART)
+
+    tester = fault.Tester(UART, UART.CLK)
+    tester.poke(UART.CLK, 0)
+    tester.poke(UART.ASYNCRESET, 0)
+    tester.eval()
+    tester.poke(UART.ASYNCRESET, 1)
+    tester.eval()
+    tester.poke(UART.ASYNCRESET, 0)
+    tester.eval()
+
+    # idle
+    tester.expect(UART.O, 1)
+    tester.print("idle=1\n")
+
+    for message in [0xDE, 0xAD]:
+        tester.poke(UART.message, message)
+        tester.poke(UART.run, 1)
+        tester.step(2)
+
+        # start bit
+        tester.print("start=0\n")
+        tester.expect(UART.O, 0)
+        tester.poke(UART.message, 0xFF)
+        tester.poke(UART.run, 0)
+
+        for i in range(8):
+            tester.step(2)
+            tester.print(f"message[{i}]\n")
+            tester.expect(UART.O, (message >> (7-i)) & 1)
+
+        # end bit
+        tester.step(2)
+        tester.expect(UART.O, 1)
+
+    # idle
+    for i in range(2):
+        tester.step(2)
+        tester.expect(UART.O, 1)
+
+    directory = f"{os.path.abspath(os.path.dirname(__file__))}/build/"
+    tester.compile_and_run(target="verilator", directory=directory,
+                           flags=['-Wno-fatal', "--trace"], skip_compile=True)

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -275,3 +275,22 @@ def test_sequential2_arr_of_bits():
     m.compile("build/TestSequential2ArrOfBits", Test2, inline=True)
     assert check_files_equal(__file__, f"build/TestSequential2ArrOfBits.v",
                              f"gold/TestSequential2ArrOfBits.v")
+
+
+def test_sequential2_getitem():
+    T = m.Array[8, m.Bits[7]]
+    @m.sequential2()
+    class Test2:
+        def __init__(self):
+            self.reg_arr = m.Register(T=T)()
+            self.index = m.Register(T=m.Bits[3])()
+
+        def __call__(self, I: T, index: m.Bits[3]) -> m.Array[2, m.Bits[7]]:
+            out = m.array([self.reg_arr[index], self.reg_arr[self.index]])
+            self.reg_arr = I
+            self.index = index
+            return out
+
+    m.compile("build/TestSequential2GetItem", Test2, inline=True)
+    assert check_files_equal(__file__, f"build/TestSequential2GetItem.v",
+                             f"gold/TestSequential2GetItem.v")


### PR DESCRIPTION
Depends on
- `__getitem__` https://github.com/phanrahan/magma/pull/748
- coroutine2 https://github.com/phanrahan/magma/pull/749
- ast_tools self.attr.prev() https://github.com/leonardt/ast_tools/pull/52

But it has still an unresolved error.

    tests/test_syntax/test_coroutine2/test_jtag2.py::test_jtag Traceback (most recent call last):
      File "magma/magma/ast_utils.py", line 54, in compile_function_to_file
        exec(code, defn_env)
      File ".magma/JTAG.py", line 2, in <module>
        class JTAG:
      File "magma/magma/syntax/sequential2.py", line 210, in seq_inner
        cls.__call__ = apply_ast_passes(passes, debug=debug, env=env,
      File "ast_tools/ast_tools/passes/util.py", line 172, in __init__
        env = get_symbol_table([self.__init__])
      File "ast_tools/ast_tools/stack.py", line 69, in get_symbol_table
        raise RuntimeError(f'{frame.function} @ {frame.filename}:{frame.lineno} might be leaking names')
    RuntimeError: wrapped_0 @ ast_tools/ast_tools/stack.py:116 might be leaking names

`wrapped_0` should be in `get_symbol_table` `decorators` to avoid this error.
https://github.com/leonardt/ast_tools/blob/658b9d3eddb34d6ffb72b5980cefdb38b6bdb640/ast_tools/stack.py#L107

testing with this workaround

    diff --git a/ast_tools/stack.py b/ast_tools/stack.py
    index d445059..ab9a644 100644
    --- a/ast_tools/stack.py
    +++ b/ast_tools/stack.py
    @@ -65,7 +65,7 @@ def get_symbol_table(
                 continue
             debug_check = frame.frame.f_locals.get(_SKIP_FRAME_DEBUG_NAME, None)
             if debug_check == _SKIP_FRAME_DEBUG_VALUE:
    -            if _SKIP_FRAME_DEBUG_FAIL:
    +            if False:#_SKIP_FRAME_DEBUG_FAIL:
                     raise RuntimeError(f'{frame.function} @ {frame.filename}:{frame.lineno} might be leaking names')
                 else:
                     logging.debug(f'{frame.function} @ {frame.filename}:{frame.lineno} might be leaking names')