### PR TITLE
Adds support for `namespace` override in Circuit

### DIFF
--- a/magma/backend/coreir_compiler.py
+++ b/magma/backend/coreir_compiler.py
@@ -40,8 +40,6 @@ def _make_opts(backend, opts):
     user_namespace = opts.get("user_namespace", None)
     if user_namespace is not None:
         out["user_namespace"] = backend.context.new_namespace(user_namespace)
-    else:
-        out["user_namespace"] = backend.context.global_namespace
     return out
 
 

--- a/magma/backend/coreir_compiler.py
+++ b/magma/backend/coreir_compiler.py
@@ -40,6 +40,8 @@ def _make_opts(backend, opts):
     user_namespace = opts.get("user_namespace", None)
     if user_namespace is not None:
         out["user_namespace"] = backend.context.new_namespace(user_namespace)
+    else:
+        out["user_namespace"] = backend.context.global_namespace
     return out
 
 
@@ -65,7 +67,8 @@ class CoreIRCompiler(Compiler):
                        not config.fast_coreir_verilog_compile)
         if output_json:
             filename = f"{self.basename}.json"
-            backend.modules[self.main.coreir_name].save_to_file(filename)
+            backend.context.set_top(backend.modules[self.main.coreir_name])
+            backend.context.save_to_file(filename, include_default_libs=False)
         if self.opts.get("output_verilog", False):
             fn = (self._fast_compile_verilog
                   if config.fast_coreir_verilog_compile

--- a/magma/backend/coreir_transformer.py
+++ b/magma/backend/coreir_transformer.py
@@ -381,10 +381,11 @@ class DeclarationTransformer(LeafTransformer):
             # Allows users to choose namespace explicitly with
             # class MyCircuit(m.Circuit):
             #     namespace = "foo"
+            # overrides user_namespace setting
             namespace = self.backend.libs[self.decl.namespace]
         else:
-            # default is global_namespace, see coreir_compiler.py _make_opts
-            namespace = self.opts["user_namespace"]
+            namespace = self.opts.get("user_namespace",
+                                      self.backend.context.global_namespace)
         coreir_module = namespace.new_module(
             self.decl.coreir_name, module_type, **kwargs)
         if get_codegen_debug_info() and self.decl.debug_info:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='magma-lang',
-    version='2.0.68',
+    version='2.0.69',
     url='https://github.com/phanrahan/magma',
     license='MIT',
     maintainer='Lenny Truong',
@@ -33,7 +33,7 @@ setup(
         "pyverilog",
         "numpy",
         "graphviz",
-        "coreir>=2.0.87",
+        "coreir>=2.0.88",
         "hwtypes>=1.0.*",
         "ast_tools>=0.0.16",
         "kratos",

--- a/tests/test_compile/gold/test_user_namespace_override.v
+++ b/tests/test_compile/gold/test_user_namespace_override.v
@@ -1,0 +1,13 @@
+// Module `Foo` defined externally
+module my_namespace_Main (
+    input I,
+    output O
+);
+wire Foo_inst0_O;
+Foo Foo_inst0 (
+    .I(I),
+    .O(Foo_inst0_O)
+);
+assign O = Foo_inst0_O;
+endmodule
+


### PR DESCRIPTION
Allows the user to override the default `user_namespace` for certain
circuits.  Needed for imported verilog circuits that should not include
the user_namespace prefix (as their name is defined in an external file
that is not changed).

Depends on https://github.com/rdaly525/coreir/pull/922 and https://github.com/leonardt/pycoreir/pull/138