### PR TITLE
Add support for user_namespace to bind

### DIFF
--- a/magma/backend/coreir_compiler.py
+++ b/magma/backend/coreir_compiler.py
@@ -44,7 +44,11 @@ def _make_opts(backend, opts):
     out = {}
     user_namespace = opts.get("user_namespace", None)
     if user_namespace is not None:
-        out["user_namespace"] = backend.context.new_namespace(user_namespace)
+        if backend.context.has_namespace(user_namespace):
+            user_namespace = backend.context.get_namespace(user_namespace)
+        else:
+            user_namespace = backend.context.new_namespace(user_namespace)
+        out["user_namespace"] = user_namespace
     return out
 
 

--- a/magma/backend/coreir_transformer.py
+++ b/magma/backend/coreir_transformer.py
@@ -234,7 +234,7 @@ class DefinitionTransformer(TransformerBase):
                 {"str": inline_verilog,
                  "connect_references": connect_references}
             ))
-        for name, module in self.defn.bind_modules.items():
+        for name, module in self.defn.compiled_bind_modules.items():
             self.backend.sv_bind_files[name] = module
 
         self.coreir_module.definition = self.get_coreir_defn()

--- a/magma/bind.py
+++ b/magma/bind.py
@@ -95,7 +95,6 @@ Bind monitor interface does not match circuit interface
     set_compile_dir("normal")
     # Circular dependency, need coreir backend to compile, backend imports
     # circuit (for wrap casts logic, we might be able to factor that out).
-    print(monitor, id(monitor))
     compile_fn(f".magma/{monitor.name}", monitor, inline=True,
                user_namespace=user_namespace)
     set_compile_dir(curr_compile_dir)

--- a/magma/bind.py
+++ b/magma/bind.py
@@ -110,6 +110,5 @@ class BindPass(CircuitPass):
         self.user_namespace = user_namespace
 
     def __call__(self, cls):
-        cls.compiled_bind_modules = {}
         for monitor, args in cls.bind_modules.items():
             _bind(cls, monitor, self._compile_fn, self.user_namespace, *args)

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -235,6 +235,7 @@ class CircuitKind(type):
         dct.setdefault("inline_verilog_strs", [])
         dct["inline_verilog_generated"] = False
         dct["bind_modules"] = {}
+        dct["compiled_bind_modules"] = {}
 
         # If in debug_mode is active and debug_info is not supplied, attach
         # callee stack info.

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -235,7 +235,6 @@ class CircuitKind(type):
         dct.setdefault("inline_verilog_strs", [])
         dct["inline_verilog_generated"] = False
         dct["bind_modules"] = {}
-        dct["bind_modules_bound"] = False
 
         # If in debug_mode is active and debug_info is not supplied, attach
         # callee stack info.

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -52,7 +52,7 @@ def compile(basename, main, output="coreir-verilog", **kwargs):
     ProcessInlineVerilogPass(main).run()
 
     # Bind after uniquification so the bind logic works on unique modules
-    BindPass(main, compile).run()
+    BindPass(main, compile, opts.get("user_namespace")).run()
 
     if opts.get("drive_undriven", False):
         DriveUndrivenPass(main).run()

--- a/tests/test_verilog/gold/RTLMonitor.sv
+++ b/tests/test_verilog/gold/RTLMonitor.sv
@@ -19,7 +19,7 @@ module corebit_term (
 
 endmodule
 
-module RTLMonitor (
+module foo_RTLMonitor (
     input CLK,
     input handshake_arr_0_ready,
     input handshake_arr_0_valid,
@@ -62,7 +62,7 @@ always @(*) $display("%x", inst_input);
 endmodule
 
 
-bind RTL RTLMonitor RTLMonitor_inst (
+bind foo_RTL foo_RTLMonitor foo_RTLMonitor_inst (
     .CLK(CLK),
     .in1(in1),
     .in2(in2),

--- a/tests/test_verilog/gold/RTLMonitor_unq1.sv
+++ b/tests/test_verilog/gold/RTLMonitor_unq1.sv
@@ -19,7 +19,7 @@ module corebit_term (
 
 endmodule
 
-module RTLMonitor_unq1 (
+module foo_RTLMonitor_unq1 (
     input CLK,
     input handshake_arr_0_ready,
     input handshake_arr_0_valid,
@@ -62,7 +62,7 @@ always @(*) $display("%x", inst_input);
 endmodule
 
 
-bind RTL_unq1 RTLMonitor_unq1 RTLMonitor_unq1_inst (
+bind foo_RTL_unq1 foo_RTLMonitor_unq1 foo_RTLMonitor_unq1_inst (
     .CLK(CLK),
     .in1(in1),
     .in2(in2),

--- a/tests/test_verilog/gold/bind_test.v
+++ b/tests/test_verilog/gold/bind_test.v
@@ -1,9 +1,12 @@
-            module orr_4 (input [3:0] I, output O);
-            assign O = |(I);
-            endmodule
-            module logical_and (input I0, input I1, output O);
-            assign O = I0 && I1;
-            endmodule
+module orr_4 (input [3:0] I, output O);
+assign O = |(I);
+endmodule
+module logical_and (input I0, input I1, output O);
+assign O = I0 && I1;
+endmodule
+module andr_4 (input [3:0] I, output O);
+assign O = &(I);
+endmodule
 module coreir_term #(
     parameter width = 1
 ) (
@@ -12,16 +15,7 @@ module coreir_term #(
 
 endmodule
 
-module corebit_term (
-    input in
-);
-
-endmodule
-
-            module andr_4 (input [3:0] I, output O);
-            assign O = &(I);
-            endmodule
-module SomeCircuit (
+module foo_SomeCircuit (
     input [3:0] I
 );
 coreir_term #(
@@ -31,7 +25,13 @@ coreir_term #(
 );
 endmodule
 
-module RTL (
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module foo_RTL (
     input CLK,
     input handshake_arr_0_ready,
     output handshake_arr_0_valid,
@@ -53,7 +53,7 @@ wire [3:0] _magma_bind_wire_3;
 wire andr_4_inst0_O;
 wire [3:0] magma_Bits_4_xor_inst0_out;
 wire orr_4_inst0_O;
-SomeCircuit SomeCircuit_inst0 (
+foo_SomeCircuit SomeCircuit_inst0 (
     .I(magma_Bits_4_xor_inst0_out)
 );
 assign _magma_bind_wire_0 = orr_4_inst0_O;

--- a/tests/test_verilog/gold/bind_uniq_test.v
+++ b/tests/test_verilog/gold/bind_uniq_test.v
@@ -21,34 +21,7 @@ module coreir_term #(
 
 endmodule
 
-module corebit_undriven (
-    output out
-);
-
-endmodule
-
-            module orr_5 (input [4:0] I, output O);
-            assign O = |(I);
-            endmodule
-            module orr_4 (input [3:0] I, output O);
-            assign O = |(I);
-            endmodule
-module corebit_term (
-    input in
-);
-
-endmodule
-
-            module logical_and (input I0, input I1, output O);
-            assign O = I0 && I1;
-            endmodule
-            module andr_5 (input [4:0] I, output O);
-            assign O = &(I);
-            endmodule
-            module andr_4 (input [3:0] I, output O);
-            assign O = &(I);
-            endmodule
-module SomeCircuit_unq1 (
+module foo_SomeCircuit_unq1 (
     input [4:0] I
 );
 coreir_term #(
@@ -58,7 +31,7 @@ coreir_term #(
 );
 endmodule
 
-module SomeCircuit (
+module foo_SomeCircuit (
     input [3:0] I
 );
 coreir_term #(
@@ -68,7 +41,34 @@ coreir_term #(
 );
 endmodule
 
-module RTL_unq1 (
+module corebit_undriven (
+    output out
+);
+
+endmodule
+
+module orr_5 (input [4:0] I, output O);
+assign O = |(I);
+endmodule
+module orr_4 (input [3:0] I, output O);
+assign O = |(I);
+endmodule
+module andr_5 (input [4:0] I, output O);
+assign O = &(I);
+endmodule
+module andr_4 (input [3:0] I, output O);
+assign O = &(I);
+endmodule
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module logical_and (input I0, input I1, output O);
+assign O = I0 && I1;
+endmodule
+module foo_RTL_unq1 (
     input CLK,
     input handshake_arr_0_ready,
     output handshake_arr_0_valid,
@@ -91,7 +91,7 @@ wire andr_5_inst0_O;
 wire coreir_wrapInClock_inst0_out;
 wire [4:0] magma_Bits_5_xor_inst0_out;
 wire orr_5_inst0_O;
-SomeCircuit_unq1 SomeCircuit_inst0 (
+foo_SomeCircuit_unq1 SomeCircuit_inst0 (
     .I(magma_Bits_5_xor_inst0_out)
 );
 assign _magma_bind_wire_0 = orr_5_inst0_O;
@@ -143,7 +143,7 @@ assign handshake_arr_2_valid = handshake_arr_0_ready;
 assign handshake_valid = handshake_ready;
 endmodule
 
-module RTL (
+module foo_RTL (
     input CLK,
     input handshake_arr_0_ready,
     output handshake_arr_0_valid,
@@ -166,7 +166,7 @@ wire andr_4_inst0_O;
 wire coreir_wrapInClock_inst0_out;
 wire [3:0] magma_Bits_4_xor_inst0_out;
 wire orr_4_inst0_O;
-SomeCircuit SomeCircuit_inst0 (
+foo_SomeCircuit SomeCircuit_inst0 (
     .I(magma_Bits_4_xor_inst0_out)
 );
 assign _magma_bind_wire_0 = orr_4_inst0_O;
@@ -218,7 +218,7 @@ assign handshake_arr_2_valid = handshake_arr_0_ready;
 assign handshake_valid = handshake_ready;
 endmodule
 
-module Main (
+module foo_Main (
     input CLK
 );
 wire RTL_inst0_handshake_arr_0_valid;
@@ -248,7 +248,7 @@ wire [3:0] undriven_inst0_out;
 wire [3:0] undriven_inst1_out;
 wire [4:0] undriven_inst2_out;
 wire [4:0] undriven_inst3_out;
-RTL RTL_inst0 (
+foo_RTL RTL_inst0 (
     .CLK(coreir_wrapOutClock_inst0_out),
     .handshake_arr_0_ready(corebit_undriven_inst2_out),
     .handshake_arr_0_valid(RTL_inst0_handshake_arr_0_valid),
@@ -262,7 +262,7 @@ RTL RTL_inst0 (
     .in2(undriven_inst1_out),
     .out(RTL_inst0_out)
 );
-RTL_unq1 RTL_inst1 (
+foo_RTL_unq1 RTL_inst1 (
     .CLK(coreir_wrapOutClock_inst1_out),
     .handshake_arr_0_ready(corebit_undriven_inst7_out),
     .handshake_arr_0_valid(RTL_inst1_handshake_arr_0_valid),

--- a/tests/test_verilog/rtl.py
+++ b/tests/test_verilog/rtl.py
@@ -5,17 +5,17 @@ class RTL(m.Generator):
     @staticmethod
     def generate(width):
         orr, andr, logical_and = m.define_from_verilog(f"""
-            module orr_{width} (input [{width - 1}:0] I, output O);
-            assign O = |(I);
-            endmodule
+module orr_{width} (input [{width - 1}:0] I, output O);
+assign O = |(I);
+endmodule
 
-            module andr_{width} (input [{width - 1}:0] I, output O);
-            assign O = &(I);
-            endmodule
+module andr_{width} (input [{width - 1}:0] I, output O);
+assign O = &(I);
+endmodule
 
-            module logical_and (input I0, input I1, output O);
-            assign O = I0 && I1;
-            endmodule
+module logical_and (input I0, input I1, output O);
+assign O = I0 && I1;
+endmodule
         """)
 
         class HandShake(m.Product):

--- a/tests/test_verilog/test_bind.py
+++ b/tests/test_verilog/test_bind.py
@@ -9,7 +9,7 @@ from subprocess import run
 def test_bind():
     RTL4 = RTL.generate(4)
 
-    m.compile("build/bind_test", RTL4, inline=True)
+    m.compile("build/bind_test", RTL4, inline=True, user_namespace="foo")
     assert m.testing.check_files_equal(__file__,
                                        f"build/bind_test.v",
                                        f"gold/bind_test.v")
@@ -22,7 +22,7 @@ def test_bind():
     if version >= 4.016:
         assert not os.system('cd tests/test_verilog/build && '
                              'verilator --lint-only bind_test.v RTLMonitor.sv '
-                             '--top-module RTL -Wno-MODDUP')
+                             '--top-module foo_RTL -Wno-MODDUP')
     listings_file = "tests/test_verilog/build/bind_test_bind_files.list"
     with open(listings_file, "r") as f:
         assert f.read() == """\
@@ -38,7 +38,7 @@ def test_bind_multi_unique_name():
         RTL5 = RTL.generate(5)()
 
     m.compile("build/bind_uniq_test", Main, inline=True, drive_undriven=True,
-              terminate_unused=True)
+              terminate_unused=True, user_namespace="foo")
     assert m.testing.check_files_equal(__file__,
                                        f"build/bind_uniq_test.v",
                                        f"gold/bind_uniq_test.v")


### PR DESCRIPTION
Bind logic needs to be aware that the generated module names will change
if the user_namespace option is present.

Also needed to change the generator cacheing to be use cache_definition
so the cache is reset between test invocations (issue revealed in the
bind test)

Also needed the coreir compiler to check if a namespace exists and use it before creating a new one (issue arises when using multiple invocations of compile with the same user_namespace)