### PR TITLE
Fix spurious warning from automatic clock wiring

### DIFF
--- a/magma/backend/coreir_transformer.py
+++ b/magma/backend/coreir_transformer.py
@@ -320,7 +320,7 @@ class DefinitionTransformer(TransformerBase):
             if not clock_wired:
                 # No default clock
                 return
-            value = port.value()
+            value = port.trace()
         if value is None:
             if port.is_inout():
                 return  # skip inouts because they might be conn. as an input.

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -108,9 +108,9 @@ def wire_clock_port(port, clocktype, defnclk):
         # Python, so we explicilty slice port.ts
         for t in port.ts[1:]:
             for elem in port[1:]:
-              wire_clock_port(elem, clocktype, defnclk)
+                wire_clock_port(elem, clocktype, defnclk)
     elif isinstance(port, clocktype) and not port.driven():
-        # Trace to last undriven driver 
+        # Trace to last undriven driver
         while port.value() is not None:
             port = port.value()
         wire(defnclk, port)

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -110,6 +110,9 @@ def wire_clock_port(port, clocktype, defnclk):
             for elem in port[1:]:
               wire_clock_port(elem, clocktype, defnclk)
     elif isinstance(port, clocktype) and not port.driven():
+        # Trace to last undriven driver 
+        while port.value() is not None:
+            port = port.value()
         wire(defnclk, port)
         wired = True
     return wired

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -166,7 +166,7 @@ def wire_new_bit(origbit, newbit, cur_scope, primitive_map, bit_map, old_circuit
     # Trace back from origbit to its source, tracking bits that will be "collapsed"
     new_circuit = flattened_circuit.circuit
 
-    sourcebit = origbit.value()
+    sourcebit = origbit.trace()
     if sourcebit is None:
         if isinstance(origbit, Array):
             # TODO: Raise an exception for now, can we handle this case silently (ignore unwired ports)?

--- a/tests/test_higher/build/.gitignore
+++ b/tests/test_higher/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_higher/test_fold.py
+++ b/tests/test_higher/test_fold.py
@@ -1,0 +1,18 @@
+import magma as m
+
+
+def test_fold_shift_register(caplog):
+    class EnableShiftRegister(m.Circuit):
+        io = m.IO(
+            I=m.In(m.UInt[4]),
+            shift=m.In(m.Bit),
+            O=m.Out(m.UInt[4])
+        ) + m.ClockIO(has_async_reset=True)
+        regs = [m.Register(m.UInt[4], reset_type=m.AsyncReset,
+                           has_enable=True)() for _ in range(4)]
+        io.O @= m.fold(regs, foldargs={"I": "O"})(io.I, CE=io.shift)
+
+    m.compile("build/EnableShiftRegister", EnableShiftRegister)
+
+    assert "Wiring multiple outputs to same wire, using last connection. Input: EnableShiftRegister.Register_inst0.CLK, Old Output: Clock(), New Output: EnableShiftRegister.CLK" not in caplog.messages  # noqa
+    assert 'Wiring multiple outputs to same wire, using last connection. Input: EnableShiftRegister.Register_inst0.ASYNCRESET, Old Output: AsyncReset(), New Output: EnableShiftRegister.ASYNCRESET' not in caplog.messages  # noqa


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/808
Traces a clock port to the first undriven driver and drives that value
rather than overwriting the driver for the current clock port.  This
handles the case when fold introduces a temporary value for forked
clocks (and undriven temporary clock values more generally).

Fixes a case in the simulator logic where it should have been using
trace instead of value.