### PR TITLE
Avoid fetching entire stack in debug logic

### DIFF
--- a/magma/config.py
+++ b/magma/config.py
@@ -89,7 +89,7 @@ class ConfigManager:
 
 config = ConfigManager(
     compile_dir=RuntimeConfig("normal"),
-    debug_mode=RuntimeConfig(False),
+    debug_mode=RuntimeConfig(True),
 )
 
 

--- a/magma/config.py
+++ b/magma/config.py
@@ -89,7 +89,7 @@ class ConfigManager:
 
 config = ConfigManager(
     compile_dir=RuntimeConfig("normal"),
-    debug_mode=RuntimeConfig(True),
+    debug_mode=RuntimeConfig(False),
 )
 
 

--- a/magma/debug.py
+++ b/magma/debug.py
@@ -8,15 +8,15 @@ debug_info = collections.namedtuple("debug_info", ["filename", "lineno", "module
 
 
 def get_callee_frame_info():
-    stack = inspect.stack()
+    callee_frame = inspect.currentframe()
     # FIXME: Right now we assume a max 10 frames deep
     for i in range(0, 10):
-        callee_frame = stack[i][0]
         module = inspect.getmodule(callee_frame)
         # Go up until we're out of the magma module (assuming this is the user
         # code)
         if not module or module.__name__.split(".")[0] != "magma":
             break
+        callee_frame = callee_frame.f_back
     callee_frame = inspect.getframeinfo(callee_frame)
     return debug_info(callee_frame.filename, callee_frame.lineno, module)
 

--- a/magma/placer.py
+++ b/magma/placer.py
@@ -16,10 +16,11 @@ def _parse_name(inst):
 
     otherwise, returns None.
     """
-    with open(inst.debug_info.filename, "r") as f:
-        line = f.read().splitlines()[inst.debug_info.lineno - 1]
     try:
-        tree = ast.parse(textwrap.dedent(line)).body[0]
+        # File may not exist (e.g. in sequential we exec a string)
+        with open(inst.debug_info.filename, "r") as f:
+            line = f.read().splitlines()[inst.debug_info.lineno - 1]
+            tree = ast.parse(textwrap.dedent(line)).body[0]
     except Exception:
         # Sometimes we cannot parse the line, e.g.
         # x = [Circuit()


### PR DESCRIPTION
This improves the debug mode performance considerably by only fetching stack frames on demand (rather getting the entire list of active frames), here's the runtime for garnet.py -v

```
garnet runtime:
* no_debug: 73.83s
* curr_debug:  110.22s
* faster_debug: 88.90s
```