### PR TITLE
Add support for user provided inline wire prefix

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -98,8 +98,10 @@ class DefinitionContext:
                 _VERILOG_FILE_CLOSE.format(filename=file.filename),
                 {}, {})
 
-    def add_inline_verilog(self, format_str, format_args, symbol_table):
-        self._inline_verilog.append((format_str, format_args, symbol_table))
+    def add_inline_verilog(self, format_str, format_args, symbol_table,
+                           inline_wire_prefix="_magma_inline_wire"):
+        self._inline_verilog.append((format_str, format_args, symbol_table,
+                                     inline_wire_prefix))
 
     def insert_default_log_level(self):
         self._insert_default_log_level = True

--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -44,8 +44,7 @@ def _make_inline_value(cls, inline_value_map, value):
 def _make_temporary(defn, value, num, inline_wire_prefix, parent=None):
     with defn.open():
         # Insert a wire so it can't be inlined out
-        temp_name = inline_wire_prefix
-        temp_name += f"{num}"
+        temp_name = f"{inline_wire_prefix}{num}"
         temp = Wire(type(value))(name=temp_name)
         temp.I @= value
     if parent is not None:

--- a/tests/test_verilog/gold/test_inline_simple.sv
+++ b/tests/test_verilog/gold/test_inline_simple.sv
@@ -15,15 +15,15 @@ module Main (
     input [1:0] arr,
     input CLK
 );
-wire _magma_inline_wire0;
+wire _foo_prefix_0;
 FF FF_inst0 (
     .I(I),
     .O(O),
     .CLK(CLK)
 );
-assign _magma_inline_wire0 = O;
+assign _foo_prefix_0 = O;
 
-assert property (@(posedge CLK) I |-> ##1 _magma_inline_wire0);
+assert property (@(posedge CLK) I |-> ##1 _foo_prefix_0);
 
 
 assert property (@(posedge CLK) arr[0] |-> ##1 arr[1]);

--- a/tests/test_verilog/test_inline.py
+++ b/tests/test_verilog/test_inline.py
@@ -21,7 +21,7 @@ assert property (@(posedge CLK) {I} |-> ##1 {O});
 """, O=io.O, I=io.I, inline_wire_prefix="_foo_prefix_")
         m.inline_verilog("""
 assert property (@(posedge CLK) {io.arr[0]} |-> ##1 {io.arr[1]});
-""",)
+""")
 
     m.compile(f"build/test_inline_simple", Main, output="coreir-verilog",
               sv=True, inline=True)

--- a/tests/test_verilog/test_inline.py
+++ b/tests/test_verilog/test_inline.py
@@ -18,10 +18,10 @@ endmodule
         io.O <= FF()(io.I)
         m.inline_verilog("""
 assert property (@(posedge CLK) {I} |-> ##1 {O});
-""", O=io.O, I=io.I)
+""", O=io.O, I=io.I, inline_wire_prefix="_foo_prefix_")
         m.inline_verilog("""
 assert property (@(posedge CLK) {io.arr[0]} |-> ##1 {io.arr[1]});
-""")
+""",)
 
     m.compile(f"build/test_inline_simple", Main, output="coreir-verilog",
               sv=True, inline=True)


### PR DESCRIPTION
When magma is generating inline_verilog code, it assigns some values to temporary wires.  This change allows the user to choose a string for the wire names, useful for the case when these wires are used inside an `ifdef macro in the verilog.  

For example, an assertion may be wrapped inside an \`ifdef so it can be turned off for synthesis.  By providing a specific prefix for the wires entering into the \`ifdef block that may be unused (normally marked as an error by the linter), the user can provide a pattern matching string to the lint tool to ignore these dangling wires (i.e. ignore all dangling wires containing "_MAGMA_INLINE_ASSERTION_" in the name)