### PR TITLE
Add right-hand operators to Bits/UInt/SInt

### DIFF
--- a/magma/bits.py
+++ b/magma/bits.py
@@ -409,6 +409,9 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
         except TypeError:
             return NotImplemented
 
+    def __rand__(self, other):
+        return self & other
+
     def __or__(self, other):
         try:
             return self.bvor(other)
@@ -416,6 +419,9 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             raise e from None
         except TypeError:
             return NotImplemented
+
+    def __ror__(self, other):
+        return self | other
 
     def __xor__(self, other):
         try:
@@ -425,6 +431,9 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
         except TypeError:
             return NotImplemented
 
+    def __rxor__(self, other):
+        return self ^ other
+
     def __lshift__(self, other):
         try:
             return self.bvshl(other)
@@ -433,6 +442,9 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
         except TypeError:
             return NotImplemented
 
+    def __rlshift__(self, other):
+        return type(self)(other) << self
+
     def __rshift__(self, other):
         try:
             return self.bvlshr(other)
@@ -440,6 +452,9 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             raise e from None
         except TypeError:
             return NotImplemented
+
+    def __rrshift__(self, other):
+        return type(self)(other) >> self
 
     def __eq__(self, other):
         try:
@@ -468,6 +483,9 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
         except TypeError:
             return NotImplemented
 
+    def __radd__(self, other):
+        return self + other
+
     def __sub__(self, other):
         try:
             return self.bvsub(other)
@@ -476,6 +494,9 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
         except TypeError:
             return NotImplemented
 
+    def __rsub__(self, other):
+        return type(self)(other) - self
+
     def __mul__(self, other):
         try:
             return self.bvmul(other)
@@ -483,6 +504,9 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             raise e from None
         except TypeError:
             return NotImplemented
+
+    def __rmul__(self, other):
+        return self * other
 
     @classmethod
     def get_family(cls):
@@ -542,7 +566,21 @@ DefineUnused = make_Define("term", "I", In)
 BitsType = Bits
 
 
-class UInt(Bits):
+class Number(Bits):
+    """
+    Defines shared right-hand operators for UInt/SInt
+    """
+    def __rfloordiv__(self, other):
+        return type(self)(other) // self
+
+    def __rtruediv__(self, other):
+        return type(self)(other) / self
+
+    def __rmod__(self, other):
+        return type(self)(other) % self
+
+
+class UInt(Number):
     hwtypes_T = ht.UIntVector
 
     def __repr__(self):
@@ -610,7 +648,7 @@ class UInt(Bits):
             return NotImplemented
 
 
-class SInt(Bits):
+class SInt(Number):
     hwtypes_T = ht.SIntVector
 
     def __init__(self, *args, **kwargs):
@@ -756,5 +794,5 @@ class SInt(Bits):
 
     def __int__(self):
         if not self.const():
-            raise Exception("Can't call __int__ on a non-constant")
+            raise TypeError("Can't call __int__ on a non-constant")
         return BitVector[len(self)](self.bits()).as_int()

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -566,7 +566,7 @@ DefineUnused = make_Define("term", "I", In)
 BitsType = Bits
 
 
-class Number(Bits):
+class Int(Bits):
     """
     Defines shared right-hand operators for UInt/SInt
     """
@@ -580,7 +580,7 @@ class Number(Bits):
         return type(self)(other) % self
 
 
-class UInt(Number):
+class UInt(Int):
     hwtypes_T = ht.UIntVector
 
     def __repr__(self):
@@ -648,7 +648,7 @@ class UInt(Number):
             return NotImplemented
 
 
-class SInt(Number):
+class SInt(Int):
     hwtypes_T = ht.SIntVector
 
     def __init__(self, *args, **kwargs):

--- a/tests/test_type/test_bits.py
+++ b/tests/test_type/test_bits.py
@@ -381,3 +381,20 @@ EndCircuit()\
         sim.set_value(TestRepeat.I, I)
         sim.evaluate()
         assert sim.get_value(TestRepeat.O) == I.repeat(x)
+
+
+@pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor,
+                                operator.lshift, operator.rshift, operator.add,
+                                operator.sub, operator.mul])
+def test_rops(op):
+    x = BitVector.random(5)
+
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[5]), O=m.Out(m.Bits[5]))
+        io.O @= op(x, io.I)
+
+    sim = PythonSimulator(Main)
+    I = BitVector.random(5)
+    sim.set_value(Main.I, I)
+    sim.evaluate()
+    assert sim.get_value(Main.O) == op(x, I)

--- a/tests/test_type/test_sint.py
+++ b/tests/test_type/test_sint.py
@@ -1,3 +1,4 @@
+import magma as m
 import operator
 import pytest
 from magma.testing import check_files_equal
@@ -241,3 +242,18 @@ EndCircuit()\
         sim.set_value(TestNegate.I, I)
         sim.evaluate()
         assert sim.get_value(TestNegate.O) == -I
+
+
+@pytest.mark.parametrize("op", [operator.floordiv, operator.mod])
+def test_rops(op):
+    x = SIntVector.random(5)
+
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.SInt[5]), O=m.Out(m.SInt[5]))
+        io.O @= op(x, io.I)
+
+    sim = PythonSimulator(Main)
+    I = SIntVector.random(5)
+    sim.set_value(Main.I, I)
+    sim.evaluate()
+    assert sim.get_value(Main.O) == op(x, I)

--- a/tests/test_type/test_uint.py
+++ b/tests/test_type/test_uint.py
@@ -1,3 +1,4 @@
+import magma as m
 from magma.testing import check_files_equal
 import operator
 import pytest
@@ -214,3 +215,18 @@ EndCircuit()\
         sim.evaluate()
         assert sim.get_value(TestBinary.O) == I0 + I1
         assert sim.get_value(TestBinary.COUT) == (I0.zext(1) + I1.zext(1))[-1]
+
+
+@pytest.mark.parametrize("op", [operator.floordiv, operator.mod])
+def test_rops(op):
+    x = UIntVector.random(5)
+
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.UInt[5]), O=m.Out(m.UInt[5]))
+        io.O @= op(x, io.I)
+
+    sim = PythonSimulator(Main)
+    I = UIntVector.random(5)
+    sim.set_value(Main.I, I)
+    sim.evaluate()
+    assert sim.get_value(Main.O) == op(x, I)


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/770

Needed to change the `const` exception to a TypeError so it would force
BitVector to return NotImplemented rather than raising an exception
(which then causes Python to try the right hand operator).