### PR TITLE
Add missing type to ClockTypes tuple

### DIFF
--- a/magma/clock.py
+++ b/magma/clock.py
@@ -75,7 +75,7 @@ class Enable(_ClockType, metaclass=DigitalMeta):
 EnableIn = Enable[Direction.In]
 EnableOut = Enable[Direction.Out]
 
-ClockTypes = (Clock, Reset, AsyncReset, AsyncResetN, Enable)
+ClockTypes = (Clock, Reset, ResetN, AsyncReset, AsyncResetN, Enable)
 
 
 def ClockInterface(has_enable=False, has_reset=False, has_ce=False,

--- a/tests/test_higher/test_fold.py
+++ b/tests/test_higher/test_fold.py
@@ -2,6 +2,7 @@ import magma as m
 
 
 def test_fold_shift_register(caplog):
+    # https://github.com/phanrahan/magma/issues/808
     class EnableShiftRegister(m.Circuit):
         io = m.IO(
             I=m.In(m.UInt[4]),
@@ -16,3 +17,19 @@ def test_fold_shift_register(caplog):
 
     assert "Wiring multiple outputs to same wire, using last connection. Input: EnableShiftRegister.Register_inst0.CLK, Old Output: Clock(), New Output: EnableShiftRegister.CLK" not in caplog.messages  # noqa
     assert 'Wiring multiple outputs to same wire, using last connection. Input: EnableShiftRegister.Register_inst0.ASYNCRESET, Old Output: AsyncReset(), New Output: EnableShiftRegister.ASYNCRESET' not in caplog.messages  # noqa
+
+
+def test_fold_reset_shift_register():
+    # https://github.com/phanrahan/magma/issues/816
+    class ResetShiftRegister(m.Circuit):
+        io = m.IO(
+            I=m.In(m.UInt[4]),
+            shift=m.In(m.Bit),
+            O=m.Out(m.UInt[4])
+        ) + m.ClockIO(has_resetn=True)
+        regs = [m.Register(m.UInt[4], has_enable=True, reset_type=m.ResetN)()
+                for _ in range(4)]
+        io.O @= m.fold(regs, foldargs={"I": "O"})(io.I, CE=io.shift)
+
+    # This should not raise an unconnected port exception
+    m.compile("build/ResetShiftRegister", ResetShiftRegister)


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/816

This allows ResetN ports to be properly handled by the automatic clock
wiring logic.

Pulled into #823 since I reused the newly introduced test file and didn't want to deal with the merge issues.