### PR TITLE
Add support for normal assign to inline_combinational

### DIFF
--- a/docs/inline_combinational.md
+++ b/docs/inline_combinational.md
@@ -1,0 +1,90 @@
+**NOTE** This is an experimental feature, you will likely encounter bugs.
+Please use GitHub Issues to report any problems or to provide us with feedback
+on how to improve the syntax.
+
+# Overview
+The goal of the `m.inline_combinational` syntax is to improve the ergonomics of
+using the `m.combinational` syntax described [here](./circuit_definitions.md).
+
+`inline_combinational` avoids having to define function parameters, pass
+arguments, and assign return values when defining a combinational block.  Instead,
+the user can define a `combinational` function inside their `m.Circuit` class
+defintiion and refer directly to magma values in the scope.  
+
+Here's a simple example:
+
+```python
+class Main(m.Circuit):
+    io = m.IO(invert=m.In(m.Bit), O0=m.Out(m.Bit), O1=m.Out(m.Bit))
+    io += m.ClockIO()
+    reg = m.Register(m.Bit)()
+
+    @m.inline_combinational(debug=True, file_name="inline_comb.py")
+    def logic():
+        if io.invert:
+            reg.I @= ~reg.O
+            O1 = ~reg.O
+        else:
+            reg.I @= reg.O
+            O1 = reg.O
+
+    io.O0 @= reg.O
+    io.O1 @= O1
+```
+
+Notice that the first 3 lines of `Main`'s definition are standard magma.
+
+Inside the function `logic` that has been decorated with
+`@m.inline_combinational`, the user can refer to `reg` (a normal magma
+instance) and it's ports to perform logic and wiring.  The definition of
+`logic` shows two ways to use the `combinational` rewrite to generate a muxes.
+
+The first way wires to `reg.I` using the `@=` operator inside the if statement.
+The `combinational` rewrite logic will change these statements to assign to a
+temporary value, which will then get process by the SSA pass to produce the
+final value (output of a mux or chain of muxes) which is then wired to the
+original target (`reg.I` in this case).
+
+The second way assigns to a temporary value `O1`.  This value is handled using
+the standard `combinational` treatment and the final value produced by SSA is
+returned from the function and assigned in the enclosing environment.
+
+For more details on the rewrites, here are two dumps of the intermediate code
+during the `inline_combinational` rewrite process:
+1. Introduce temporary values.  At this point, the wiring targets (LHS of `@=`
+   operators) and assignment targets are replaced with a temporary values
+   (using the prefix `auto_prefix0`, so `auto_prefix00` is the first temporary,
+   `auto_prefix01` is the second temporary, the 2nd digit is used for the
+   unique id). These temporary values are returned from the function.
+   ```python
+   @m.inline_combinational(debug=True, file_name='inline_comb.py')
+   def logic():
+       if io.invert:
+           _auto_prefix_00 = ~reg.O
+           _auto_prefix_01 = ~reg.O
+       else:
+           _auto_prefix_00 = reg.O
+           _auto_prefix_01 = reg.O
+       return _auto_prefix_00, _auto_prefix_01
+   ```
+2. Run the standard combinational passes.  This removes the if statements by
+   transforming them into muxes using SSA.  Notice the temporaries have an
+   extra digit attached, which is a unique identifier introduced by SSA.
+   ```python
+   @m.inline_combinational(debug=True, file_name='inline_comb.py')
+   def logic():
+       _auto_prefix_000 = ~reg.O
+       _auto_prefix_010 = ~reg.O
+       _auto_prefix_001 = reg.O
+       _auto_prefix_011 = reg.O
+       _auto_prefix_002 = __phi(io.invert, _auto_prefix_000, _auto_prefix_001)
+       _auto_prefix_012 = __phi(io.invert, _auto_prefix_010, _auto_prefix_011)
+       __return_value0 = _auto_prefix_002, _auto_prefix_012
+       return __return_value0
+   ```
+
+After this rewrite process, the `inline_combinational` logic calls the function
+to produce the return value.  The function execution uses the enclosing scope
+(so references like `reg.O` should behave as expected).  The return values are
+either wired to their target (e.g. `reg.I @= _auto_prefix_002`) or assigned to
+their target value in the enclosing scope (e.g. `O1 = auto_prefix012`).

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -4,10 +4,10 @@ from typing import MutableMapping, Optional
 import astor
 
 import ast_tools
-from ast_tools.stack import SymbolTable
+from ast_tools.stack import SymbolTable, _SKIP_FRAME_DEBUG_STMT, get_symbol_table
 from ast_tools.passes import (apply_ast_passes, Pass, PASS_ARGS_T, ssa,
                               if_to_phi, bool_to_bit)
-from ast_tools.common import gen_free_prefix
+from ast_tools.common import gen_free_prefix, gen_free_name
 from ast_tools.immutable_ast import immutable, mutable
 
 from magma.syntax.combinational2 import combinational2
@@ -16,9 +16,10 @@ from magma.wire import wire
 
 
 class _ToCombinationalRewriter(ast.NodeTransformer):
-    def __init__(self, free_prefix, target_map):
+    def __init__(self, free_prefix, wire_map, assign_map):
         self.prefix = free_prefix
-        self.target_map = target_map
+        self.wire_map = wire_map
+        self.assign_map = assign_map
         self.name_count = 0
 
     def _gen_new_name(self):
@@ -30,11 +31,18 @@ class _ToCombinationalRewriter(ast.NodeTransformer):
         if not isinstance(node.op, ast.MatMult):
             return node
         key = immutable(node.target)
-        if key not in self.target_map:
-            retval_name = self._gen_new_name()
-            self.target_map[key] = retval_name
-        target = ast.Name(self.target_map[key], ast.Store())
+        if key not in self.wire_map:
+            self.wire_map[key] = self._gen_new_name()
+        target = ast.Name(self.wire_map[key], ast.Store())
         return ast.Assign([target], node.value)
+
+    def visit_Assign(self, node):
+        for i, target in enumerate(node.targets):
+            key = immutable(node.targets[i])
+            if key not in self.assign_map:
+                self.assign_map[key] = self._gen_new_name()
+            node.targets[i] = ast.Name(self.assign_map[key], ast.Store())
+        return node
 
 
 class _RewriteToCombinational(Pass):
@@ -42,10 +50,14 @@ class _RewriteToCombinational(Pass):
     Replace wiring targets with a temporary value (so it is handled properly by
     SSA), store the mapping from temporary values so they can be wired up
     later, "inputs" will just read from the enclosing scope
+
+    Replace assign targets with a temporary value, assign the final value
+    returned by SSA
     """
-    def __init__(self, target_map):
+    def __init__(self, wire_map, assign_map):
         super().__init__()
-        self.target_map = target_map
+        self.wire_map = wire_map
+        self.assign_map = assign_map
 
     def rewrite(
         self, tree: ast.AST, env: SymbolTable, metadata: MutableMapping
@@ -53,11 +65,13 @@ class _RewriteToCombinational(Pass):
         # prefix used for temporaries
         prefix = gen_free_prefix(tree, env)
 
-        tree = _ToCombinationalRewriter(prefix, self.target_map).visit(tree)
+        tree = _ToCombinationalRewriter(prefix, self.wire_map,
+                                        self.assign_map).visit(tree)
 
-        # Return augassign targets for wiring
-        elts = [ast.Name(value, ast.Load())
-                for value in self.target_map.values()]
+        # Return targets for wiring
+        return_values = (list(self.wire_map.values()) +
+                         list(self.assign_map.values()))
+        elts = [ast.Name(value, ast.Load()) for value in return_values]
         retval = ast.Tuple(elts, ast.Load()) if len(elts) > 1 else elts[0]
         tree.body.append(ast.Return(retval))
 
@@ -71,8 +85,12 @@ class inline_combinational(apply_ast_passes):
                  path: Optional[str] = None,
                  file_name: Optional[str] = None
                  ):
-        self.target_map = {}
-        passes = (pre_passes + [_RewriteToCombinational(self.target_map),
+        if env is None:
+            env = get_symbol_table([self.__init__])
+        self.wire_map = {}
+        self.assign_map = {}
+        passes = (pre_passes + [_RewriteToCombinational(self.wire_map,
+                                                        self.assign_map),
                                 ssa(strict=False), bool_to_bit(),
                                 if_to_phi(Bit.ite)] +
                   post_passes)
@@ -84,9 +102,15 @@ class inline_combinational(apply_ast_passes):
         result = fn()
         if not isinstance(result, tuple):
             result = (result,)
-        for key, value in zip(self.target_map.keys(), result):
+        for key, value in zip(self.wire_map.keys(), result):
             # Eval original target in env to do wiring, not sure if there's a
             # way we can avoid having to do eval here (other option is to
             # codegen the original augassign in a new tree, but that's
             # effectively the same as evaling)
             wire(eval(astor.to_source(mutable(key)).rstrip(), {}, env), value)
+        for key, value in zip(self.assign_map.keys(),
+                              result[len(self.wire_map):]):
+            value_name = gen_free_name(ast.NameConstant(False), env)
+            env.locals.update({value_name: value})
+            exec(f"{astor.to_source(mutable(key)).rstrip()} = {value_name}",
+                 env.globals, env.locals)

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -68,7 +68,7 @@ class _RewriteToCombinational(Pass):
         tree = _ToCombinationalRewriter(prefix, self.wire_map,
                                         self.assign_map).visit(tree)
 
-        # Return targets for wiring
+        # Return targets for wiring and assignments
         return_values = (list(self.wire_map.values()) +
                          list(self.assign_map.values()))
         elts = [ast.Name(value, ast.Load()) for value in return_values]

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -4,7 +4,7 @@ from typing import MutableMapping, Optional
 import astor
 
 import ast_tools
-from ast_tools.stack import SymbolTable, _SKIP_FRAME_DEBUG_STMT, get_symbol_table
+from ast_tools.stack import SymbolTable, get_symbol_table
 from ast_tools.passes import (apply_ast_passes, Pass, PASS_ARGS_T, ssa,
                               if_to_phi, bool_to_bit)
 from ast_tools.common import gen_free_prefix, gen_free_name

--- a/tests/test_syntax/gold/test_inline_comb_basic.v
+++ b/tests/test_syntax/gold/test_inline_comb_basic.v
@@ -54,19 +54,26 @@ endmodule
 
 module Main (
     input invert,
-    output O,
+    output O0,
+    output O1,
     input CLK
 );
 wire Mux2xOutBit_inst0_O;
 Mux2xOutBit Mux2xOutBit_inst0 (
-    .I0(O),
-    .I1(~ O),
+    .I0(O0),
+    .I1(~ O0),
     .S(invert),
     .O(Mux2xOutBit_inst0_O)
 );
+Mux2xOutBit Mux2xOutBit_inst1 (
+    .I0(O0),
+    .I1(~ O0),
+    .S(invert),
+    .O(O1)
+);
 Register Register_inst0 (
     .I(Mux2xOutBit_inst0_O),
-    .O(O),
+    .O(O0),
     .CLK(CLK)
 );
 endmodule

--- a/tests/test_syntax/test_inline_comb.py
+++ b/tests/test_syntax/test_inline_comb.py
@@ -4,7 +4,7 @@ from magma.testing import check_files_equal
 
 def test_inline_comb_basic():
     class Main(m.Circuit):
-        io = m.IO(invert=m.In(m.Bit), O=m.Out(m.Bit))
+        io = m.IO(invert=m.In(m.Bit), O0=m.Out(m.Bit), O1=m.Out(m.Bit))
         io += m.ClockIO()
         reg = m.Register(m.Bit)()
 
@@ -12,10 +12,13 @@ def test_inline_comb_basic():
         def logic():
             if io.invert:
                 reg.I @= ~reg.O
+                O1 = ~reg.O
             else:
                 reg.I @= reg.O
+                O1 = reg.O
 
-        io.O @= reg.O
+        io.O0 @= reg.O
+        io.O1 @= O1
 
     m.compile("build/test_inline_comb_basic", Main, inline=True)
     assert check_files_equal(__file__, f"build/test_inline_comb_basic.v",


### PR DESCRIPTION
Extends inline_combinational to support normal assignment statements.  These are handled similarly to wiring where the final value (determined by SSA) is returned from function and an assignment statement is "execed" (ugh, but not sure if there's a way around this without rewriting the AST from the enclosing scope, which probably isn't much better) with the return value from the rewritten inline_combinational function call