### PR TITLE
Add logic to infer Register type from init

### DIFF
--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -134,15 +134,16 @@ class Register(Generator2):
                 raise ValueError("User must provide type T or init value (from"
                                  " which T will be inferred)")
             T = _get_T_from_init(init)
-        if not isinstance(T, Kind):
-            raise TypeError(
-                f"Expected instance of Kind for argument T, not {type(T)}")
-        if init is not None and not isinstance(init,
-                                               (Type, bool, int, ht.BitVector,
-                                                ht.Bit)):
-            raise TypeError(
-                "Expected instance of Type, bool, int, ht.BitVector, or Bit "
-                f"for argument init, not {type(init)}")
+        else:
+            if not isinstance(T, Kind):
+                raise TypeError(
+                    f"Expected instance of Kind for argument T, not {type(T)}")
+            if init is not None and not issubclass(_get_T_from_init(init), T):
+                raise ValueError(
+                    f"Type {_get_T_from_init(init)} of init ({init}) does not "
+                    f"match T ({T})"
+                )
+
         (
             has_async_reset, has_async_resetn, has_reset, has_resetn
         ) = get_reset_args(reset_type)

--- a/tests/test_primitives/test_register.py
+++ b/tests/test_primitives/test_register.py
@@ -246,7 +246,7 @@ def test_enable_reg():
      # (ht.UIntVector[3](3), m.UInt[3]),
      # (ht.SIntVector[3](-3), m.SInt[3]),
      (ht.UIntVector[3](5), m.UInt[3]),
-     (ht.SIntVector[3](-7), m.SInt[3]),
+     (ht.SIntVector[3](-2), m.SInt[3]),
      (ht.BitVector[3](2), m.Bits[3])])
 def test_reg_infer_init(init, expected_T):
     Circuit = Register(init=init)

--- a/tests/test_primitives/test_register.py
+++ b/tests/test_primitives/test_register.py
@@ -242,9 +242,11 @@ def test_enable_reg():
 @pytest.mark.parametrize(
     "init, expected_T",
     [(3, m.Bits[2]), (True, m.Bit), (ht.Bit(True), m.Bit),
-     # (ht.UIntVector[3](3), m.UInt[3]),  # blocked by https://github.com/leonardt/hwtypes/pull/140
+     # These are blocked by https://github.com/leonardt/hwtypes/pull/140
+     # (ht.UIntVector[3](3), m.UInt[3]),
+     # (ht.SIntVector[3](-3), m.SInt[3]),
      (ht.UIntVector[3](5), m.UInt[3]),
-     (ht.SIntVector[3](-3), m.SInt[3]),
+     (ht.SIntVector[3](-7), m.SInt[3]),
      (ht.BitVector[3](2), m.Bits[3])])
 def test_reg_infer_init(init, expected_T):
     Circuit = Register(init=init)

--- a/tests/test_primitives/test_register.py
+++ b/tests/test_primitives/test_register.py
@@ -237,3 +237,15 @@ def test_enable_reg():
     tester.compile_and_run("verilator", skip_compile=True,
                            directory=os.path.join(os.path.dirname(__file__),
                                                   "build"))
+
+
+@pytest.mark.parametrize(
+    "init, expected_T",
+    [(3, m.Bits[2]), (True, m.Bit), (ht.Bit(True), m.Bit),
+     # (ht.UIntVector[3](3), m.UInt[3]),  # blocked by https://github.com/leonardt/hwtypes/pull/140
+     (ht.UIntVector[3](5), m.UInt[3]),
+     (ht.SIntVector[3](-3), m.SInt[3]),
+     (ht.BitVector[3](2), m.Bits[3])])
+def test_reg_infer_init(init, expected_T):
+    Circuit = Register(init=init)
+    assert isinstance(Circuit.I, expected_T)


### PR DESCRIPTION
Pulling into https://github.com/phanrahan/magma/pull/835 since it touches the same lines in the register changes.

This adds some convenience when the user is specifying an init value, avoiding the need to specify both T and init when we can simply infer T from init