### PR TITLE
Improve error message for hanging wire

### DIFF
--- a/magma/passes/insert_coreir_wires.py
+++ b/magma/passes/insert_coreir_wires.py
@@ -104,6 +104,8 @@ class InsertCoreIRWires(DefinitionPass):
         if value in self.seen:
             return  # in the case of inouts, we may see more than once
         self.seen.add(value)
+        if not value.driven():
+            return  # undriven wire
         driver = value.value()
 
         while (driver is not None and driver.name.anon() and

--- a/magma/passes/insert_coreir_wires.py
+++ b/magma/passes/insert_coreir_wires.py
@@ -105,7 +105,7 @@ class InsertCoreIRWires(DefinitionPass):
             return  # in the case of inouts, we may see more than once
         self.seen.add(value)
         if not value.driven():
-            return  # undriven wire
+            return  # undriven value, skip wire insertion
         driver = value.value()
 
         while (driver is not None and driver.name.anon() and

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -181,6 +181,7 @@ def test_hanging_anon_error(caplog):
 
         try:
             m.compile("Foo", _Foo, output="coreir")
+            assert False, "Did not raise excpected exception"
         except Exception as e:
             assert str(e) == "Found unconnected port: _Foo.O"
 

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -16,7 +16,7 @@ def test_input_as_output(caplog):
         buf = Buf()
         wire(io.O, buf.I)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:15\033[0m: Using `.O` (an input) as an output
+\033[1mtests/test_wire/test_errors.py:17\033[0m: Using `.O` (an input) as an output
 >>         wire(io.O, buf.I)"""
     assert has_error(caplog, msg)
     magma.config.set_debug_mode(False)
@@ -34,7 +34,7 @@ def test_output_as_input(caplog):
         a = A()
         wire(io.I, a.O)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:33\033[0m: Using `..O` (an output) as an input
+\033[1mtests/test_wire/test_errors.py:35\033[0m: Using `..O` (an output) as an input
 >>         wire(io.I, a.O)"""
     assert has_error(caplog, msg)
     magma.config.set_debug_mode(False)
@@ -53,7 +53,7 @@ def test_multiple_outputs_to_input_warning(caplog):
         wire(io.I[0], a.I)
         wire(io.I[1], a.I)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:52\033[0m: Wiring multiple outputs to same wire, using last connection. Input: ..I,  Old Output: LazyCircuit.I[0],  New Output: LazyCircuit.I[1]
+\033[1mtests/test_wire/test_errors.py:54\033[0m: Wiring multiple outputs to same wire, using last connection. Input: ..I,  Old Output: LazyCircuit.I[0],  New Output: LazyCircuit.I[1]
 >>         wire(io.I[1], a.I)"""
     assert has_warning(caplog, msg)
     magma.config.set_debug_mode(False)
@@ -71,7 +71,7 @@ def test_muliple_outputs_circuit(caplog):
         a = A()
         wire(a, io.I)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:60\033[0m: Can only wire circuits with one output. Argument 0 to wire `.a` has outputs [inst0.O, inst0.U]
+\033[1mtests/test_wire/test_errors.py:62\033[0m: Can only wire circuits with one output. Argument 0 to wire `.a` has outputs [inst0.O, inst0.U]
 >>         wire(a, .I)"""
     assert has_warning(caplog, msg)
     magma.config.set_debug_mode(False)
@@ -89,7 +89,7 @@ def test_muliple_outputs_circuit(caplog):
         a = A()
     main.a(main)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:88\033[0m: Number of inputs is not equal to the number of outputs, expected 2 inputs, got 1. Only 1 will be wired.
+\033[1mtests/test_wire/test_errors.py:90\033[0m: Number of inputs is not equal to the number of outputs, expected 2 inputs, got 1. Only 1 will be wired.
 >>     main.a(main)"""
     assert has_warning(caplog, msg)
     magma.config.set_debug_mode(False)
@@ -107,7 +107,7 @@ def test_no_inputs_circuit(caplog):
         a = A()
         wire(io.I, a)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:106\033[0m: Wiring an output to a circuit with no input arguments, skipping
+\033[1mtests/test_wire/test_errors.py:108\033[0m: Wiring an output to a circuit with no input arguments, skipping
 >>         wire(io.I, a)"""
     assert has_warning(caplog, msg)
     magma.config.set_debug_mode(False)
@@ -125,7 +125,7 @@ def test_muliple_inputs_circuit(caplog):
         a = A()
         wire(io.I, a)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:124\033[0m: Wiring an output to a circuit with more than one input argument, using the first input ..I
+\033[1mtests/test_wire/test_errors.py:126\033[0m: Wiring an output to a circuit with more than one input argument, using the first input ..I
 >>         wire(io.I, a)"""
     assert has_warning(caplog, msg)
     magma.config.set_debug_mode(False)
@@ -143,7 +143,7 @@ def test_no_key(caplog):
         a = A()
         a(K=io.I)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:142\033[0m: Instance . does not have input K
+\033[1mtests/test_wire/test_errors.py:144\033[0m: Instance . does not have input K
 >>         a(K=io.I)"""
 
     assert has_warning(caplog, msg)
@@ -165,7 +165,7 @@ def test_const_array_error(caplog):
         wire(buf.O, io.O)
 
     msg = """\
-\033[1mtests/test_wire/test_errors.py:162\033[0m: Cannot wire 1 (type=<class 'int'>) to ..I (type=Array[1, In(Bit)]) because conversions from IntegerTypes are only defined for Bits, not general Arrays
+\033[1mtests/test_wire/test_errors.py:164\033[0m: Cannot wire 1 (type=<class 'int'>) to ..I (type=Array[1, In(Bit)]) because conversions from IntegerTypes are only defined for Bits, not general Arrays
 >>         wire(1, buf.I)"""
     assert caplog.records[0].msg == msg
     assert has_error(caplog, msg)

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -190,4 +190,3 @@ def test_hanging_anon_error(caplog):
 >>         class _Foo(m.Circuit):"""
         assert caplog.records[0].msg == msg
         assert has_error(caplog, msg)
-        magma.config.set_debug_mode(False)


### PR DESCRIPTION
Fixes #764

Inserts a guard in the insert_coreir_wires logic to avoid the exception from the missing driver.  Now it reports the standard exception for finding an undriven wire in the backend.