### PR TITLE
Fix #778

### DIFF
--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -14,6 +14,7 @@ from .bfloat import BFloat
 from .digital import Digital
 from .tuple import Tuple, Product
 from .bitutils import int2seq
+from .protocol_type import get_type, get_value
 import hwtypes
 
 __all__ = ['bit']
@@ -276,12 +277,12 @@ def _tuple(value, n=None, t=Tuple):
     if isinstance(value, Sequence):
         ts = list(value)
         for i in range(len(ts)):
-            args.append(ts[i])
-            decl[i] = type(ts[i])
+            args.append(get_value(ts[i]))
+            decl[i] = get_type(ts[i])
     elif isinstance(value, Mapping):
         for k, v in value.items():
-            args.append(v)
-            decl[k] = type(v)
+            args.append(get_value(v))
+            decl[k] = get_type(v)
     for a, d in zip(args, decl):
         # bool types to Bit
         if decl[d] is bool:

--- a/magma/protocol_type.py
+++ b/magma/protocol_type.py
@@ -93,3 +93,9 @@ def get_type(value):
     if issubclass(T, MagmaProtocol):
         return T._to_magma_()
     return T
+
+
+def get_value(value):
+    if isinstance(value, MagmaProtocol):
+        return value._get_magma_value_()
+    return value

--- a/tests/test_syntax/gold/TestSequential2Ite.v
+++ b/tests/test_syntax/gold/TestSequential2Ite.v
@@ -1,0 +1,98 @@
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module Register (
+    input I,
+    output O,
+    input CLK
+);
+wire [0:0] reg_P_inst0_out;
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(1'h0),
+    .width(1)
+) reg_P_inst0 (
+    .clk(CLK),
+    .in(I),
+    .out(reg_P_inst0_out)
+);
+assign O = reg_P_inst0_out[0];
+endmodule
+
+module Mux2xTuplea_OutBit (
+    input I0_a,
+    input I1_a,
+    output O_a,
+    input S
+);
+reg [0:0] coreir_commonlib_mux2x1_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x1_inst0_out = I0_a;
+end else begin
+    coreir_commonlib_mux2x1_inst0_out = I1_a;
+end
+end
+
+assign O_a = coreir_commonlib_mux2x1_inst0_out[0];
+endmodule
+
+module Mux2xOutBit (
+    input I0,
+    input I1,
+    input S,
+    output O
+);
+reg [0:0] coreir_commonlib_mux2x1_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x1_inst0_out = I0;
+end else begin
+    coreir_commonlib_mux2x1_inst0_out = I1;
+end
+end
+
+assign O = coreir_commonlib_mux2x1_inst0_out[0];
+endmodule
+
+module Test (
+    input CLK,
+    output O_a,
+    input sel
+);
+wire Mux2xOutBit_inst0_O;
+wire Register_inst0_O;
+Mux2xOutBit Mux2xOutBit_inst0 (
+    .I0(sel),
+    .I1(sel),
+    .S(sel),
+    .O(Mux2xOutBit_inst0_O)
+);
+Mux2xTuplea_OutBit Mux2xTuplea_OutBit_inst0 (
+    .I0_a(Register_inst0_O),
+    .I1_a(Register_inst0_O),
+    .O_a(O_a),
+    .S(sel)
+);
+Register Register_inst0 (
+    .I(Mux2xOutBit_inst0_O),
+    .O(Register_inst0_O),
+    .CLK(CLK)
+);
+endmodule
+

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -382,3 +382,21 @@ def test_sequential2_reset():
     m.compile("build/TestSequential2Reset", Test2, inline=True)
     assert check_files_equal(__file__, f"build/TestSequential2Reset.v",
                              f"gold/TestSequential2Reset.v")
+
+
+def test_sequential2_ite():
+    @m.sequential2()
+    class Test:
+        def __init__(self):
+            self.v = m.Register(T=m.Bit, init=m.bit(0))()
+
+        def __call__(self, sel: m.Bit) -> m.AnonProduct[dict(a=m.Bit)]:
+            self.v = sel
+            if sel:
+                return m.namedtuple(a=self.v.prev())
+            else:
+                return m.namedtuple(a=self.v.prev())
+
+    m.compile("build/TestSequential2Ite", Test, inline=True)
+    assert check_files_equal(__file__, f"build/TestSequential2Ite.v",
+                             f"gold/TestSequential2Ite.v")


### PR DESCRIPTION
Convert MagmaProtocol type/value in `_tuple` to fix #778.

(Another option would be keeping MagmaProtocol inside Tuple/Product and dealing it with later. Most likely it requires a lot of code changes, but no particular benefits?)