### PR TITLE
Fix bind support for intermediate values

### DIFF
--- a/magma/bind.py
+++ b/magma/bind.py
@@ -36,7 +36,6 @@ def _wire_temp(bind_arg, temp):
         bind_arg = bind_arg.value()
         if bind_arg is None:
             raise ValueError("Cannot bind undriven input")
-    assert bind_arg.is_output()
     wire(bind_arg, temp)
 
 

--- a/tests/test_verilog/gold/RTLMonitor.sv
+++ b/tests/test_verilog/gold/RTLMonitor.sv
@@ -36,6 +36,7 @@ module RTLMonitor (
     input intermediate_tuple__1,
     input mon_temp1,
     input mon_temp2,
+    input mon_temp3,
     input out
 );
 wire _magma_inline_wire0;
@@ -57,7 +58,7 @@ assign temp3 = temp1 ^ temp2 & _magma_inline_wire0;
 assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
 logic [3:0] temp4 [1:0];
 assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
-always @(*) $display("%x", inst_input);
+always @(*) $display("%x", inst_input & {4{mon_temp3}});
                                    
 endmodule
 
@@ -79,5 +80,6 @@ bind RTL RTLMonitor RTLMonitor_inst (
     .mon_temp2(_magma_bind_wire_1),
     .intermediate_tuple__0(_magma_bind_wire_2_0),
     .intermediate_tuple__1(_magma_bind_wire_2_1),
-    .inst_input(_magma_bind_wire_3)
+    .inst_input(_magma_bind_wire_3),
+    .mon_temp3(_magma_bind_wire_4)
 );

--- a/tests/test_verilog/gold/RTLMonitor_unq1.sv
+++ b/tests/test_verilog/gold/RTLMonitor_unq1.sv
@@ -36,6 +36,7 @@ module RTLMonitor_unq1 (
     input intermediate_tuple__1,
     input mon_temp1,
     input mon_temp2,
+    input mon_temp3,
     input out
 );
 wire _magma_inline_wire0;
@@ -57,7 +58,7 @@ assign temp3 = temp1 ^ temp2 & _magma_inline_wire0;
 assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
 logic [4:0] temp4 [1:0];
 assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
-always @(*) $display("%x", inst_input);
+always @(*) $display("%x", inst_input & {5{mon_temp3}});
                                    
 endmodule
 
@@ -79,5 +80,6 @@ bind RTL_unq1 RTLMonitor_unq1 RTLMonitor_unq1_inst (
     .mon_temp2(_magma_bind_wire_1),
     .intermediate_tuple__0(_magma_bind_wire_2_0),
     .intermediate_tuple__1(_magma_bind_wire_2_1),
-    .inst_input(_magma_bind_wire_3)
+    .inst_input(_magma_bind_wire_3),
+    .mon_temp3(_magma_bind_wire_4)
 );

--- a/tests/test_verilog/gold/bind_test.v
+++ b/tests/test_verilog/gold/bind_test.v
@@ -50,9 +50,11 @@ wire _magma_bind_wire_1;
 wire _magma_bind_wire_2_0;
 wire _magma_bind_wire_2_1;
 wire [3:0] _magma_bind_wire_3;
+wire _magma_bind_wire_4;
 wire andr_4_inst0_O;
 wire [3:0] magma_Bits_4_xor_inst0_out;
 wire orr_4_inst0_O;
+wire temp3;
 SomeCircuit SomeCircuit_inst0 (
     .I(magma_Bits_4_xor_inst0_out)
 );
@@ -61,21 +63,28 @@ assign _magma_bind_wire_1 = andr_4_inst0_O;
 assign _magma_bind_wire_2_0 = orr_4_inst0_O;
 assign _magma_bind_wire_2_1 = andr_4_inst0_O;
 assign _magma_bind_wire_3 = magma_Bits_4_xor_inst0_out;
+assign _magma_bind_wire_4 = temp3;
 andr_4 andr_4_inst0 (
     .I(in1),
     .O(andr_4_inst0_O)
 );
 corebit_term corebit_term_inst0 (
-    .in(_magma_bind_wire_0)
+    .in(temp3)
 );
 corebit_term corebit_term_inst1 (
-    .in(_magma_bind_wire_1)
+    .in(_magma_bind_wire_0)
 );
 corebit_term corebit_term_inst2 (
-    .in(_magma_bind_wire_2_0)
+    .in(_magma_bind_wire_1)
 );
 corebit_term corebit_term_inst3 (
+    .in(_magma_bind_wire_2_0)
+);
+corebit_term corebit_term_inst4 (
     .in(_magma_bind_wire_2_1)
+);
+corebit_term corebit_term_inst5 (
+    .in(_magma_bind_wire_4)
 );
 logical_and logical_and_inst0 (
     .I0(orr_4_inst0_O),
@@ -87,6 +96,7 @@ orr_4 orr_4_inst0 (
     .I(in1),
     .O(orr_4_inst0_O)
 );
+assign temp3 = andr_4_inst0_O;
 coreir_term #(
     .width(4)
 ) term_inst0 (

--- a/tests/test_verilog/gold/bind_uniq_test.v
+++ b/tests/test_verilog/gold/bind_uniq_test.v
@@ -87,10 +87,12 @@ wire _magma_bind_wire_1;
 wire _magma_bind_wire_2_0;
 wire _magma_bind_wire_2_1;
 wire [4:0] _magma_bind_wire_3;
+wire _magma_bind_wire_4;
 wire andr_5_inst0_O;
 wire coreir_wrapInClock_inst0_out;
 wire [4:0] magma_Bits_5_xor_inst0_out;
 wire orr_5_inst0_O;
+wire temp3;
 SomeCircuit_unq1 SomeCircuit_inst0 (
     .I(magma_Bits_5_xor_inst0_out)
 );
@@ -99,23 +101,30 @@ assign _magma_bind_wire_1 = andr_5_inst0_O;
 assign _magma_bind_wire_2_0 = orr_5_inst0_O;
 assign _magma_bind_wire_2_1 = andr_5_inst0_O;
 assign _magma_bind_wire_3 = magma_Bits_5_xor_inst0_out;
+assign _magma_bind_wire_4 = temp3;
 andr_5 andr_5_inst0 (
     .I(in1),
     .O(andr_5_inst0_O)
 );
 corebit_term corebit_term_inst0 (
-    .in(_magma_bind_wire_0)
+    .in(temp3)
 );
 corebit_term corebit_term_inst1 (
-    .in(_magma_bind_wire_1)
+    .in(_magma_bind_wire_0)
 );
 corebit_term corebit_term_inst2 (
-    .in(_magma_bind_wire_2_0)
+    .in(_magma_bind_wire_1)
 );
 corebit_term corebit_term_inst3 (
-    .in(_magma_bind_wire_2_1)
+    .in(_magma_bind_wire_2_0)
 );
 corebit_term corebit_term_inst4 (
+    .in(_magma_bind_wire_2_1)
+);
+corebit_term corebit_term_inst5 (
+    .in(_magma_bind_wire_4)
+);
+corebit_term corebit_term_inst6 (
     .in(coreir_wrapInClock_inst0_out)
 );
 coreir_wrap coreir_wrapInClock_inst0 (
@@ -132,6 +141,7 @@ orr_5 orr_5_inst0 (
     .I(in1),
     .O(orr_5_inst0_O)
 );
+assign temp3 = andr_5_inst0_O;
 coreir_term #(
     .width(5)
 ) term_inst0 (
@@ -162,10 +172,12 @@ wire _magma_bind_wire_1;
 wire _magma_bind_wire_2_0;
 wire _magma_bind_wire_2_1;
 wire [3:0] _magma_bind_wire_3;
+wire _magma_bind_wire_4;
 wire andr_4_inst0_O;
 wire coreir_wrapInClock_inst0_out;
 wire [3:0] magma_Bits_4_xor_inst0_out;
 wire orr_4_inst0_O;
+wire temp3;
 SomeCircuit SomeCircuit_inst0 (
     .I(magma_Bits_4_xor_inst0_out)
 );
@@ -174,23 +186,30 @@ assign _magma_bind_wire_1 = andr_4_inst0_O;
 assign _magma_bind_wire_2_0 = orr_4_inst0_O;
 assign _magma_bind_wire_2_1 = andr_4_inst0_O;
 assign _magma_bind_wire_3 = magma_Bits_4_xor_inst0_out;
+assign _magma_bind_wire_4 = temp3;
 andr_4 andr_4_inst0 (
     .I(in1),
     .O(andr_4_inst0_O)
 );
 corebit_term corebit_term_inst0 (
-    .in(_magma_bind_wire_0)
+    .in(temp3)
 );
 corebit_term corebit_term_inst1 (
-    .in(_magma_bind_wire_1)
+    .in(_magma_bind_wire_0)
 );
 corebit_term corebit_term_inst2 (
-    .in(_magma_bind_wire_2_0)
+    .in(_magma_bind_wire_1)
 );
 corebit_term corebit_term_inst3 (
-    .in(_magma_bind_wire_2_1)
+    .in(_magma_bind_wire_2_0)
 );
 corebit_term corebit_term_inst4 (
+    .in(_magma_bind_wire_2_1)
+);
+corebit_term corebit_term_inst5 (
+    .in(_magma_bind_wire_4)
+);
+corebit_term corebit_term_inst6 (
     .in(coreir_wrapInClock_inst0_out)
 );
 coreir_wrap coreir_wrapInClock_inst0 (
@@ -207,6 +226,7 @@ orr_4 orr_4_inst0 (
     .I(in1),
     .O(orr_4_inst0_O)
 );
+assign temp3 = andr_4_inst0_O;
 coreir_term #(
     .width(4)
 ) term_inst0 (

--- a/tests/test_verilog/rtl.py
+++ b/tests/test_verilog/rtl.py
@@ -37,6 +37,9 @@ class RTL(m.Generator):
             temp1 = orr()(io.in1)
             temp2 = andr()(io.in1)
             intermediate_tuple = m.tuple_([temp1, temp2])
+            temp3 = m.Bit(name="temp3")
+            temp3 @= temp2
+            temp3.unused()
             io.out @= logical_and()(intermediate_tuple[0],
                                     intermediate_tuple[1])
             m.wire(io.handshake.valid, io.handshake.ready)

--- a/tests/test_verilog/rtl_monitor.py
+++ b/tests/test_verilog/rtl_monitor.py
@@ -12,7 +12,8 @@ class RTLMonitor(m.MonitorGenerator):
                       mon_temp1=m.In(m.Bit),
                       mon_temp2=m.In(m.Bit),
                       intermediate_tuple=m.In(m.Tuple[m.Bit, m.Bit]),
-                      inst_input=m.In(m.Bits[width]))
+                      inst_input=m.In(m.Bits[width]),
+                      mon_temp3=m.In(m.Bit))
 
             # NOTE: Needs to have a name
             arr_2d = m.Array[2, m.Bits[width]](name="arr_2d")
@@ -27,12 +28,13 @@ assign temp3 = temp1 ^ temp2 & {arr_2d[0][1]};
 assert property (@(posedge {io.CLK}) {valid} -> {io.out} === temp1 && temp2);
 logic [{width-1}:0] temp4 [1:0];
 assign temp4 = {arr_2d};
-always @(*) $display("%x", {io.inst_input});
+always @(*) $display("%x", {io.inst_input} & {{{width}{{{io.mon_temp3}}}}});
                                    """,
                                    valid=io.handshake.valid)
 
         circuit.bind(RTLMonitor, circuit.temp1, circuit.temp2,
-                     circuit.intermediate_tuple, circuit.some_circ.I)
+                     circuit.intermediate_tuple, circuit.some_circ.I,
+                     circuit.temp3)
 
 
 RTL.bind(RTLMonitor)


### PR DESCRIPTION
Removes conservative assertion that forces all bind values to be
outputs.  This check fails when binding an output port that is driven by
a temporary value, or when simply binding to a temporary value, here's
an example produces from the test:
```python
  tests/test_verilog/test_bind.py:40:
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  magma/compile.py:55: in compile
      BindPass(main, compile).run()
  magma/passes/passes.py:62: in run
      self._run(self.main)
  magma/passes/passes.py:53: in _run
      self._run(type(inst))
  magma/passes/passes.py:59: in _run
      self(circuit)
  magma/bind.py:111: in __call__
      _bind(cls, monitor, self._compile_fn, *args)
  magma/bind.py:79: in _bind
      _wire_temp(driver, temp)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

  bind_arg = Bit(name="temp3"), temp = Bit(name="_magma_bind_wire_9")

      def _wire_temp(bind_arg, temp):
          if bind_arg.is_mixed():
              for x, y in zip(bind_arg, temp):
                  _wire_temp(x, y)
              return
          if bind_arg.is_input():
              bind_arg = bind_arg.value()
              if bind_arg is None:
                  raise ValueError("Cannot bind undriven input")
  >       assert bind_arg.is_output()
  E       AssertionError

  magma/bind.py:39: AssertionError
```