### PR TITLE
sequential2: support register params

### DIFF
--- a/magma/clock.py
+++ b/magma/clock.py
@@ -155,3 +155,16 @@ def wireclock(define, circuit):
     wireclocktype(define, circuit, AsyncReset)
     wireclocktype(define, circuit, AsyncResetN)
     wireclocktype(define, circuit, Enable)
+
+
+def get_reset_args(reset_type: AbstractReset = None):
+    if reset_type is not None and not issubclass(reset_type, AbstractReset):
+        raise TypeError(
+            f"Expected subclass of AbstractReset for argument reset_type, "
+            f"not {type(reset_type)}")
+
+    has_async_reset = reset_type == AsyncReset
+    has_async_resetn = reset_type == AsyncResetN
+    has_reset = reset_type == Reset
+    has_resetn = reset_type == ResetN
+    return (has_async_reset, has_async_resetn, has_reset, has_resetn)

--- a/magma/clock_io.py
+++ b/magma/clock_io.py
@@ -1,4 +1,5 @@
-from .clock import AsyncReset, AsyncResetN, Clock, Enable, Reset, ResetN
+from .clock import (AbstractReset, AsyncReset, AsyncResetN, Clock, Enable,
+                    Reset, ResetN, get_reset_args)
 from .interface import IO
 from .t import In
 
@@ -18,3 +19,15 @@ def ClockIO(has_enable=False, has_reset=False, has_resetn=False, has_ce=False,
     if has_async_resetn:
         args['ASYNCRESETN'] = In(AsyncResetN)
     return IO(**args)
+
+
+def gen_clock_io(reset_type: AbstractReset = None, has_enable: bool = False):
+    (
+        has_async_reset, has_async_resetn, has_reset, has_resetn
+    ) = get_reset_args(reset_type)
+
+    return ClockIO(has_enable=has_enable,
+                   has_async_reset=has_async_reset,
+                   has_async_resetn=has_async_resetn,
+                   has_reset=has_reset,
+                   has_resetn=has_resetn)

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -12,8 +12,8 @@ from magma.interface import IO
 from magma.generator import Generator2
 from magma.t import Type, Kind, In, Out
 from magma.tuple import Tuple
-from magma.clock import (AbstractReset, Reset, ResetN, AsyncReset, AsyncResetN,
-                         Clock, Enable)
+from magma.clock import (AbstractReset,
+                         AsyncReset, AsyncResetN, Clock, get_reset_args)
 from magma.clock_io import ClockIO
 from magma.primitives.mux import Mux
 
@@ -116,16 +116,11 @@ class Register(Generator2):
             raise TypeError(
                 f"Expected instance of Type or int for argument init, not "
                 f"{type(init)}")
-        if reset_type is not None and not issubclass(reset_type, AbstractReset):
-            raise TypeError(
-                f"Expected subclass of AbstractReset for argument reset_type, "
-                f"not {type(reset_type)}")
+        (
+            has_async_reset, has_async_resetn, has_reset, has_resetn
+        ) = get_reset_args(reset_type)
 
         self.io = IO(I=In(T), O=Out(T))
-        has_async_reset = reset_type == AsyncReset
-        has_async_resetn = reset_type == AsyncResetN
-        has_reset = reset_type == Reset
-        has_resetn = reset_type == ResetN
         self.io += ClockIO(has_enable=has_enable,
                            has_async_reset=has_async_reset,
                            has_async_resetn=has_async_resetn,

--- a/tests/test_syntax/gold/TestSequential2Reset.v
+++ b/tests/test_syntax/gold/TestSequential2Reset.v
@@ -1,0 +1,87 @@
+module coreir_reg_arst #(
+    parameter width = 1,
+    parameter arst_posedge = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input arst,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg;
+  wire real_rst;
+  assign real_rst = arst_posedge ? arst : ~arst;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk, posedge real_rst) begin
+    if (real_rst) outReg <= init;
+    else outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module Mux2xUInt3 (
+    input [2:0] I0,
+    input [2:0] I1,
+    input S,
+    output [2:0] O
+);
+reg [2:0] coreir_commonlib_mux2x3_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x3_inst0_out = I0;
+end else begin
+    coreir_commonlib_mux2x3_inst0_out = I1;
+end
+end
+
+assign O = coreir_commonlib_mux2x3_inst0_out;
+endmodule
+
+module Register (
+    input [2:0] I,
+    output [2:0] O,
+    input CLK,
+    input CE,
+    input ASYNCRESET
+);
+wire [2:0] enable_mux_O;
+Mux2xUInt3 enable_mux (
+    .I0(O),
+    .I1(I),
+    .S(CE),
+    .O(enable_mux_O)
+);
+coreir_reg_arst #(
+    .arst_posedge(1'b1),
+    .clk_posedge(1'b1),
+    .init(3'h0),
+    .width(3)
+) reg_PR_inst0 (
+    .clk(CLK),
+    .arst(ASYNCRESET),
+    .in(enable_mux_O),
+    .out(O)
+);
+endmodule
+
+module Test2 (
+    output [2:0] O,
+    input CLK,
+    input CE,
+    input ASYNCRESET
+);
+wire [2:0] Register_inst0_O;
+wire [2:0] magma_Bits_3_add_inst0_out;
+Register Register_inst0 (
+    .I(magma_Bits_3_add_inst0_out),
+    .O(Register_inst0_O),
+    .CLK(CLK),
+    .CE(CE),
+    .ASYNCRESET(ASYNCRESET)
+);
+assign magma_Bits_3_add_inst0_out = 3'(Register_inst0_O + 3'h1);
+assign O = magma_Bits_3_add_inst0_out;
+endmodule
+

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -366,3 +366,19 @@ def test_sequential2_prev():
     m.compile("build/TestSequential2Prev", Test2, inline=True)
     assert check_files_equal(__file__, f"build/TestSequential2Prev.v",
                              f"gold/TestSequential2Prev.v")
+
+
+def test_sequential2_reset():
+    @m.sequential2(reset_type=m.AsyncReset, has_enable=True)
+    class Test2:
+        def __init__(self):
+            # reset_type and has_enable will be set implicitly
+            self.cnt = m.Register(T=m.UInt[3])()
+
+        def __call__(self) -> m.UInt[3]:
+            self.cnt = self.cnt + 1
+            return self.cnt
+
+    m.compile("build/TestSequential2Reset", Test2, inline=True)
+    assert check_files_equal(__file__, f"build/TestSequential2Reset.v",
+                             f"gold/TestSequential2Reset.v")


### PR DESCRIPTION
same as sequential, Register reset_type is set implicitly

    self.yield_state = m.Register(T=m.Bits[5], init=INIT_NOP1)()

    self.yield_state = m.Register(T=m.Bits[5], init=INIT_NOP1, reset_type=m.AsyncResetN)()