### PR TITLE
Only call set top if main is a definition

### DIFF
--- a/magma/backend/coreir_compiler.py
+++ b/magma/backend/coreir_compiler.py
@@ -3,6 +3,7 @@ import subprocess
 from .coreir_ import InsertWrapCasts
 from ..compiler import Compiler
 from ..frontend import coreir_ as coreir_frontend
+from ..is_definition import isdefinition
 from ..passes import InstanceGraphPass
 from ..passes.insert_coreir_wires import InsertCoreIRWires
 from ..logging import root_logger
@@ -65,7 +66,8 @@ class CoreIRCompiler(Compiler):
                        not config.fast_coreir_verilog_compile)
         if output_json:
             filename = f"{self.basename}.json"
-            backend.context.set_top(backend.modules[self.main.coreir_name])
+            if isdefinition(self.main):
+                backend.context.set_top(backend.modules[self.main.coreir_name])
             backend.context.save_to_file(filename, include_default_libs=False)
         if self.opts.get("output_verilog", False):
             fn = (self._fast_compile_verilog


### PR DESCRIPTION
This fixes a regression introduced by #775.  In order to support
user_namespace, we changed the logic to save the entire context instead
of just saving the top module.  Before, saving the top module worked
since it just passed a name (str) ref to the fileWriter logic which was
used to emit the top reference (see
https://github.com/rdaly525/coreir/blob/5b4e98355e8f849f2ede137e32f8280d8a28f7d1/src/passes/analysis/coreirjson.cpp#L367).
This unblocks downstream users that have a top that is a declaration
(coreir's Context.setTop will error if trying to call setTop with a
declaration).  Later on we could change setTop to accept a declaration
rather than a definition, but I'm not sure if that's important (because
marking a declaration as Top isn't really useful since there's no
dependency graph to trace from the top anyways).