### PR TITLE
Let kratos be an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
 - pip install twine
 - pip install python-coveralls
 - pip install pytest-cov pytest-codestyle fault
+- pip install kratos  # test optional dependency
 - pip install -e .
 script:
 - py.test --cov magma -v --cov-report term-missing tests

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -20,8 +20,12 @@ from .is_definition import isdefinition
 from .placer import Placer, StagedPlacer
 from magma.syntax.combinational import combinational
 from magma.syntax.sequential import sequential
-from magma.syntax.verilog import combinational_to_verilog, \
-    sequential_to_verilog
+try:
+    import kratos
+    from magma.syntax.verilog import combinational_to_verilog, \
+        sequential_to_verilog
+except ImportError:
+    pass
 from .view import PortView
 from magma.protocol_type import MagmaProtocol
 

--- a/magma/syntax/__init__.py
+++ b/magma/syntax/__init__.py
@@ -1,2 +1,6 @@
 from magma.syntax.combinational import combinational
-from magma.syntax.verilog import build_kratos_debug_info
+try:
+    import kratos
+    from magma.syntax.verilog import build_kratos_debug_info
+except ImportError:
+    pass

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "coreir>=2.0.98",
         "hwtypes>=1.0.*",
         "ast_tools>=0.0.16",
-        "kratos",
         "staticfg"
     ],
     python_requires='>=3.6',


### PR DESCRIPTION
Varun is seeing an error trying to import kratos, since he's not using
it we can make this an optional dependency for now until the issue is
resolved
```
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/func_sim/test_func_sim.py:7: in <module>
    import magma as m
../../../../opt/miniconda3/envs/myenv/lib/python3.8/site-packages/magma/__init__.py:35: in <module>
    from .bit import *
../../../../opt/miniconda3/envs/myenv/lib/python3.8/site-packages/magma/bit.py:16: in <module>
    from magma.circuit import Circuit, coreir_port_mapping
../../../../opt/miniconda3/envs/myenv/lib/python3.8/site-packages/magma/circuit.py:21: in <module>
    from magma.syntax.combinational import combinational
../../../../opt/miniconda3/envs/myenv/lib/python3.8/site-packages/magma/syntax/__init__.py:2: in <module>
    from magma.syntax.verilog import build_kratos_debug_info
../../../../opt/miniconda3/envs/myenv/lib/python3.8/site-packages/magma/syntax/verilog.py:9: in <module>
    import kratos
../../../../opt/miniconda3/envs/myenv/lib/python3.8/site-packages/kratos/__init__.py:1: in <module>
    from .generator import Generator, PortType, PortDirection, BlockEdgeType, \
../../../../opt/miniconda3/envs/myenv/lib/python3.8/site-packages/kratos/generator.py:2: in <module>
    from .pyast import transform_stmt_block, CodeBlockType, add_scope_context, \
../../../../opt/miniconda3/envs/myenv/lib/python3.8/site-packages/kratos/pyast.py:5: in <module>
    import _kratos
E   ImportError: dlopen(/Users/varunshenoy/opt/miniconda3/envs/myenv/lib/python3.8/site-packages/_kratos.cpython-38-darwin.so, 2): Symbol not found: _aligned_alloc
E     Referenced from: /Users/varunshenoy/opt/miniconda3/envs/myenv/lib/python3.8/site-packages/_kratos.cpython-38-darwin.so
E     Expected in: /usr/lib/libSystem.B.dylib
E    in /Users/varunshenoy/opt/miniconda3/envs/myenv/lib/python3.8/site-packages/_kratos.cpython-38-darwin.so
```