### PR TITLE
Fix bug with automatic wiring of temporary clock

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -665,13 +665,13 @@ class DefineCircuitKind(CircuitKind):
 
     def check_unconnected(self):
         for port in self.interface.inputs():
-            if not port.driven():
+            if port.trace() is None:
                 msg = f"Output port {self.name}.{port.name} not driven"
                 _logger.error(msg, debug_info=self.debug_info)
 
         for inst in self.instances:
             for port in inst.interface.inputs():
-                if not port.driven():
+                if port.trace() is None:
                     msg = f"Input port {inst.name}.{port.name} not driven"
                     _logger.error(msg, debug_info=inst.debug_info)
 

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -109,10 +109,10 @@ def wire_clock_port(port, clocktype, defnclk):
         for t in port.ts[1:]:
             for elem in port[1:]:
                 wire_clock_port(elem, clocktype, defnclk)
-    elif isinstance(port, clocktype) and not port.driven():
+    elif isinstance(port, clocktype) and port.trace() is None:
         # Trace to last undriven driver
-        while port.driver is not None:
-            port = port.driver.bit
+        while port.driven():
+            port = port.value()
         wire(defnclk, port)
         wired = True
     return wired

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -188,10 +188,6 @@ class Digital(Type, metaclass=DigitalMeta):
     def driving(self):
         return self._wire.driving()
 
-    @property
-    def driver(self):
-        return self._wire.driver
-
     @classmethod
     def unflatten(cls, value):
         if len(value) != 1 or not isinstance(value[0], Digital):

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -117,8 +117,9 @@ def _make_wires(value, wired):
         return ""
     if not driver.iswhole():
         return "".join(_make_wires(v, wired) for v in value)
-    while driver is not None and driver.name.anon() and not driver.is_output():
-        driver = driver.value()  # skip anon values
+    while (driver is not None and (driver.name.anon() and driver.driven()) and
+           not driver.is_output()):
+        driver = driver.value()  # skip anon values that are driven
     s = ""
     while driver is not None:
         if (driver, value) in wired:

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -117,9 +117,8 @@ def _make_wires(value, wired):
         return ""
     if not driver.iswhole():
         return "".join(_make_wires(v, wired) for v in value)
-    while (driver is not None and (driver.name.anon() and driver.driven()) and
-           not driver.is_output()):
-        driver = driver.value()  # skip anon values that are driven
+    while driver is not None and driver.is_driven_anon_temporary():
+        driver = driver.value()
     s = ""
     while driver is not None:
         if (driver, value) in wired:

--- a/magma/passes/insert_coreir_wires.py
+++ b/magma/passes/insert_coreir_wires.py
@@ -104,11 +104,13 @@ class InsertCoreIRWires(DefinitionPass):
         if value in self.seen:
             return  # in the case of inouts, we may see more than once
         self.seen.add(value)
+        print(type(value))
         if not value.driven():
             return  # undriven value, skip wire insertion
         driver = value.value()
 
-        while (driver is not None and driver.name.anon() and
+        while (driver is not None and
+               (driver.name.anon() and driver.driven()) and
                not driver.is_output()):
             value, driver = driver, driver.value()
 
@@ -119,7 +121,8 @@ class InsertCoreIRWires(DefinitionPass):
                 self._insert_wire(child, definition)
             return
 
-        if driver is None or driver.is_output() or driver.is_inout():
+        if (driver is None or driver.is_output() or driver.is_inout() or
+                driver.name.anon()):
             return
 
         if isinstance(driver.name, PortViewRef):

--- a/magma/passes/insert_coreir_wires.py
+++ b/magma/passes/insert_coreir_wires.py
@@ -1,6 +1,7 @@
 from ..array import Array
 from magma.bit import Bit
 from ..bits import Bits
+from ..clock import AsyncReset, AsyncResetN, Clock
 from ..circuit import coreir_port_mapping
 from ..conversions import as_bits, from_bits
 from ..digital import Digital
@@ -25,8 +26,9 @@ class Wire(Generator2):
         if issubclass(T, Digital):
             coreir_lib = "corebit"
             coreir_genargs = None
-            # Convert to bit so we wrap named types like clock if necessary
-            T = Bit
+            if issubclass(T, (AsyncReset, AsyncResetN, Clock)):
+                # Convert to bit so we wrap named types like clock if necessary
+                T = Bit
         else:
             width = T.flat_length()
             T = Bits[width]

--- a/magma/passes/insert_coreir_wires.py
+++ b/magma/passes/insert_coreir_wires.py
@@ -104,7 +104,6 @@ class InsertCoreIRWires(DefinitionPass):
         if value in self.seen:
             return  # in the case of inouts, we may see more than once
         self.seen.add(value)
-        print(type(value))
         if not value.driven():
             return  # undriven value, skip wire insertion
         driver = value.value()

--- a/magma/passes/insert_coreir_wires.py
+++ b/magma/passes/insert_coreir_wires.py
@@ -110,9 +110,7 @@ class InsertCoreIRWires(DefinitionPass):
             return  # undriven value, skip wire insertion
         driver = value.value()
 
-        while (driver is not None and
-               (driver.name.anon() and driver.driven()) and
-               not driver.is_output()):
+        while driver is not None and driver.is_driven_anon_temporary():
             value, driver = driver, driver.value()
 
         descend = (isinstance(driver, (Array, Tuple)) and

--- a/magma/t.py
+++ b/magma/t.py
@@ -124,6 +124,13 @@ class Type(object):
         # `undriven` on its members.
         raise NotImplementedError()
 
+    def is_driven_anon_temporary(self):
+        """
+        Returns true if this is an anonymous temporary value (not an output)
+        that is driven
+        """
+        return self.name.anon() and not self.is_output() and self.driven()
+
 
 class Kind(type):
     # Subclasses only need to implement one of these methods.

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -106,7 +106,7 @@ class Wire:
         return None
 
     def driven(self):
-        return self.trace() is not None
+        return self._driver is not None
 
     def wired(self):
         return self._driver or self._driving

--- a/tests/test_type/gold/test_insert_wrap_casts_temporary.v
+++ b/tests/test_type/gold/test_insert_wrap_casts_temporary.v
@@ -20,9 +20,11 @@ module corebit_term (
 endmodule
 
 module Bar (
-    input CLK
+    input CLK,
+    input RESETN
 );
 wire _magma_inline_wire0_out;
+wire _magma_inline_wire1_out;
 wire coreir_wrapInClock_inst0_out;
 wire coreir_wrapInClock_inst1_out;
 wire coreir_wrapOutClock_inst0_out;
@@ -34,6 +36,10 @@ Foo Foo_inst0 (
 corebit_wire _magma_inline_wire0 (
     .in(coreir_wrapInClock_inst0_out),
     .out(_magma_inline_wire0_out)
+);
+corebit_wire _magma_inline_wire1 (
+    .in(RESETN),
+    .out(_magma_inline_wire1_out)
 );
 coreir_wrap coreir_wrapInClock_inst0 (
     .in(CLK),
@@ -55,6 +61,6 @@ corebit_wire temp1 (
     .in(coreir_wrapInClock_inst1_out),
     .out(temp1_out)
 );
-always @(posedge coreir_wrapOutClock_inst1_out) $display("Hello");
+always @(posedge coreir_wrapOutClock_inst1_out) disable iff (! _magma_inline_wire1_out) $display("Hello");
 endmodule
 

--- a/tests/test_type/gold/test_insert_wrap_casts_temporary.v
+++ b/tests/test_type/gold/test_insert_wrap_casts_temporary.v
@@ -1,0 +1,60 @@
+// Module `Foo` defined externally
+module coreir_wrap (
+    input in,
+    output out
+);
+  assign out = in;
+endmodule
+
+module corebit_wire (
+    input in,
+    output out
+);
+  assign out = in;
+endmodule
+
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module Bar (
+    input CLK
+);
+wire _magma_inline_wire0_out;
+wire coreir_wrapInClock_inst0_out;
+wire coreir_wrapInClock_inst1_out;
+wire coreir_wrapOutClock_inst0_out;
+wire coreir_wrapOutClock_inst1_out;
+wire temp1_out;
+Foo Foo_inst0 (
+    .CLK(coreir_wrapOutClock_inst0_out)
+);
+corebit_wire _magma_inline_wire0 (
+    .in(coreir_wrapInClock_inst0_out),
+    .out(_magma_inline_wire0_out)
+);
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(CLK),
+    .out(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapInClock_inst1 (
+    .in(CLK),
+    .out(coreir_wrapInClock_inst1_out)
+);
+coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(temp1_out),
+    .out(coreir_wrapOutClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst1 (
+    .in(_magma_inline_wire0_out),
+    .out(coreir_wrapOutClock_inst1_out)
+);
+corebit_wire temp1 (
+    .in(coreir_wrapInClock_inst1_out),
+    .out(temp1_out)
+);
+always @(posedge coreir_wrapOutClock_inst1_out) $display("Hello");
+endmodule
+

--- a/tests/test_type/test_array.py
+++ b/tests/test_type/test_array.py
@@ -177,7 +177,8 @@ def test_wire():
     assert a0.wired()
     assert a1.wired()
 
-    assert a1.driven() is False, "Not driven by an input"
+    assert a0.driven() is False, "Not driven by an input"
+    assert a1.driven() is True, "Driven by a1"
 
     assert a0.trace() is None, "Cannot trace to input"
     assert a1.trace() is None, "Cannot trace to input"

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -397,7 +397,7 @@ def test_insert_wrap_casts_temporary():
         io = m.ClockIO()
 
     class Bar(m.Circuit):
-        io = m.ClockIO()
+        io = m.ClockIO(has_resetn=True)
         foo0 = Foo()
         temp0 = m.Clock()
         temp1 = m.Bit(name="temp1")
@@ -405,8 +405,9 @@ def test_insert_wrap_casts_temporary():
         foo0.CLK @= m.clock(temp1)
 
         temp2 = m.Clock()
+        temp3 = m.ResetN()
         # Test using inline_verilog flow
-        m.inline_verilog('always @(posedge {temp2}) $display("Hello");')
+        m.inline_verilog('always @(posedge {temp2}) disable iff (! {temp3}) $display("Hello");')
 
     m.compile(f"build/test_insert_wrap_casts_temporary", Bar)
     assert check_files_equal(__file__,

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -390,3 +390,25 @@ def test_asyncreset_cast(T, convert):
     m.compile(f"build/test_{T.__name__}_cast", AsyncResetTest)
     assert check_files_equal(__file__, f"build/test_{T.__name__}_cast.v",
                              f"gold/test_{T.__name__}_cast.v")
+
+
+def test_insert_wrap_casts_temporary():
+    class Foo(m.Circuit):
+        io = m.ClockIO()
+
+    class Bar(m.Circuit):
+        io = m.ClockIO()
+        foo0 = Foo()
+        temp0 = m.Clock()
+        temp1 = m.Bit(name="temp1")
+        temp1 @= m.bit(temp0)
+        foo0.CLK @= m.clock(temp1)
+
+        temp2 = m.Clock()
+        # Test using inline_verilog flow
+        m.inline_verilog('always @(posedge {temp2}) $display("Hello");')
+
+    m.compile(f"build/test_insert_wrap_casts_temporary", Bar)
+    assert check_files_equal(__file__,
+                             f"build/test_insert_wrap_casts_temporary.v",
+                             f"gold/test_insert_wrap_casts_temporary.v")


### PR DESCRIPTION
This adds a test and fixes bugs related to automatic wiring of temporary
clocks.  The issue is that the automatic clock wiring logic assumed that
clocks were either driven or undriven at the sink of an instance.
However, in some case, the clock could be driven by a temporary value,
which itself isn't driven.  https://github.com/phanrahan/magma/pull/823
addressed one case where this issue arose, but did not cover the cases
presented in the added test.

First, the InsertWrapCasts logic had to be improved to traverse the
drivers of a port to find any instances where wrapping was necessary.
For example, we could have a temporary value of type Bit driving an
instance port of type Bit (no wrapping needed).  However, the driver of
the temporary Bit might be a clock, so a wrap needs to occur there.

The repr/insert_coreir_wire logic has been improved to handle anon bits
that are no driven (before it would try to call value on these to "skip"
them, but since they are undriven value would actually return the value
that it drives).

This changes the internal `driven` API to return True if a value is
driven (something is wired up to it), rather than True if trace() is
None.  The idea here is that this new version of `driven` is useful for
the above changes, while when we want to check whether a value can be
traced to a source driver, we can simply do trace() is None (whereas
there was no API to check if something is driven without tracing all the
way to a source).