### PR TITLE
Add preliminary support for BitPattern

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -101,3 +101,5 @@ from .syntax.coroutine import coroutine
 
 from magma.primitives import (LUT, Mux, mux, Register, get_slice, set_slice,
                               slice, reduce, Memory)
+
+from magma.types import BitPattern

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -27,12 +27,13 @@ _logger = root_logger()
 
 
 def _coerce(T: tp.Type['Bits'], val: tp.Any) -> 'Bits':
+    if isinstance(val, ht.BitVector):
+        val = val.bits()
     if not isinstance(val, Bits):
         return T(val)
-    elif len(val) != len(T):
+    if len(val) != len(T):
         raise InconsistentSizeError('Inconsistent size')
-    else:
-        return val
+    return val
 
 
 def bits_cast(fn: tp.Callable[['Bits', 'Bits'], tp.Any]) -> \
@@ -124,7 +125,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
 
     def __int__(self):
         if not self.const():
-            raise Exception("Can't call __int__ on a non-constant")
+            raise TypeError("Can't call __int__ on a non-constant")
         return BitVector[len(self)](self.bits()).as_uint()
 
     @debug_wire
@@ -286,6 +287,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def bvcomp(self, other) -> 'AbstractBitVector[1]':
         return Bits[1](self == other)
 
+    @bits_cast
     def bveq(self, other) -> AbstractBit:
         return self.declare_compare_op("eq")()(self, other)
 

--- a/magma/types/__init__.py
+++ b/magma/types/__init__.py
@@ -1,0 +1,1 @@
+from .bit_pattern import BitPattern

--- a/magma/types/bit_pattern.py
+++ b/magma/types/bit_pattern.py
@@ -40,7 +40,7 @@ class BitPattern:
         self.bits = BitVector[count](bits)
         self.mask = BitVector[count](mask)
         self.width = count
-        self.const = self.mask != ((1 << self.width) - 1)
+        self.const = self.mask == ((1 << self.width) - 1)
 
     def __eq__(self, other):
         if not isinstance(other, Bits):

--- a/magma/types/bit_pattern.py
+++ b/magma/types/bit_pattern.py
@@ -38,6 +38,7 @@ class BitPattern:
                 count += 1
         self.bits = BitVector[count](bits)
         self.mask = BitVector[count](mask)
+        self.width = count
 
     def __eq__(self, other):
         if not isinstance(other, Bits):
@@ -45,3 +46,10 @@ class BitPattern:
                 "BitPattern equality can only be compared with Bits value"
             )
         return self.bits == (other & self.mask)
+
+    def as_bv(self):
+        if self.mask != ((1 << self.width) - 1):
+            raise TypeError(
+                "Can only convert BitPattern with no don't cares to int"
+            )
+        return self.bits

--- a/magma/types/bit_pattern.py
+++ b/magma/types/bit_pattern.py
@@ -40,6 +40,7 @@ class BitPattern:
         self.bits = BitVector[count](bits)
         self.mask = BitVector[count](mask)
         self.width = count
+        self.const = self.mask != ((1 << self.width) - 1)
 
     def __eq__(self, other):
         if not isinstance(other, Bits):
@@ -49,7 +50,7 @@ class BitPattern:
         return self.bits == (other & self.mask)
 
     def as_bv(self):
-        if self.mask != ((1 << self.width) - 1):
+        if not self.const:
             raise TypeError(
                 "Can only convert BitPattern with no don't cares to int"
             )

--- a/magma/types/bit_pattern.py
+++ b/magma/types/bit_pattern.py
@@ -28,14 +28,15 @@ class BitPattern:
         mask = 0
         count = 0
         for digit in pattern[1:]:
-            if not (digit == '_' or digit in string.whitespace):
-                if digit not in "01?":
-                    raise ValueError(
-                        f"Literal: {pattern} contains illegal character: {d}"
-                    )
-                mask = (mask << 1) + (0 if digit == "?" else 1)
-                bits = (bits << 1) + (1 if digit == "1" else 0)
-                count += 1
+            if digit == '_' or digit in string.whitespace:
+                continue
+            if digit not in "01?":
+                raise ValueError(
+                    f"BitPattern {pattern} contains illegal character: {d}"
+                )
+            mask = (mask << 1) + (0 if digit == "?" else 1)
+            bits = (bits << 1) + (1 if digit == "1" else 0)
+            count += 1
         self.bits = BitVector[count](bits)
         self.mask = BitVector[count](mask)
         self.width = count
@@ -43,7 +44,7 @@ class BitPattern:
     def __eq__(self, other):
         if not isinstance(other, Bits):
             raise TypeError(
-                "BitPattern equality can only be compared with Bits value"
+                "BitPattern can only be compared to Bits"
             )
         return self.bits == (other & self.mask)
 

--- a/magma/types/bit_pattern.py
+++ b/magma/types/bit_pattern.py
@@ -1,0 +1,47 @@
+"""
+Based on chisel BitPat
+https://github.com/freechipsproject/chisel3/blob/v3.3.2/src/main/scala/chisel3/util/BitPat.scala
+"""
+import string
+
+from hwtypes import BitVector
+
+from magma.bits import Bits
+
+
+class BitPattern:
+    def __init__(self, pattern):
+        """
+        Parses a bit pattern string `pattern` into the attributes `bits`,
+        `mask`, `width`
+
+        * `bits`  - the literal value, with don't cares being 0
+        * `mask`  - the mask bits, with don't cares being 0 and cares being 1
+        * `width` - the number of bits in the literal, including values and
+                    don't cares, but not including the white space and
+                    underscores
+        """
+        if pattern[0] != "b":
+            raise ValueError("BitPattern must be in binary and prefixed with "
+                             "'b'")
+        bits = 0
+        mask = 0
+        count = 0
+        for digit in pattern[1:]:
+            if not (digit == '_' or digit in string.whitespace):
+                if digit not in "01?":
+                    raise ValueError(
+                        f"Literal: {pattern} contains illegal character: {d}"
+                    )
+                mask = (mask << 1) + (0 if digit == "?" else 1)
+                bits = (bits << 1) + (1 if digit == "1" else 0)
+                count += 1
+        self.bits = BitVector[count](bits)
+        self.mask = BitVector[count](mask)
+
+    def __eq__(self, other):
+        if not isinstance(other, Bits):
+            raise TypeError(
+                "BitPattern equality can only be compared with Bits value"
+            )
+        return self.bits == (other & self.mask)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         "magma.syntax",
         "magma.syntax.transforms",
         "magma.ssa",
-        "magma.testing"
+        "magma.testing",
+        "magma.types"
     ],
     install_requires=[
         "colorlog",

--- a/tests/test_type/test_bit_pattern.py
+++ b/tests/test_type/test_bit_pattern.py
@@ -1,0 +1,27 @@
+import os
+
+import fault
+import magma as m
+
+
+def test_bit_pattern_simple():
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bit))
+        bit_pat = m.BitPattern("b??1??01?")
+        io.O @= bit_pat == io.I
+
+    m.compile("build/Foo", Foo)
+
+    tester = fault.Tester(Foo)
+    tester.circuit.I = 0b00100010
+    tester.eval()
+    tester.circuit.O.expect(1)
+    tester.circuit.I = 0b10100010
+    tester.eval()
+    tester.circuit.O.expect(1)
+    tester.circuit.I = 0b10100000
+    tester.eval()
+    tester.circuit.O.expect(0)
+    tester.compile_and_run("verilator",
+                           directory=os.path.join(os.path.dirname(__file__),
+                                                  "build"))

--- a/tests/test_type/test_bit_pattern.py
+++ b/tests/test_type/test_bit_pattern.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 import fault
 import magma as m
 
@@ -25,3 +27,14 @@ def test_bit_pattern_simple():
     tester.compile_and_run("verilator",
                            directory=os.path.join(os.path.dirname(__file__),
                                                   "build"))
+
+
+def test_as_bv():
+    x = m.BitPattern("b1001")
+    assert x.as_bv() == 0b1001
+
+    y = m.BitPattern("b1??1")
+    with pytest.raises(TypeError) as e:
+        y.as_bv()
+    assert (str(e.value) ==
+            "Can only convert BitPattern with no don't cares to int")


### PR DESCRIPTION
This adds support for declaring and comparing bit pattern values that
can include don't cares (?) ala chisel's BitPat:
https://github.com/freechipsproject/chisel3/blob/v3.3.2/src/main/scala/chisel3/util/BitPat.scala

For now, we implement the comparison logic in magma using a mask for the
don't care bits, in the future we should consider whether it matters
that we generate these in the output verilog (for synthesis quality or
readability).  If it does matter, we'll need to add support for
compiling it through CoreIR.  This uses the chisel syntax for bit
pattern strings.