### PR TITLE
Minor bug fixes for riscv_mini CSR

### DIFF
--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -14,7 +14,6 @@ from .bfloat import BFloat
 from .digital import Digital
 from .tuple import Tuple, Product
 from .bitutils import int2seq
-import hwtypes
 import hwtypes as ht
 
 __all__ = ['bit']
@@ -104,7 +103,7 @@ def convertbits(value, n, totype, checkbit):
         return value
 
     convertible_types = (Digital, Tuple, Array, IntegerTypes,
-                         Sequence, hwtypes.BitVector)
+                         Sequence, ht.BitVector)
     if not isinstance(value, convertible_types):
         raise ValueError(
             "bits can only be used on a Bit, an Array, a Tuple, an int, or a"
@@ -115,7 +114,7 @@ def convertbits(value, n, totype, checkbit):
         if n is None:
             n = max(value.bit_length(), 1)
         ts = int2seq(value, n)
-    elif isinstance(value, hwtypes.BitVector):
+    elif isinstance(value, ht.BitVector):
         ts = value.bits()
     elif isinstance(value, Sequence):
         ts = list(value)
@@ -192,7 +191,7 @@ def bfloat(value, n=None):
 def concat(*arrays):
     ts = []
     for a in arrays:
-        if isinstance(a, hwtypes.BitVector):
+        if isinstance(a, ht.BitVector):
             ts.extend(a.bits())
         elif isinstance(a, Bit):
             ts.extend([a])
@@ -311,12 +310,12 @@ def _tuple(value, n=None, t=Tuple):
             decl[k] = type(v)
     for a, d in zip(args, decl):
         # bool types to Bit
-        if issubclass(decl[d], (bool, hwtypes.Bit)):
+        if issubclass(decl[d], (bool, ht.Bit)):
             decl[d] = Digital
         # Promote integer types to Bits
         elif decl[d] in IntegerTypes:
             decl[d] = Bits[max(a.bit_length(), 1)]
-        elif issubclass(decl[d], hwtypes.BitVector):
+        elif issubclass(decl[d], ht.BitVector):
             decl[d] = Bits[len(decl[d])]
 
     if t == Tuple:

--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -198,6 +198,11 @@ def concat(*arrays):
         elif isinstance(a, (bool, ht.Bit)):
             ts.extend([Bit(a)])
         else:
+            if not isinstance(a, Array):
+                raise TypeError(
+                    "concat expects values of type Array, BitVector, Bit, or "
+                    f"bool, not {a} with type {type(a)}"
+                )
             ts.extend(a.ts)
     return array(ts)
 

--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -15,6 +15,7 @@ from .digital import Digital
 from .tuple import Tuple, Product
 from .bitutils import int2seq
 import hwtypes
+import hwtypes as ht
 
 __all__ = ['bit']
 __all__ += ['clock', 'reset', 'enable', 'asyncreset', 'asyncresetn']
@@ -195,6 +196,8 @@ def concat(*arrays):
             ts.extend(a.bits())
         elif isinstance(a, Bit):
             ts.extend([a])
+        elif isinstance(a, (bool, ht.Bit)):
+            ts.extend([Bit(a)])
         else:
             ts.extend(a.ts)
     return array(ts)

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -1,7 +1,6 @@
 from typing import Union
 
 import coreir
-import hwtypes
 import hwtypes as ht
 
 from magma.array import Array
@@ -61,7 +60,7 @@ class _CoreIRRegister(Generator2):
 
             if not state_store:
                 state_store['prev_clock'] = cur_clock
-                state_store['cur_val'] = hwtypes.BitVector[width](init)
+                state_store['cur_val'] = ht.BitVector[width](init)
 
             if has_async_reset or has_async_resetn:
                 cur_reset = value_store.get_value(self.arst)
@@ -76,10 +75,10 @@ class _CoreIRRegister(Generator2):
 
             if has_async_reset and cur_reset or \
                     has_async_resetn and not cur_reset:
-                new_val = hwtypes.BitVector[width](init)
+                new_val = ht.BitVector[width](init)
 
             state_store['prev_clock'] = cur_clock
-            state_store['cur_val'] = hwtypes.BitVector[width](new_val)
+            state_store['cur_val'] = ht.BitVector[width](new_val)
             value_store.set_value(self.O, new_val)
         self.simulate = _simulate
 

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -2,6 +2,7 @@ from typing import Union
 
 import coreir
 import hwtypes
+import hwtypes as ht
 
 from magma.array import Array
 from magma.bit import Bit
@@ -92,8 +93,8 @@ def _zero_init(T, init):
 
 
 class Register(Generator2):
-    def __init__(self, T: Kind, init: Union[Type, int] = None, reset_type:
-                 AbstractReset = None, has_enable: bool = False,
+    def __init__(self, T: Kind, init: Union[Type, int, ht.BitVector] = None,
+                 reset_type: AbstractReset = None, has_enable: bool = False,
                  reset_priority: bool = True):
         """
         T: The type of the value that is stored inside the register (e.g.
@@ -114,7 +115,8 @@ class Register(Generator2):
         if not isinstance(T, Kind):
             raise TypeError(
                 f"Expected instance of Kind for argument T, not {type(T)}")
-        if init is not None and not isinstance(init, (Type, int)):
+        if init is not None and not isinstance(init,
+                                               (Type, int, ht.BitVector)):
             raise TypeError(
                 f"Expected instance of Type or int for argument init, not "
                 f"{type(init)}")

--- a/magma/syntax/inline_combinational.py
+++ b/magma/syntax/inline_combinational.py
@@ -25,7 +25,7 @@ class _ToCombinationalRewriter(ast.NodeTransformer):
         self.name_count = 0
 
     def _gen_new_name(self):
-        new_name = f"{self.prefix}{self.name_count}"
+        new_name = f"{self.prefix}_{self.name_count}_"
         self.name_count += 1
         return new_name
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,4 +1,5 @@
 import magma as m
+import hwtypes as ht
 
 
 def test_concat():
@@ -8,6 +9,10 @@ def test_concat():
     bits1 = m.concat(m.bits(b0), b1)
     assert bits0 == bits1
     assert type(bits0) == m.Out(m.Bits[2])
+
+
+def test_concat_bit():
+    assert int(m.bits(m.concat(ht.Bit(True), True, m.bits(1)))) == 7
 
 
 def test_ext():

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,3 +1,4 @@
+import pytest
 import magma as m
 import hwtypes as ht
 
@@ -26,3 +27,8 @@ def test_ext():
     x4 = m.sext_to(x0, 3)
     assert repr(x3) == "sint(-1, 3)"
     assert repr(x3) == repr(x4)
+
+
+def test_concat_type_error():
+    with pytest.raises(TypeError):
+        m.concat(object(), object())

--- a/tests/test_primitives/test_register.py
+++ b/tests/test_primitives/test_register.py
@@ -1,4 +1,6 @@
 import os
+import pytest
+import hwtypes as ht
 
 import magma as m
 from magma.testing import check_files_equal
@@ -7,10 +9,12 @@ from magma.primitives import Register
 import fault
 
 
-def test_basic_reg():
+@pytest.mark.parametrize("init_T", [m.Bits[8], ht.BitVector[8]])
+def test_basic_reg(init_T):
     class test_basic_reg(m.Circuit):
-        io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8])) + m.ClockIO(has_reset=True)
-        io.O @= Register(m.Bits[8], m.Bits[8](0xDE), reset_type=m.Reset)()(io.I)
+        io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8]))
+        io += m.ClockIO(has_reset=True)
+        io.O @= Register(m.Bits[8], init_T(0xDE), reset_type=m.Reset)()(io.I)
 
     m.compile("build/test_basic_reg", test_basic_reg)
 

--- a/tests/test_syntax/test_inline_comb.py
+++ b/tests/test_syntax/test_inline_comb.py
@@ -139,383 +139,204 @@ def test_Bit_bool():
                                                   "build"))
 
 
-def test_csr_comb():
-    class CSR:
-        N = BV[3](0)
-        W = BV[3](1)
-        S = BV[3](2)
-        C = BV[3](3)
-        P = BV[3](4)
+def test_many_name_gen():
+    """
+    Ensures that there are no collisions when auto generating names in the
+    translation when there are 11 if/else cases and 11 variables.  Before we
+    could encounter a collision with prefix111 where it was either case 11, var
+    1 or case 1, var 11.  Separating the case/var prefix with an underscore
+    avoids this problem
 
-        # Supports machine & user modes
-        PRV_U = BV[2](0x0)
-        PRV_M = BV[2](0x3)
+    See https://github.com/phanrahan/magma/pull/835 for some more context
+    """
 
-        # User-level CSR addrs
-        cycle = BV[12](0xc00)
-        time = BV[12](0xc01)
-        instret = BV[12](0xc02)
-        cycleh = BV[12](0xc80)
-        timeh = BV[12](0xc81)
-        instreth = BV[12](0xc82)
-
-        # Supervisor-level CSR addrs
-        cyclew = BV[12](0x900)
-        timew = BV[12](0x901)
-        instretw = BV[12](0x902)
-        cyclehw = BV[12](0x980)
-        timehw = BV[12](0x981)
-        instrethw = BV[12](0x982)
-
-        # Machine-level CSR addrs
-        # Machine Information Registers
-        mcpuid = BV[12](0xf00)
-        mimpid = BV[12](0xf01)
-        mhartid = BV[12](0xf10)
-
-        # Machine Trap Setup
-        mstatus = BV[12](0x300)
-        mtvec = BV[12](0x301)
-        mtdeleg = BV[12](0x302)
-        mie = BV[12](0x304)
-        mtimecmp = BV[12](0x321)
-
-        # Machine Timers and Counters
-        mtime = BV[12](0x701)
-        mtimeh = BV[12](0x741)
-
-        # Machine Trap Handling
-        mscratch = BV[12](0x340)
-        mepc = BV[12](0x341)
-        mcause = BV[12](0x342)
-        mbadaddr = BV[12](0x343)
-        mip = BV[12](0x344)
-
-        # Machine HITF
-        mtohost = BV[12](0x780)
-        mfromhost = BV[12](0x781)
-
-        regs = [cycle, time, instret, cycleh, timeh, instreth, cyclew, timew,
-                instretw, cyclehw, timehw, instrethw, mcpuid, mimpid, mhartid,
-                mtvec, mtdeleg, mie, mtimecmp, mtime, mtimeh, mscratch, mepc,
-                mcause, mbadaddr, mip, mtohost, mfromhost, mstatus]
-
-    class Const:
-        PC_START = 0x200
-        PC_EVEC = 0x100
-
-    def Valid(T):
-        return m.Product.from_fields(f"Valid[{T}]", {
-            "bits": T,
-            "valid": m.Bit
-        })
-
-    def HostIO(x_len):
-        return m.IO(
-            host=m.Product.from_fields("HostIO", {
-                "fromhost": m.In(Valid(m.UInt[x_len])),
-                "tohost": m.Out(m.UInt[x_len])
-            })
+    # Should not raise TypeError from the combinational block
+    # E.g. 
+    # E           TypeError: ite expects same type for both branches: Out(Bits[12]) != Out(Bits[2])
+    class Foo(m.Circuit):
+        io = m.IO(
+            S=m.In(m.Bits[4]),
+            O0=m.Out(m.Bits[1]),
+            O1=m.Out(m.Bits[2]),
+            O2=m.Out(m.Bits[3]),
+            O3=m.Out(m.Bits[4]),
+            O4=m.Out(m.Bits[5]),
+            O5=m.Out(m.Bits[6]),
+            O6=m.Out(m.Bits[7]),
+            O7=m.Out(m.Bits[8]),
+            O8=m.Out(m.Bits[9]),
+            O9=m.Out(m.Bits[10]),
+            O10=m.Out(m.Bits[11]),
+            O11=m.Out(m.Bits[12])
         )
 
-    class CSRGen(m.Generator2):
-        def __init__(self, x_len):
-            class Cause:
-                InstAddrMisaligned = m.UInt[x_len](0x0)
-                IllegalInst = m.UInt[x_len](0x2)
-                Breakpoint = m.UInt[x_len](0x3)
-                LoadAddrMisaligned = m.UInt[x_len](0x4)
-                StoreAddrMisaligned = m.UInt[x_len](0x6)
-                Ecall = m.UInt[x_len](0x8)
-
-            self.io = io = m.IO(
-                stall=m.In(m.Bit),
-                cmd=m.In(m.UInt[3]),
-                I=m.In(m.UInt[x_len]),
-                O=m.Out(m.UInt[x_len]),
-                # Excpetion
-                pc=m.In(m.UInt[x_len]),
-                addr=m.In(m.UInt[x_len]),
-                inst=m.In(m.UInt[x_len]),
-                illegal=m.In(m.Bit),
-                st_type=m.In(m.UInt[2]),
-                ld_type=m.In(m.UInt[3]),
-                pc_check=m.In(m.Bit),
-                expt=m.Out(m.Bit),
-                evec=m.Out(m.UInt[x_len]),
-                epc=m.Out(m.UInt[x_len])
-            ) + HostIO(x_len) + m.ClockIO()
-
-            csr_addr = io.inst[20:32]
-            rs1_addr = io.inst[15:20]
-
-            # user counters
-            time = m.Register(m.UInt[x_len])()
-            timeh = m.Register(m.UInt[x_len])()
-            cycle = m.Register(m.UInt[x_len])()
-            cycleh = m.Register(m.UInt[x_len])()
-            instret = m.Register(m.UInt[x_len])()
-            instreth = m.Register(m.UInt[x_len])()
-
-            mcpuid = m.concat(BV[2](0),  # RV32I
-                              BV[x_len - 28](0),
-                              BV[26](1 << (ord('I') - ord('A')) |  # Base ISA
-                                     1 << (ord('U') - ord('A'))))  # User Mode
-            mimpid = BV[x_len](0)
-            mhartid = BV[x_len](0)
-
-            # interrupt enable stack
-            PRV = m.Register(m.UInt[len(CSR.PRV_M)], init=CSR.PRV_M)()
-            PRV1 = m.Register(m.UInt[len(CSR.PRV_M)], init=CSR.PRV_M)()
-            PRV2 = BV[2](0)
-            PRV3 = BV[2](0)
-            IE = m.Register(m.Bit, init=False)()
-            IE1 = m.Register(m.Bit, init=False)()
-            IE2 = False
-            IE3 = False
-
-            # virtualization management field
-            VM = BV[5](0)
-
-            # memory privilege
-            MPRV = False
-
-            # Extension context status
-            XS = BV[2](0)
-            FS = BV[2](0)
-            SD = BV[1](0)
-            mstatus = m.concat(SD, BV[x_len-23](0), VM, MPRV, XS, FS, PRV3, IE3,
-                               PRV2, IE2, PRV1.O, IE1.O, PRV.O, IE.O)
-            mtvec = BV[x_len](Const.PC_EVEC)
-            mtdeleg = BV[x_len](0)
-
-            # interrupt registers
-            MTIP = m.Register(m.Bit, init=False)()
-            HTIP = False
-            STIP = False
-            MTIE = m.Register(m.Bit, init=False)()
-            HTIE = False
-            STIE = False
-            MSIP = m.Register(m.Bit, init=False)()
-            HSIP = False
-            SSIP = False
-            MSIE = m.Register(m.Bit, init=False)()
-            HSIE = False
-            SSIE = False
-
-            mip = m.concat(BV[x_len - 8](0), MTIP.O, HTIP, STIP, Bit(False),
-                           MSIP.O, HSIP, SSIP, Bit(False))
-            mie = m.concat(BV[x_len - 8](0), MTIE.O, HTIE, STIE, Bit(False),
-                           MSIE.O, HSIE, SSIE, Bit(False))
-
-            mtimecmp = m.Register(m.UInt[x_len])()
-            mscratch = m.Register(m.UInt[x_len])()
-
-            mepc = m.Register(m.UInt[x_len])()
-            mcause = m.Register(m.UInt[x_len])()
-            mbadaddr = m.Register(m.UInt[x_len])()
-
-            mtohost = m.Register(m.UInt[x_len])()
-            mfromhost = m.Register(m.UInt[x_len])()
-
-            io.host.tohost @= mtohost.O
-            csr_file = {
-                CSR.cycle: cycle.O,
-                CSR.time: time.O,
-                CSR.instret: instret.O,
-                CSR.cycleh: cycleh.O,
-                CSR.timeh: timeh.O,
-                CSR.instreth: instreth.O,
-                CSR.cyclew: cycle.O,
-                CSR.timew: time.O,
-                CSR.instretw: instret.O,
-                CSR.cyclehw: cycleh.O,
-                CSR.timehw: timeh.O,
-                CSR.instrethw: instreth.O,
-                CSR.mcpuid: mcpuid,
-                CSR.mimpid: mimpid,
-                CSR.mhartid: mhartid,
-                CSR.mtvec: mtvec,
-                CSR.mtdeleg: mtdeleg,
-                CSR.mie: mie,
-                CSR.mtimecmp: mtimecmp.O,
-                CSR.mtime: time.O,
-                CSR.mtimeh: timeh.O,
-                CSR.mscratch: mscratch.O,
-                CSR.mepc: mepc.O,
-                CSR.mcause: mcause.O,
-                CSR.mbadaddr: mbadaddr.O,
-                CSR.mip: mip,
-                CSR.mtohost: mtohost.O,
-                CSR.mfromhost: mfromhost.O,
-                CSR.mstatus: mstatus,
-            }
-            out = m.bits(0, x_len)
-            for key, value in reversed(list(csr_file.items())):
-                out = m.mux([out, value], csr_addr == key)
-            io.O @= out
-
-            priv_valid = csr_addr[8:10] <= PRV.O
-            priv_inst = io.cmd == CSR.P
-            is_E_call = priv_inst & ~csr_addr[0] & ~csr_addr[8]
-            is_E_break = priv_inst & csr_addr[0] & ~csr_addr[8]
-            is_E_ret = priv_inst & ~csr_addr[0] & csr_addr[8]
-            csr_valid = m.reduce(operator.or_, m.bits([csr_addr == key
-                                                       for key in csr_file]))
-            csr_RO = (m.reduce(operator.and_, csr_addr[10:12]) |
-                      (csr_addr == CSR.mtvec) | (csr_addr == CSR.mtdeleg))
-            wen = (io.cmd == CSR.W) | io.cmd[1] & m.reduce(operator.or_, rs1_addr)
-            wdata_dict = {
-                CSR.W: io.I,
-                CSR.S: out | io.I,
-                CSR.C: out & ~io.I
-            }
-            wdata = m.uint(0, x_len)
-            for key, value in reversed(list(wdata_dict.items())):
-                wdata = m.mux([wdata, value], io.cmd == key)
-
-            iaddr_invalid = io.pc_check & io.addr[1]
-
-            LD_LW = BV[3](1)
-            LD_LH = BV[3](2)
-            LD_LHU = BV[3](4)
-            laddr_dict = {
-                LD_LW: m.reduce(operator.or_, io.addr[0:1]),
-                LD_LH: io.addr[0],
-                LD_LHU: io.addr[0]
-            }
-            laddr_invalid = False
-            for key, value in reversed(list(laddr_dict.items())):
-                laddr_invalid = m.mux([laddr_invalid, value], io.ld_type == key)
-
-            ST_SW = BV[2](1)
-            ST_SH = BV[2](2)
-            saddr_dict = {
-                ST_SW: m.reduce(operator.or_, io.addr[0:1]),
-                ST_SH: io.addr[0]
-            }
-            saddr_invalid = False
-            for key, value in reversed(list(saddr_dict.items())):
-                saddr_invalid = m.mux([saddr_invalid, value], io.st_type == key)
-
-            expt = (io.illegal | iaddr_invalid | laddr_invalid | saddr_invalid |
-                    m.reduce(operator.or_, io.cmd[0:1]) &
-                    (~csr_valid | ~priv_valid) | wen & csr_RO |
-                    (priv_inst & ~priv_valid) | is_E_call | is_E_break)
-            io.expt @= expt
-
-            io.evec @= mtvec + m.zext_to(PRV.O << 6, x_len)
-            io.epc @= mepc.O
-
-            NOP = m.BitPattern("b00000000000000000000000000010011").as_bv()
-            is_inst_ret = ((io.inst != NOP) &
-                           (~expt | is_E_call | is_E_break) & ~io.stall)
-
-            @m.inline_combinational()
-            def logic():
-                # Counters
-                time.I @= time.O + 1
-                timeh.I @= timeh.O
-                if m.reduce(operator.and_, time.O):
-                    timeh.I @= timeh.O + 1
-
-                cycle.I @= cycle.O + 1
-                cycleh.I @= cycleh.O
-                if m.reduce(operator.and_, cycle.O):
-                    cycleh.I @= cycleh.O + 1
-                instret.I @= instret.O
-                if is_inst_ret:
-                    instret.I @= instret.O + 1
-                instreth.I @= instreth.O
-                if is_inst_ret & m.reduce(operator.and_, instret.O):
-                    instreth.I @= instreth.O + 1
-
-                mbadaddr.I @= mbadaddr.O
-                mepc.I @= mepc.O
-                mcause.I @= mcause.O
-                PRV.I @= PRV.O
-                IE.I @= IE.O
-                IE1.I @= IE1.O
-                PRV1.I @= PRV1.O
-                MTIP.I @= MTIP.O
-                MSIP.I @= MSIP.O
-                MTIE.I @= MTIE.O
-                MSIE.I @= MSIE.O
-                mtimecmp.I @= mtimecmp.O
-                mscratch.I @= mscratch.O
-                mtohost.I @= mtohost.O
-                mfromhost.I @= mfromhost.O
-                if io.host.fromhost.valid:
-                    mfromhost.I @= io.host.fromhost.bits
-
-                if ~io.stall:
-                    if expt:
-                        mepc.I @= io.pc >> 2 << 2
-                        if iaddr_invalid:
-                            mcause.I @= Cause.InstAddrMisaligned
-                        elif laddr_invalid:
-                            mcause.I @= Cause.LoadAddrMisaligned
-                        elif saddr_invalid:
-                            mcause.I @= Cause.StoreAddrMisaligned
-                        elif is_E_call:
-                            mcause.I @= Cause.Ecall + m.zext_to(PRV.O, x_len)
-                        elif is_E_break:
-                            mcause.I @= Cause.Breakpoint
-                        else:
-                            mcause.I @= Cause.IllegalInst
-                        PRV.I @= CSR.PRV_M
-                        IE.I @= False
-                        PRV1.I @= PRV.O
-                        IE1.I @= IE.O
-                        if iaddr_invalid | laddr_invalid | saddr_invalid:
-                            mbadaddr.I @= io.addr
-                    elif is_E_ret:
-                        PRV.I @= PRV1.O
-                        IE.I @= IE1.O
-                        PRV1.I @= CSR.PRV_U
-                        IE1.I @= True
-                    elif wen:
-                        if csr_addr == CSR.mstatus:
-                            PRV1.I @= wdata[4:6]
-                            IE1.I @= wdata[3]
-                            PRV.I @= wdata[1:3]
-                            IE.I @= wdata[0]
-                        elif csr_addr == CSR.mip:
-                            MTIP.I @= wdata[7]
-                            MSIP.I @= wdata[3]
-                        elif csr_addr == CSR.mie:
-                            MTIE.I @= wdata[7]
-                            MSIE.I @= wdata[3]
-                        elif csr_addr == CSR.mtime:
-                            time.I @= wdata
-                        elif csr_addr == CSR.mtimeh:
-                            timeh.I @= wdata
-                        elif csr_addr == CSR.mtimecmp:
-                            mtimecmp.I @= wdata
-                        elif csr_addr == CSR.mscratch:
-                            mscratch.I @= wdata
-                        elif csr_addr == CSR.mepc:
-                            mepc.I @= wdata >> 2 << 2
-                        elif csr_addr == CSR.mcause:
-                            mcause.I @= wdata & (1 << (x_len - 1) | 0xf)
-                        elif csr_addr == CSR.mbadaddr:
-                            mbadaddr.I @= wdata
-                        elif csr_addr == CSR.mtohost:
-                            mtohost.I @= wdata
-                        elif csr_addr == CSR.mfromhost:
-                            mfromhost.I @= wdata
-                        elif csr_addr == CSR.cyclew:
-                            cycle.I @= wdata
-                        elif csr_addr == CSR.timew:
-                            time.I @= wdata
-                        elif csr_addr == CSR.instretw:
-                            instret.I @= wdata
-                        elif csr_addr == CSR.cyclehw:
-                            cycleh.I @= wdata
-                        elif csr_addr == CSR.timehw:
-                            timeh.I @= wdata
-                        elif csr_addr == CSR.instrethw:
-                            instret.I @= wdata
-
-    # Should not error because of auto generated name collisions
-    CSRGen(32)
+        @m.inline_combinational()
+        def logic():
+            io.O0 @= m.bits(0, 1)
+            io.O1 @= m.bits(0, 2)
+            io.O2 @= m.bits(0, 3)
+            io.O3 @= m.bits(0, 4)
+            io.O4 @= m.bits(0, 5)
+            io.O5 @= m.bits(0, 6)
+            io.O6 @= m.bits(0, 7)
+            io.O7 @= m.bits(0, 8)
+            io.O8 @= m.bits(0, 9)
+            io.O9 @= m.bits(0, 10)
+            io.O10 @= m.bits(0, 11)
+            io.O11 @= m.bits(0, 12)
+            if io.S == 0:
+                io.O0 @= m.bits(1, 1)
+                io.O1 @= m.bits(1, 2)
+                io.O2 @= m.bits(1, 3)
+                io.O3 @= m.bits(1, 4)
+                io.O4 @= m.bits(1, 5)
+                io.O5 @= m.bits(1, 6)
+                io.O6 @= m.bits(1, 7)
+                io.O7 @= m.bits(1, 8)
+                io.O8 @= m.bits(1, 9)
+                io.O9 @= m.bits(1, 10)
+                io.O10 @= m.bits(1, 11)
+                io.O11 @= m.bits(1, 12)
+            elif io.S == 1:
+                io.O0 @= m.bits(0, 1)
+                io.O1 @= m.bits(0, 2)
+                io.O2 @= m.bits(0, 3)
+                io.O3 @= m.bits(0, 4)
+                io.O4 @= m.bits(0, 5)
+                io.O5 @= m.bits(0, 6)
+                io.O6 @= m.bits(0, 7)
+                io.O7 @= m.bits(0, 8)
+                io.O8 @= m.bits(0, 9)
+                io.O9 @= m.bits(0, 10)
+                io.O10 @= m.bits(0, 11)
+                io.O11 @= m.bits(0, 12)
+            elif io.S == 2:
+                io.O0 @= m.bits(1, 1)
+                io.O1 @= m.bits(1, 2)
+                io.O2 @= m.bits(1, 3)
+                io.O3 @= m.bits(1, 4)
+                io.O4 @= m.bits(1, 5)
+                io.O5 @= m.bits(1, 6)
+                io.O6 @= m.bits(1, 7)
+                io.O7 @= m.bits(1, 8)
+                io.O8 @= m.bits(1, 9)
+                io.O9 @= m.bits(1, 10)
+                io.O10 @= m.bits(1, 11)
+                io.O11 @= m.bits(1, 12)
+            elif io.S == 3:
+                io.O0 @= m.bits(0, 1)
+                io.O1 @= m.bits(0, 2)
+                io.O2 @= m.bits(0, 3)
+                io.O3 @= m.bits(0, 4)
+                io.O4 @= m.bits(0, 5)
+                io.O5 @= m.bits(0, 6)
+                io.O6 @= m.bits(0, 7)
+                io.O7 @= m.bits(0, 8)
+                io.O8 @= m.bits(0, 9)
+                io.O9 @= m.bits(0, 10)
+                io.O10 @= m.bits(0, 11)
+                io.O11 @= m.bits(0, 12)
+            elif io.S == 4:
+                io.O0 @= m.bits(1, 1)
+                io.O1 @= m.bits(1, 2)
+                io.O2 @= m.bits(1, 3)
+                io.O3 @= m.bits(1, 4)
+                io.O4 @= m.bits(1, 5)
+                io.O5 @= m.bits(1, 6)
+                io.O6 @= m.bits(1, 7)
+                io.O7 @= m.bits(1, 8)
+                io.O8 @= m.bits(1, 9)
+                io.O9 @= m.bits(1, 10)
+                io.O10 @= m.bits(1, 11)
+                io.O11 @= m.bits(1, 12)
+            elif io.S == 5:
+                io.O0 @= m.bits(0, 1)
+                io.O1 @= m.bits(0, 2)
+                io.O2 @= m.bits(0, 3)
+                io.O3 @= m.bits(0, 4)
+                io.O4 @= m.bits(0, 5)
+                io.O5 @= m.bits(0, 6)
+                io.O6 @= m.bits(0, 7)
+                io.O7 @= m.bits(0, 8)
+                io.O8 @= m.bits(0, 9)
+                io.O9 @= m.bits(0, 10)
+                io.O10 @= m.bits(0, 11)
+                io.O11 @= m.bits(0, 12)
+            elif io.S == 6:
+                io.O0 @= m.bits(1, 1)
+                io.O1 @= m.bits(1, 2)
+                io.O2 @= m.bits(1, 3)
+                io.O3 @= m.bits(1, 4)
+                io.O4 @= m.bits(1, 5)
+                io.O5 @= m.bits(1, 6)
+                io.O6 @= m.bits(1, 7)
+                io.O7 @= m.bits(1, 8)
+                io.O8 @= m.bits(1, 9)
+                io.O9 @= m.bits(1, 10)
+                io.O10 @= m.bits(1, 11)
+                io.O11 @= m.bits(1, 12)
+            elif io.S == 7:
+                io.O0 @= m.bits(0, 1)
+                io.O1 @= m.bits(0, 2)
+                io.O2 @= m.bits(0, 3)
+                io.O3 @= m.bits(0, 4)
+                io.O4 @= m.bits(0, 5)
+                io.O5 @= m.bits(0, 6)
+                io.O6 @= m.bits(0, 7)
+                io.O7 @= m.bits(0, 8)
+                io.O8 @= m.bits(0, 9)
+                io.O9 @= m.bits(0, 10)
+                io.O10 @= m.bits(0, 11)
+                io.O11 @= m.bits(0, 12)
+            elif io.S == 8:
+                io.O0 @= m.bits(1, 1)
+                io.O1 @= m.bits(1, 2)
+                io.O2 @= m.bits(1, 3)
+                io.O3 @= m.bits(1, 4)
+                io.O4 @= m.bits(1, 5)
+                io.O5 @= m.bits(1, 6)
+                io.O6 @= m.bits(1, 7)
+                io.O7 @= m.bits(1, 8)
+                io.O8 @= m.bits(1, 9)
+                io.O9 @= m.bits(1, 10)
+                io.O10 @= m.bits(1, 11)
+                io.O11 @= m.bits(1, 12)
+            elif io.S == 9:
+                io.O0 @= m.bits(0, 1)
+                io.O1 @= m.bits(0, 2)
+                io.O2 @= m.bits(0, 3)
+                io.O3 @= m.bits(0, 4)
+                io.O4 @= m.bits(0, 5)
+                io.O5 @= m.bits(0, 6)
+                io.O6 @= m.bits(0, 7)
+                io.O7 @= m.bits(0, 8)
+                io.O8 @= m.bits(0, 9)
+                io.O9 @= m.bits(0, 10)
+                io.O10 @= m.bits(0, 11)
+                io.O11 @= m.bits(0, 12)
+            elif io.S == 10:
+                io.O0 @= m.bits(1, 1)
+                io.O1 @= m.bits(1, 2)
+                io.O2 @= m.bits(1, 3)
+                io.O3 @= m.bits(1, 4)
+                io.O4 @= m.bits(1, 5)
+                io.O5 @= m.bits(1, 6)
+                io.O6 @= m.bits(1, 7)
+                io.O7 @= m.bits(1, 8)
+                io.O8 @= m.bits(1, 9)
+                io.O9 @= m.bits(1, 10)
+                io.O10 @= m.bits(1, 11)
+                io.O11 @= m.bits(1, 12)
+            elif io.S == 11:
+                io.O0 @= m.bits(0, 1)
+                io.O1 @= m.bits(0, 2)
+                io.O2 @= m.bits(0, 3)
+                io.O3 @= m.bits(0, 4)
+                io.O4 @= m.bits(0, 5)
+                io.O5 @= m.bits(0, 6)
+                io.O6 @= m.bits(0, 7)
+                io.O7 @= m.bits(0, 8)
+                io.O8 @= m.bits(0, 9)
+                io.O9 @= m.bits(0, 10)
+                io.O10 @= m.bits(0, 11)
+                io.O11 @= m.bits(0, 12)

--- a/tests/test_syntax/test_inline_comb.py
+++ b/tests/test_syntax/test_inline_comb.py
@@ -204,14 +204,6 @@ def test_csr_comb():
         PC_START = 0x200
         PC_EVEC = 0x100
 
-    def concat(*args):
-        x = args[0]
-        if isinstance(x, Bit):
-            x = BitVector[1](x)
-        if len(args) == 1:
-            return x
-        return x.concat(concat(*args[1:]))
-
     def Valid(T):
         return m.Product.from_fields(f"Valid[{T}]", {
             "bits": T,
@@ -265,10 +257,10 @@ def test_csr_comb():
             instret = m.Register(m.UInt[x_len])()
             instreth = m.Register(m.UInt[x_len])()
 
-            mcpuid = concat(BV[2](0),  # RV32I
-                            BV[x_len - 28](0),
-                            BV[26](1 << (ord('I') - ord('A')) |  # Base ISA
-                                   1 << (ord('U') - ord('A'))))  # User Mode
+            mcpuid = m.concat(BV[2](0),  # RV32I
+                              BV[x_len - 28](0),
+                              BV[26](1 << (ord('I') - ord('A')) |  # Base ISA
+                                     1 << (ord('U') - ord('A'))))  # User Mode
             mimpid = BV[x_len](0)
             mhartid = BV[x_len](0)
 

--- a/tests/test_syntax/test_inline_comb.py
+++ b/tests/test_syntax/test_inline_comb.py
@@ -1,6 +1,7 @@
+import operator
 import os
 import fault
-from hwtypes import BitVector, Bit
+from hwtypes import BitVector, Bit, BitVector as BV
 import magma as m
 from magma.testing import check_files_equal
 
@@ -136,3 +137,393 @@ def test_Bit_bool():
     tester.compile_and_run("verilator", skip_compile=True,
                            directory=os.path.join(os.path.dirname(__file__),
                                                   "build"))
+
+
+def test_csr_comb():
+    class CSR:
+        N = BV[3](0)
+        W = BV[3](1)
+        S = BV[3](2)
+        C = BV[3](3)
+        P = BV[3](4)
+
+        # Supports machine & user modes
+        PRV_U = BV[2](0x0)
+        PRV_M = BV[2](0x3)
+
+        # User-level CSR addrs
+        cycle = BV[12](0xc00)
+        time = BV[12](0xc01)
+        instret = BV[12](0xc02)
+        cycleh = BV[12](0xc80)
+        timeh = BV[12](0xc81)
+        instreth = BV[12](0xc82)
+
+        # Supervisor-level CSR addrs
+        cyclew = BV[12](0x900)
+        timew = BV[12](0x901)
+        instretw = BV[12](0x902)
+        cyclehw = BV[12](0x980)
+        timehw = BV[12](0x981)
+        instrethw = BV[12](0x982)
+
+        # Machine-level CSR addrs
+        # Machine Information Registers
+        mcpuid = BV[12](0xf00)
+        mimpid = BV[12](0xf01)
+        mhartid = BV[12](0xf10)
+
+        # Machine Trap Setup
+        mstatus = BV[12](0x300)
+        mtvec = BV[12](0x301)
+        mtdeleg = BV[12](0x302)
+        mie = BV[12](0x304)
+        mtimecmp = BV[12](0x321)
+
+        # Machine Timers and Counters
+        mtime = BV[12](0x701)
+        mtimeh = BV[12](0x741)
+
+        # Machine Trap Handling
+        mscratch = BV[12](0x340)
+        mepc = BV[12](0x341)
+        mcause = BV[12](0x342)
+        mbadaddr = BV[12](0x343)
+        mip = BV[12](0x344)
+
+        # Machine HITF
+        mtohost = BV[12](0x780)
+        mfromhost = BV[12](0x781)
+
+        regs = [cycle, time, instret, cycleh, timeh, instreth, cyclew, timew,
+                instretw, cyclehw, timehw, instrethw, mcpuid, mimpid, mhartid,
+                mtvec, mtdeleg, mie, mtimecmp, mtime, mtimeh, mscratch, mepc,
+                mcause, mbadaddr, mip, mtohost, mfromhost, mstatus]
+
+    class Const:
+        PC_START = 0x200
+        PC_EVEC = 0x100
+
+    def concat(*args):
+        x = args[0]
+        if isinstance(x, Bit):
+            x = BitVector[1](x)
+        if len(args) == 1:
+            return x
+        return x.concat(concat(*args[1:]))
+
+    def Valid(T):
+        return m.Product.from_fields(f"Valid[{T}]", {
+            "bits": T,
+            "valid": m.Bit
+        })
+
+    def HostIO(x_len):
+        return m.IO(
+            host=m.Product.from_fields("HostIO", {
+                "fromhost": m.In(Valid(m.UInt[x_len])),
+                "tohost": m.Out(m.UInt[x_len])
+            })
+        )
+
+    class CSRGen(m.Generator2):
+        def __init__(self, x_len):
+            class Cause:
+                InstAddrMisaligned = m.UInt[x_len](0x0)
+                IllegalInst = m.UInt[x_len](0x2)
+                Breakpoint = m.UInt[x_len](0x3)
+                LoadAddrMisaligned = m.UInt[x_len](0x4)
+                StoreAddrMisaligned = m.UInt[x_len](0x6)
+                Ecall = m.UInt[x_len](0x8)
+
+            self.io = io = m.IO(
+                stall=m.In(m.Bit),
+                cmd=m.In(m.UInt[3]),
+                I=m.In(m.UInt[x_len]),
+                O=m.Out(m.UInt[x_len]),
+                # Excpetion
+                pc=m.In(m.UInt[x_len]),
+                addr=m.In(m.UInt[x_len]),
+                inst=m.In(m.UInt[x_len]),
+                illegal=m.In(m.Bit),
+                st_type=m.In(m.UInt[2]),
+                ld_type=m.In(m.UInt[3]),
+                pc_check=m.In(m.Bit),
+                expt=m.Out(m.Bit),
+                evec=m.Out(m.UInt[x_len]),
+                epc=m.Out(m.UInt[x_len])
+            ) + HostIO(x_len) + m.ClockIO()
+
+            csr_addr = io.inst[20:32]
+            rs1_addr = io.inst[15:20]
+
+            # user counters
+            time = m.Register(m.UInt[x_len])()
+            timeh = m.Register(m.UInt[x_len])()
+            cycle = m.Register(m.UInt[x_len])()
+            cycleh = m.Register(m.UInt[x_len])()
+            instret = m.Register(m.UInt[x_len])()
+            instreth = m.Register(m.UInt[x_len])()
+
+            mcpuid = concat(BV[2](0),  # RV32I
+                            BV[x_len - 28](0),
+                            BV[26](1 << (ord('I') - ord('A')) |  # Base ISA
+                                   1 << (ord('U') - ord('A'))))  # User Mode
+            mimpid = BV[x_len](0)
+            mhartid = BV[x_len](0)
+
+            # interrupt enable stack
+            PRV = m.Register(m.UInt[len(CSR.PRV_M)], init=CSR.PRV_M)()
+            PRV1 = m.Register(m.UInt[len(CSR.PRV_M)], init=CSR.PRV_M)()
+            PRV2 = BV[2](0)
+            PRV3 = BV[2](0)
+            IE = m.Register(m.Bit, init=False)()
+            IE1 = m.Register(m.Bit, init=False)()
+            IE2 = False
+            IE3 = False
+
+            # virtualization management field
+            VM = BV[5](0)
+
+            # memory privilege
+            MPRV = False
+
+            # Extension context status
+            XS = BV[2](0)
+            FS = BV[2](0)
+            SD = BV[1](0)
+            mstatus = m.concat(SD, BV[x_len-23](0), VM, MPRV, XS, FS, PRV3, IE3,
+                               PRV2, IE2, PRV1.O, IE1.O, PRV.O, IE.O)
+            mtvec = BV[x_len](Const.PC_EVEC)
+            mtdeleg = BV[x_len](0)
+
+            # interrupt registers
+            MTIP = m.Register(m.Bit, init=False)()
+            HTIP = False
+            STIP = False
+            MTIE = m.Register(m.Bit, init=False)()
+            HTIE = False
+            STIE = False
+            MSIP = m.Register(m.Bit, init=False)()
+            HSIP = False
+            SSIP = False
+            MSIE = m.Register(m.Bit, init=False)()
+            HSIE = False
+            SSIE = False
+
+            mip = m.concat(BV[x_len - 8](0), MTIP.O, HTIP, STIP, Bit(False),
+                           MSIP.O, HSIP, SSIP, Bit(False))
+            mie = m.concat(BV[x_len - 8](0), MTIE.O, HTIE, STIE, Bit(False),
+                           MSIE.O, HSIE, SSIE, Bit(False))
+
+            mtimecmp = m.Register(m.UInt[x_len])()
+            mscratch = m.Register(m.UInt[x_len])()
+
+            mepc = m.Register(m.UInt[x_len])()
+            mcause = m.Register(m.UInt[x_len])()
+            mbadaddr = m.Register(m.UInt[x_len])()
+
+            mtohost = m.Register(m.UInt[x_len])()
+            mfromhost = m.Register(m.UInt[x_len])()
+
+            io.host.tohost @= mtohost.O
+            csr_file = {
+                CSR.cycle: cycle.O,
+                CSR.time: time.O,
+                CSR.instret: instret.O,
+                CSR.cycleh: cycleh.O,
+                CSR.timeh: timeh.O,
+                CSR.instreth: instreth.O,
+                CSR.cyclew: cycle.O,
+                CSR.timew: time.O,
+                CSR.instretw: instret.O,
+                CSR.cyclehw: cycleh.O,
+                CSR.timehw: timeh.O,
+                CSR.instrethw: instreth.O,
+                CSR.mcpuid: mcpuid,
+                CSR.mimpid: mimpid,
+                CSR.mhartid: mhartid,
+                CSR.mtvec: mtvec,
+                CSR.mtdeleg: mtdeleg,
+                CSR.mie: mie,
+                CSR.mtimecmp: mtimecmp.O,
+                CSR.mtime: time.O,
+                CSR.mtimeh: timeh.O,
+                CSR.mscratch: mscratch.O,
+                CSR.mepc: mepc.O,
+                CSR.mcause: mcause.O,
+                CSR.mbadaddr: mbadaddr.O,
+                CSR.mip: mip,
+                CSR.mtohost: mtohost.O,
+                CSR.mfromhost: mfromhost.O,
+                CSR.mstatus: mstatus,
+            }
+            out = m.bits(0, x_len)
+            for key, value in reversed(list(csr_file.items())):
+                out = m.mux([out, value], csr_addr == key)
+            io.O @= out
+
+            priv_valid = csr_addr[8:10] <= PRV.O
+            priv_inst = io.cmd == CSR.P
+            is_E_call = priv_inst & ~csr_addr[0] & ~csr_addr[8]
+            is_E_break = priv_inst & csr_addr[0] & ~csr_addr[8]
+            is_E_ret = priv_inst & ~csr_addr[0] & csr_addr[8]
+            csr_valid = m.reduce(operator.or_, m.bits([csr_addr == key
+                                                       for key in csr_file]))
+            csr_RO = (m.reduce(operator.and_, csr_addr[10:12]) |
+                      (csr_addr == CSR.mtvec) | (csr_addr == CSR.mtdeleg))
+            wen = (io.cmd == CSR.W) | io.cmd[1] & m.reduce(operator.or_, rs1_addr)
+            wdata_dict = {
+                CSR.W: io.I,
+                CSR.S: out | io.I,
+                CSR.C: out & ~io.I
+            }
+            wdata = m.uint(0, x_len)
+            for key, value in reversed(list(wdata_dict.items())):
+                wdata = m.mux([wdata, value], io.cmd == key)
+
+            iaddr_invalid = io.pc_check & io.addr[1]
+
+            LD_LW = BV[3](1)
+            LD_LH = BV[3](2)
+            LD_LHU = BV[3](4)
+            laddr_dict = {
+                LD_LW: m.reduce(operator.or_, io.addr[0:1]),
+                LD_LH: io.addr[0],
+                LD_LHU: io.addr[0]
+            }
+            laddr_invalid = False
+            for key, value in reversed(list(laddr_dict.items())):
+                laddr_invalid = m.mux([laddr_invalid, value], io.ld_type == key)
+
+            ST_SW = BV[2](1)
+            ST_SH = BV[2](2)
+            saddr_dict = {
+                ST_SW: m.reduce(operator.or_, io.addr[0:1]),
+                ST_SH: io.addr[0]
+            }
+            saddr_invalid = False
+            for key, value in reversed(list(saddr_dict.items())):
+                saddr_invalid = m.mux([saddr_invalid, value], io.st_type == key)
+
+            expt = (io.illegal | iaddr_invalid | laddr_invalid | saddr_invalid |
+                    m.reduce(operator.or_, io.cmd[0:1]) &
+                    (~csr_valid | ~priv_valid) | wen & csr_RO |
+                    (priv_inst & ~priv_valid) | is_E_call | is_E_break)
+            io.expt @= expt
+
+            io.evec @= mtvec + m.zext_to(PRV.O << 6, x_len)
+            io.epc @= mepc.O
+
+            NOP = m.BitPattern("b00000000000000000000000000010011").as_bv()
+            is_inst_ret = ((io.inst != NOP) &
+                           (~expt | is_E_call | is_E_break) & ~io.stall)
+
+            @m.inline_combinational()
+            def logic():
+                # Counters
+                time.I @= time.O + 1
+                timeh.I @= timeh.O
+                if m.reduce(operator.and_, time.O):
+                    timeh.I @= timeh.O + 1
+
+                cycle.I @= cycle.O + 1
+                cycleh.I @= cycleh.O
+                if m.reduce(operator.and_, cycle.O):
+                    cycleh.I @= cycleh.O + 1
+                instret.I @= instret.O
+                if is_inst_ret:
+                    instret.I @= instret.O + 1
+                instreth.I @= instreth.O
+                if is_inst_ret & m.reduce(operator.and_, instret.O):
+                    instreth.I @= instreth.O + 1
+
+                mbadaddr.I @= mbadaddr.O
+                mepc.I @= mepc.O
+                mcause.I @= mcause.O
+                PRV.I @= PRV.O
+                IE.I @= IE.O
+                IE1.I @= IE1.O
+                PRV1.I @= PRV1.O
+                MTIP.I @= MTIP.O
+                MSIP.I @= MSIP.O
+                MTIE.I @= MTIE.O
+                MSIE.I @= MSIE.O
+                mtimecmp.I @= mtimecmp.O
+                mscratch.I @= mscratch.O
+                mtohost.I @= mtohost.O
+                mfromhost.I @= mfromhost.O
+                if io.host.fromhost.valid:
+                    mfromhost.I @= io.host.fromhost.bits
+
+                if ~io.stall:
+                    if expt:
+                        mepc.I @= io.pc >> 2 << 2
+                        if iaddr_invalid:
+                            mcause.I @= Cause.InstAddrMisaligned
+                        elif laddr_invalid:
+                            mcause.I @= Cause.LoadAddrMisaligned
+                        elif saddr_invalid:
+                            mcause.I @= Cause.StoreAddrMisaligned
+                        elif is_E_call:
+                            mcause.I @= Cause.Ecall + m.zext_to(PRV.O, x_len)
+                        elif is_E_break:
+                            mcause.I @= Cause.Breakpoint
+                        else:
+                            mcause.I @= Cause.IllegalInst
+                        PRV.I @= CSR.PRV_M
+                        IE.I @= False
+                        PRV1.I @= PRV.O
+                        IE1.I @= IE.O
+                        if iaddr_invalid | laddr_invalid | saddr_invalid:
+                            mbadaddr.I @= io.addr
+                    elif is_E_ret:
+                        PRV.I @= PRV1.O
+                        IE.I @= IE1.O
+                        PRV1.I @= CSR.PRV_U
+                        IE1.I @= True
+                    elif wen:
+                        if csr_addr == CSR.mstatus:
+                            PRV1.I @= wdata[4:6]
+                            IE1.I @= wdata[3]
+                            PRV.I @= wdata[1:3]
+                            IE.I @= wdata[0]
+                        elif csr_addr == CSR.mip:
+                            MTIP.I @= wdata[7]
+                            MSIP.I @= wdata[3]
+                        elif csr_addr == CSR.mie:
+                            MTIE.I @= wdata[7]
+                            MSIE.I @= wdata[3]
+                        elif csr_addr == CSR.mtime:
+                            time.I @= wdata
+                        elif csr_addr == CSR.mtimeh:
+                            timeh.I @= wdata
+                        elif csr_addr == CSR.mtimecmp:
+                            mtimecmp.I @= wdata
+                        elif csr_addr == CSR.mscratch:
+                            mscratch.I @= wdata
+                        elif csr_addr == CSR.mepc:
+                            mepc.I @= wdata >> 2 << 2
+                        elif csr_addr == CSR.mcause:
+                            mcause.I @= wdata & (1 << (x_len - 1) | 0xf)
+                        elif csr_addr == CSR.mbadaddr:
+                            mbadaddr.I @= wdata
+                        elif csr_addr == CSR.mtohost:
+                            mtohost.I @= wdata
+                        elif csr_addr == CSR.mfromhost:
+                            mfromhost.I @= wdata
+                        elif csr_addr == CSR.cyclew:
+                            cycle.I @= wdata
+                        elif csr_addr == CSR.timew:
+                            time.I @= wdata
+                        elif csr_addr == CSR.instretw:
+                            instret.I @= wdata
+                        elif csr_addr == CSR.cyclehw:
+                            cycleh.I @= wdata
+                        elif csr_addr == CSR.timehw:
+                            timeh.I @= wdata
+                        elif csr_addr == CSR.instrethw:
+                            instret.I @= wdata
+
+    # Should not error because of auto generated name collisions
+    CSRGen(32)


### PR DESCRIPTION
* Support bool/bit in m.concat
* Support BitVector for Register init
* Include "_" separating unique numeric IDs for inline combinational
  (avoids name clobbering when we rollover, such as when there are more
  than 10 variables)

For the third bug, it's unfortunately difficult to create a small example to reproduce the issue (since it inherently only manifests with large programs), so I just factored out the necessary code from the riscv_mini csr as a test.  It's not essential that this stays up to date with the actual code, since all we need is a program complex enough to generate enough IDs to test the unique name generation logic (i.e. what the program does is not important, the fact that it compiles without error is important)