### PR TITLE
Prototype inline combinational

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -96,6 +96,7 @@ from .log import info, debug, warning, error
 
 from .syntax.sequential2 import sequential2
 from .syntax.combinational2 import combinational2
+from .syntax.inline_combinational import inline_combinational
 from .syntax.coroutine import coroutine
 
 from magma.primitives import (LUT, Mux, mux, Register, get_slice, set_slice,

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -88,8 +88,8 @@ class inline_combinational(apply_ast_passes):
         if not isinstance(result, tuple):
             result = (result,)
         for key, value in zip(self.target_map.keys(), result):
-            # Eval origin target in env to do wiring, not sure if there's a way
-            # we can avoid having to do eval here (other option is to codegen
-            # the original augassign in a new tree, but that's effectively the
-            # same as evaling)
+            # Eval original target in env to do wiring, not sure if there's a
+            # way we can avoid having to do eval here (other option is to
+            # codegen the original augassign in a new tree, but that's
+            # effectively the same as evaling)
             wire(eval(astor.to_source(mutable(key)).rstrip(), {}, env), value)

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -82,8 +82,8 @@ class inline_combinational(apply_ast_passes):
         super().__init__(passes=passes, env=env, debug=debug, path=path,
                          file_name=file_name)
 
-    def exec(self, etree, stree, env, metadata):
-        fn = super().exec(etree, stree, env, metadata)
+    def exec(self, *args, **kwargs):
+        fn = super().exec(*args, **kwargs)
         result = fn()
         if not isinstance(result, tuple):
             result = (result,)

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -79,12 +79,6 @@ class inline_combinational(apply_ast_passes):
 
     def exec(self, etree, stree, env, metadata):
         fn = super().exec(etree, stree, env, metadata)
-        annotations = {}
-        # TODO: Introspect type, for now we assume Bit
-        if len(self.target_map) > 1:
-            annotations["return"] = tuple(Bit for _ in self.target_map)
-        else:
-            annotations["return"] = Bit
         result = fn()
         if not isinstance(result, tuple):
             result = (result,)

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -82,8 +82,8 @@ class inline_combinational(apply_ast_passes):
         super().__init__(passes=passes, env=env, debug=debug, path=path,
                          file_name=file_name)
 
-    def exec(self, *args, **kwargs):
-        fn = super().exec(*args, **kwargs)
+    def exec(self, etree, stree, env):
+        fn = super().exec(etree, stree, env)
         result = fn()
         if not isinstance(result, tuple):
             result = (result,)

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -1,0 +1,92 @@
+import ast
+from typing import MutableMapping, Optional
+
+import astor
+
+from ast_tools.stack import SymbolTable
+from ast_tools.passes import (apply_ast_passes, Pass, PASS_ARGS_T, ssa,
+                              if_to_phi, bool_to_bit)
+from ast_tools.common import gen_free_prefix
+from ast_tools.immutable_ast import immutable, mutable
+
+from magma.syntax.combinational2 import combinational2
+from magma.bit import Bit
+from magma.wire import wire
+
+
+class _ToCombinationalRewriter(ast.NodeTransformer):
+    def __init__(self, free_prefix, target_map):
+        self.prefix = free_prefix
+        self.target_map = target_map
+        self.name_count = 0
+
+    def _gen_new_name(self):
+        new_name = f"{self.prefix}{self.name_count}"
+        self.name_count += 1
+        return new_name
+
+    def visit_Attribute(self, node):
+        if isinstance(node.ctx, ast.Store):
+            key = immutable(node)
+            if key not in self.target_map:
+                retval_name = self._gen_new_name()
+                self.target_map[key] = retval_name
+            return ast.Name(self.target_map[key], ast.Store())
+        return node
+
+
+class _RewriteToCombinational(Pass):
+    """
+    Replace assignment targets with a temporary value (so it is handled
+    properly by SSA), store the mapping from temporary values so they can be
+    wired up later, "inputs" will just read from the enclosing scope
+    """
+    def __init__(self, target_map):
+        super().__init__()
+        self.target_map = target_map
+
+    def rewrite(
+        self, tree: ast.AST, env: SymbolTable, metadata: MutableMapping
+    ) -> PASS_ARGS_T:
+        # prefix used for temporaries
+        prefix = gen_free_prefix(tree, env)
+        tree = _ToCombinationalRewriter(prefix, self.target_map).visit(tree)
+        elts = ()
+        for value in self.target_map.values():
+            elts += (ast.Name(value, ast.Load()),)
+        if len(elts) > 1:
+            retval = ast.Tuple(elts, ast.Load())
+        else:
+            retval = elts[0]
+        tree.body.append(ast.Return(retval))
+        return tree, env, metadata
+
+
+class inline_combinational(apply_ast_passes):
+    def __init__(self, pre_passes=[], post_passes=[],
+                 debug: bool = False,
+                 env: Optional[SymbolTable] = None,
+                 path: Optional[str] = None,
+                 file_name: Optional[str] = None
+                 ):
+        self.target_map = {}
+        passes = (pre_passes + [_RewriteToCombinational(self.target_map),
+                                ssa(strict=False), bool_to_bit(),
+                                if_to_phi(lambda s, t, f: s.ite(t, f))] +
+                  post_passes)
+        super().__init__(passes=passes, env=env, debug=debug, path=path,
+                         file_name=file_name)
+
+    def exec(self, etree, stree, env, metadata):
+        fn = super().exec(etree, stree, env, metadata)
+        annotations = {}
+        # TODO: Introspect type, for now we assume Bit
+        if len(self.target_map) > 1:
+            annotations["return"] = tuple(Bit for _ in self.target_map)
+        else:
+            annotations["return"] = Bit
+        result = fn()
+        if not isinstance(result, tuple):
+            result = (result,)
+        for key, value in zip(self.target_map.keys(), result):
+            wire(eval(astor.to_source(mutable(key)).rstrip(), {}, env), value)

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -73,11 +73,8 @@ class inline_combinational(apply_ast_passes):
                  ):
         self.target_map = {}
         passes = (pre_passes + [_RewriteToCombinational(self.target_map),
-                                ast_tools.passes.debug(dump_src=True),
                                 ssa(strict=False), bool_to_bit(),
-                                if_to_phi(lambda s, t, f: s.ite(t, f)),
-                                ast_tools.passes.debug(dump_src=True),
-                                ] +
+                                if_to_phi(Bit.ite)] +
                   post_passes)
         super().__init__(passes=passes, env=env, debug=debug, path=path,
                          file_name=file_name)

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -38,9 +38,9 @@ class _ToCombinationalRewriter(ast.NodeTransformer):
 
 class _RewriteToCombinational(Pass):
     """
-    Replace assignment targets with a temporary value (so it is handled
-    properly by SSA), store the mapping from temporary values so they can be
-    wired up later, "inputs" will just read from the enclosing scope
+    Replace wiring targets with a temporary value (so it is handled properly by
+    SSA), store the mapping from temporary values so they can be wired up
+    later, "inputs" will just read from the enclosing scope
     """
     def __init__(self, target_map):
         super().__init__()

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -25,14 +25,15 @@ class _ToCombinationalRewriter(ast.NodeTransformer):
         self.name_count += 1
         return new_name
 
-    def visit_Attribute(self, node):
-        if isinstance(node.ctx, ast.Store):
-            key = immutable(node)
-            if key not in self.target_map:
-                retval_name = self._gen_new_name()
-                self.target_map[key] = retval_name
-            return ast.Name(self.target_map[key], ast.Store())
-        return node
+    def visit_AugAssign(self, node):
+        if not isinstance(node.op, ast.MatMult):
+            return
+        key = immutable(node.target)
+        if key not in self.target_map:
+            retval_name = self._gen_new_name()
+            self.target_map[key] = retval_name
+        target = ast.Name(self.target_map[key], ast.Store())
+        return ast.Assign([target], node.value)
 
 
 class _RewriteToCombinational(Pass):

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -55,8 +55,8 @@ class _RewriteToCombinational(Pass):
         tree = _ToCombinationalRewriter(prefix, self.target_map).visit(tree)
 
         # Return augassign targets for wiring
-        elts = [ast.Name(value, ast.Load()) for value in
-                self.target_map.values()]
+        elts = [ast.Name(value, ast.Load())
+                for value in self.target_map.values()]
         if len(elts) > 1:
             retval = ast.Tuple(elts, ast.Load())
         else:

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -57,10 +57,7 @@ class _RewriteToCombinational(Pass):
         # Return augassign targets for wiring
         elts = [ast.Name(value, ast.Load())
                 for value in self.target_map.values()]
-        if len(elts) > 1:
-            retval = ast.Tuple(elts, ast.Load())
-        else:
-            retval = elts[0]
+        retval = ast.Tuple(elts, ast.Load()) if len(elts) > 1 else elts[0]
         tree.body.append(ast.Return(retval))
 
         return tree, env, metadata

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -55,9 +55,8 @@ class _RewriteToCombinational(Pass):
         tree = _ToCombinationalRewriter(prefix, self.target_map).visit(tree)
 
         # Return augassign targets for wiring
-        elts = ()
-        for value in self.target_map.values():
-            elts += (ast.Name(value, ast.Load()),)
+        elts = [ast.Name(value, ast.Load()) for value in
+                self.target_map.values()]
         if len(elts) > 1:
             retval = ast.Tuple(elts, ast.Load())
         else:

--- a/tests/test_syntax/gold/test_inline_comb_basic.v
+++ b/tests/test_syntax/gold/test_inline_comb_basic.v
@@ -1,0 +1,74 @@
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module Register (
+    input I,
+    output O,
+    input CLK
+);
+wire [0:0] reg_P_inst0_out;
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(1'h0),
+    .width(1)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in(I),
+    .out(reg_P_inst0_out)
+);
+assign O = reg_P_inst0_out[0];
+endmodule
+
+module Mux2xOutBit (
+    input I0,
+    input I1,
+    input S,
+    output O
+);
+reg [0:0] coreir_commonlib_mux2x1_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x1_inst0_out = I0;
+end else begin
+    coreir_commonlib_mux2x1_inst0_out = I1;
+end
+end
+
+assign O = coreir_commonlib_mux2x1_inst0_out[0];
+endmodule
+
+module Main (
+    input I,
+    input invert,
+    output O,
+    input CLK
+);
+wire Mux2xOutBit_inst0_O;
+Mux2xOutBit Mux2xOutBit_inst0 (
+    .I0(O),
+    .I1(~ O),
+    .S(invert),
+    .O(Mux2xOutBit_inst0_O)
+);
+Register Register_inst0 (
+    .I(Mux2xOutBit_inst0_O),
+    .O(O),
+    .CLK(CLK)
+);
+endmodule
+

--- a/tests/test_syntax/gold/test_inline_comb_basic.v
+++ b/tests/test_syntax/gold/test_inline_comb_basic.v
@@ -53,7 +53,6 @@ assign O = coreir_commonlib_mux2x1_inst0_out[0];
 endmodule
 
 module Main (
-    input I,
     input invert,
     output O,
     input CLK

--- a/tests/test_syntax/test_inline_comb.py
+++ b/tests/test_syntax/test_inline_comb.py
@@ -4,7 +4,7 @@ from magma.testing import check_files_equal
 
 def test_inline_comb_basic():
     class Main(m.Circuit):
-        io = m.IO(I=m.In(m.Bit), invert=m.In(m.Bit), O=m.Out(m.Bit))
+        io = m.IO(invert=m.In(m.Bit), O=m.Out(m.Bit))
         io += m.ClockIO()
         reg = m.Register(m.Bit)()
 

--- a/tests/test_syntax/test_inline_comb.py
+++ b/tests/test_syntax/test_inline_comb.py
@@ -11,9 +11,9 @@ def test_inline_comb_basic():
         @m.inline_combinational(debug=True, file_name="inline_comb.py")
         def logic():
             if io.invert:
-                reg.I = ~reg.O
+                reg.I @= ~reg.O
             else:
-                reg.I = reg.O
+                reg.I @= reg.O
 
         io.O @= reg.O
 

--- a/tests/test_syntax/test_inline_comb.py
+++ b/tests/test_syntax/test_inline_comb.py
@@ -1,0 +1,22 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_inline_comb_basic():
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), invert=m.In(m.Bit), O=m.Out(m.Bit))
+        io += m.ClockIO()
+        reg = m.Register(m.Bit)()
+
+        @m.inline_combinational(debug=True, file_name="inline_comb.py")
+        def logic():
+            if io.invert:
+                reg.I = ~reg.O
+            else:
+                reg.I = reg.O
+
+        io.O @= reg.O
+
+    m.compile("build/test_inline_comb_basic", Main, inline=True)
+    assert check_files_equal(__file__, f"build/test_inline_comb_basic.v",
+                             f"gold/test_inline_comb_basic.v")


### PR DESCRIPTION
See https://github.com/phanrahan/magma/issues/759 for some background.

The goal is to provide the ability to write combinational syntax while referring to the enclosing scope.  This avoids having to pass and return values (tedious when there's a large number inside the module definition).

The minimum working example for prototyping:
```python
    class Main(m.Circuit):
        io = m.IO(invert=m.In(m.Bit), O=m.Out(m.Bit))
        io += m.ClockIO()
        reg = m.Register(m.Bit)()

        @m.inline_combinational(debug=True, file_name="inline_comb.py")
        def logic():
            if io.invert:
                reg.I = ~reg.O
            else:
                reg.I = reg.O

        io.O @= reg.O
```

The basic algorithm:
1. rewrite the tree so that all wiring is done as assignments to temporaries, return the temporaries at the end.  AugAssignment targets are mapped to a temporary value based on their immutable hash (structure).  This allows us to run generic SSA (since it's defined for variable assignments, rather than wiring to general objects).
1. run standard combinational passes on the tree
1. exec the function, call it to get the return values (the execution should use the enclosing scope so references will work), then wire the return values (temporaries) to the actual values stored in the mapping (original AugAssign AST node target hash).

For step 1, the above example is rewritten into:
```python
def logic():
    _auto_prefix_000 = ~reg.O
    _auto_prefix_001 = reg.O
    _auto_prefix_002 = __phi(io.invert, _auto_prefix_000, _auto_prefix_001)
    __return_value0 = _auto_prefix_002
    return __return_value0
```
(the first digit is from gen_free_prefix, the second digit is the unique id for each new temporary added with prefix (only 1 in this case), the third digit is from ssa)

I chose this path rather than rewriting to a standard comb2 function because there were some non-trivial analysis required.  For example, we would need to analyze the source to determine the input types (e.g. reg.O) and the output types (e.g. the final value of reg.I).  By simply doing the rewrites and executing them in the enclosing scope (without the comb2 wrapper), we avoid having to do this analysis.

Open to suggestions on how we could improve the algorithm as well as edge cases that we should watch out for.