### PR TITLE
Update golds for upstream coreir change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "pyverilog",
         "numpy",
         "graphviz",
-        "coreir>=2.0.104",
+        "coreir>=2.0.107",
         "hwtypes>=1.0.*",
         "ast_tools>=0.0.16",
         "staticfg"

--- a/tests/test_primitives/gold/test_memory_arr.v
+++ b/tests/test_primitives/gold/test_memory_arr.v
@@ -16,7 +16,8 @@ module coreir_mem #(
     parameter has_init = 1'b0,
     parameter sync_read = 1'b0,
     parameter depth = 1,
-    parameter width = 1
+    parameter width = 1,
+    parameter [(width * depth) - 1:0] init = 0
 ) (
     input clk,
     input [width-1:0] wdata,
@@ -26,7 +27,6 @@ module coreir_mem #(
     input [$clog2(depth)-1:0] raddr
 );
   reg [width-1:0] data [depth-1:0];
-  parameter [width*depth-1:0] init = 0;
   generate if (has_init) begin
     genvar j;
     for (j = 0; j < depth; j = j + 1) begin

--- a/tests/test_primitives/gold/test_memory_basic.v
+++ b/tests/test_primitives/gold/test_memory_basic.v
@@ -2,7 +2,8 @@ module coreir_mem #(
     parameter has_init = 1'b0,
     parameter sync_read = 1'b0,
     parameter depth = 1,
-    parameter width = 1
+    parameter width = 1,
+    parameter [(width * depth) - 1:0] init = 0
 ) (
     input clk,
     input [width-1:0] wdata,
@@ -12,7 +13,6 @@ module coreir_mem #(
     input [$clog2(depth)-1:0] raddr
 );
   reg [width-1:0] data [depth-1:0];
-  parameter [width*depth-1:0] init = 0;
   generate if (has_init) begin
     genvar j;
     for (j = 0; j < depth; j = j + 1) begin

--- a/tests/test_primitives/gold/test_memory_product.v
+++ b/tests/test_primitives/gold/test_memory_product.v
@@ -16,7 +16,8 @@ module coreir_mem #(
     parameter has_init = 1'b0,
     parameter sync_read = 1'b0,
     parameter depth = 1,
-    parameter width = 1
+    parameter width = 1,
+    parameter [(width * depth) - 1:0] init = 0
 ) (
     input clk,
     input [width-1:0] wdata,
@@ -26,7 +27,6 @@ module coreir_mem #(
     input [$clog2(depth)-1:0] raddr
 );
   reg [width-1:0] data [depth-1:0];
-  parameter [width*depth-1:0] init = 0;
   generate if (has_init) begin
     genvar j;
     for (j = 0; j < depth; j = j + 1) begin

--- a/tests/test_primitives/gold/test_memory_read_latency.v
+++ b/tests/test_primitives/gold/test_memory_read_latency.v
@@ -20,7 +20,8 @@ module coreir_mem #(
     parameter has_init = 1'b0,
     parameter sync_read = 1'b0,
     parameter depth = 1,
-    parameter width = 1
+    parameter width = 1,
+    parameter [(width * depth) - 1:0] init = 0
 ) (
     input clk,
     input [width-1:0] wdata,
@@ -30,7 +31,6 @@ module coreir_mem #(
     input [$clog2(depth)-1:0] raddr
 );
   reg [width-1:0] data [depth-1:0];
-  parameter [width*depth-1:0] init = 0;
   generate if (has_init) begin
     genvar j;
     for (j = 0; j < depth; j = j + 1) begin

--- a/tests/test_primitives/gold/test_memory_read_only.v
+++ b/tests/test_primitives/gold/test_memory_read_only.v
@@ -2,7 +2,8 @@ module coreir_mem #(
     parameter has_init = 1'b0,
     parameter sync_read = 1'b0,
     parameter depth = 1,
-    parameter width = 1
+    parameter width = 1,
+    parameter [(width * depth) - 1:0] init = 0
 ) (
     input clk,
     input [width-1:0] wdata,
@@ -12,7 +13,6 @@ module coreir_mem #(
     input [$clog2(depth)-1:0] raddr
 );
   reg [width-1:0] data [depth-1:0];
-  parameter [width*depth-1:0] init = 0;
   generate if (has_init) begin
     genvar j;
     for (j = 0; j < depth; j = j + 1) begin


### PR DESCRIPTION
See https://github.com/rdaly525/coreir/pull/940

This confirms that the syntax is okay with verilator (used by the memory primitive tests)