### PR TITLE
Add built-in Valid type

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -102,4 +102,4 @@ from .syntax.coroutine import coroutine
 from magma.primitives import (LUT, Mux, mux, Register, get_slice, set_slice,
                               slice, reduce, Memory)
 
-from magma.types import BitPattern
+from magma.types import BitPattern, Valid

--- a/magma/types/__init__.py
+++ b/magma/types/__init__.py
@@ -1,1 +1,2 @@
 from .bit_pattern import BitPattern
+from .valid import Valid

--- a/magma/types/valid.py
+++ b/magma/types/valid.py
@@ -1,0 +1,17 @@
+from magma.bit import Bit
+from magma.t import Type
+from magma.tuple import Product, ProductKind
+
+
+class ValidKind(ProductKind):
+    def __getitem__(cls, T: Type):
+        if not issubclass(T, Type):
+            raise TypeError(
+                f"Valid[T] expected T to be a subclass of m.Type not {T}"
+            )
+        fields = {"valid": Bit, "data": T}
+        return type(f"Valid[{T}]", (Valid, ), fields)
+
+
+class Valid(Product, metaclass=ValidKind):
+    pass

--- a/tests/test_type/gold/TestValidSimple.v
+++ b/tests/test_type/gold/TestValidSimple.v
@@ -1,0 +1,10 @@
+module TestValidSimple (
+    input [4:0] I_data,
+    input I_valid,
+    output [4:0] O_data,
+    output O_valid
+);
+assign O_data = I_data;
+assign O_valid = I_valid;
+endmodule
+

--- a/tests/test_type/gold/TestValidTuple.v
+++ b/tests/test_type/gold/TestValidTuple.v
@@ -1,0 +1,13 @@
+module TestValidTuple (
+    input I_data__0,
+    input [4:0] I_data__1,
+    input I_valid,
+    output O_data__0,
+    output [4:0] O_data__1,
+    output O_valid
+);
+assign O_data__0 = I_data__0;
+assign O_data__1 = I_data__1;
+assign O_valid = I_valid;
+endmodule
+

--- a/tests/test_type/test_valid.py
+++ b/tests/test_type/test_valid.py
@@ -12,7 +12,7 @@ def test_valid_simple():
         io.O @= io.I
 
     m.compile("build/TestValidSimple", TestValidSimple)
-    assert check_files_equal(__file__, f"build/TestvalidSimple.v",
+    assert check_files_equal(__file__, f"build/TestValidSimple.v",
                              f"gold/TestValidSimple.v")
 
 
@@ -25,5 +25,5 @@ def test_valid_tuple():
         io.O @= io.I
 
     m.compile("build/TestValidTuple", TestValidTuple)
-    assert check_files_equal(__file__, f"build/TestvalidTuple.v",
+    assert check_files_equal(__file__, f"build/TestValidTuple.v",
                              f"gold/TestValidTuple.v")

--- a/tests/test_type/test_valid.py
+++ b/tests/test_type/test_valid.py
@@ -1,0 +1,29 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_valid_simple():
+    class TestValidSimple(m.Circuit):
+        io = m.IO(
+            I=m.In(m.Valid[m.Bits[5]]),
+            O=m.Out(m.Valid[m.Bits[5]])
+        )
+        assert isinstance(io.I, m.Valid)
+        io.O @= io.I
+
+    m.compile("build/TestValidSimple", TestValidSimple)
+    assert check_files_equal(__file__, f"build/TestvalidSimple.v",
+                             f"gold/TestValidSimple.v")
+
+
+def test_valid_tuple():
+    class TestValidTuple(m.Circuit):
+        io = m.IO(
+            I=m.In(m.Valid[m.Tuple[m.Bit, m.Bits[5]]]),
+            O=m.Out(m.Valid[m.Tuple[m.Bit, m.Bits[5]]])
+        )
+        io.O @= io.I
+
+    m.compile("build/TestValidTuple", TestValidTuple)
+    assert check_files_equal(__file__, f"build/TestvalidTuple.v",
+                             f"gold/TestValidTuple.v")


### PR DESCRIPTION
This provides a standardize type for the valid pattern.  It uses the
same getitem interface as the other parametrized types (e.g. Valid[T]).
It creates a product with two fields:
* `valid: Bit`
* `data: T`

For now it doesn't provide any other methods but we can use the Valid
class as a place to add any useful functions.  We can also start using
introspect on Valid types to define standard/reuseable code based on
Valid interfaces.