### PR TITLE
Restrict inline_combinational to use wiring

### DIFF
--- a/docs/inline_combinational.md
+++ b/docs/inline_combinational.md
@@ -15,18 +15,23 @@ Here's a simple example:
 
 ```python
 class Main(m.Circuit):
-    io = m.IO(invert=m.In(m.Bit), O=m.Out(m.Bit))
+    io = m.IO(invert=m.In(m.Bit), O0=m.Out(m.Bit), O1=m.Out(m.Bit))
     io += m.ClockIO()
     reg = m.Register(m.Bit)()
 
-    @m.inline_combinational()
+    O1 = m.Bit()
+
+    @m.inline_combinational(debug=True, file_name="inline_comb.py")
     def logic():
         if io.invert:
             reg.I @= ~reg.O
+            O1 @= ~reg.O
         else:
             reg.I @= reg.O
+            O1 @= reg.O
 
-    io.O @= reg.O
+    io.O0 @= reg.O
+    io.O1 @= O1
 ```
 
 Notice that the first 3 lines of `Main`'s definition are standard magma.
@@ -53,8 +58,10 @@ during the `inline_combinational` rewrite process:
    def logic():
        if io.invert:
            _auto_prefix_00 = ~reg.O
+           _auto_prefix_01 = ~reg.O
        else:
            _auto_prefix_00 = reg.O
+           _auto_prefix_01 = reg.O
        return _auto_prefix_00, _auto_prefix_01
    ```
 2. Run the standard combinational passes.  This removes the if statements by
@@ -64,9 +71,12 @@ during the `inline_combinational` rewrite process:
    @m.inline_combinational(debug=True, file_name='inline_comb.py')
    def logic():
        _auto_prefix_000 = ~reg.O
+       _auto_prefix_010 = ~reg.O
        _auto_prefix_001 = reg.O
+       _auto_prefix_011 = reg.O
        _auto_prefix_002 = __phi(io.invert, _auto_prefix_000, _auto_prefix_001)
-       __return_value0 = _auto_prefix_002
+       _auto_prefix_012 = __phi(io.invert, _auto_prefix_010, _auto_prefix_011)
+       __return_value0 = _auto_prefix_002, _auto_prefix_012
        return __return_value0
    ```
 

--- a/docs/inline_combinational.md
+++ b/docs/inline_combinational.md
@@ -15,7 +15,7 @@ Here's a simple example:
 
 ```python
 class Main(m.Circuit):
-    io = m.IO(invert=m.In(m.Bit), O0=m.Out(m.Bit), O1=m.Out(m.Bit))
+    io = m.IO(invert=m.In(m.Bit), O=m.Out(m.Bit))
     io += m.ClockIO()
     reg = m.Register(m.Bit)()
 
@@ -23,37 +23,28 @@ class Main(m.Circuit):
     def logic():
         if io.invert:
             reg.I @= ~reg.O
-            O1 = ~reg.O
         else:
             reg.I @= reg.O
-            O1 = reg.O
 
-    io.O0 @= reg.O
-    io.O1 @= O1
+    io.O @= reg.O
 ```
 
 Notice that the first 3 lines of `Main`'s definition are standard magma.
 
 Inside the function `logic` that has been decorated with
 `@m.inline_combinational`, the user can refer to `reg` (a normal magma
-instance) and it's ports to perform logic and wiring.  The definition of
-`logic` shows two ways to use the `combinational` rewrite to generate a muxes.
-
-The first way wires to `reg.I` using the `@=` operator inside the if statement.
-The `combinational` rewrite logic will change these statements to assign to a
-temporary value, which will then get process by the SSA pass to produce the
-final value (output of a mux or chain of muxes) which is then wired to the
-original target (`reg.I` in this case).
-
-The second way assigns to a temporary value `O1`.  This value is handled using
-the standard `combinational` treatment and the final value produced by SSA is
-returned from the function and assigned in the enclosing environment.
+instance) and it's ports to perform logic and wiring.
+Notice that the code wires the `reg.I` using the `@=` operator inside the if
+statement.  The `combinational` rewrite logic will change these statements to
+assign to a temporary value, which will then get process by the SSA pass to
+produce the final value (output of a mux or chain of muxes) which is then wired
+to the original target (`reg.I` in this case).
 
 # Internal Details
 For more details on the rewrites, here are two dumps of the intermediate code
 during the `inline_combinational` rewrite process:
 1. Introduce temporary values.  At this point, the wiring targets (LHS of `@=`
-   operators) and assignment targets are replaced with a temporary values
+   operators) are replaced with a temporary values
    (using the prefix `auto_prefix0`, so `auto_prefix00` is the first temporary,
    `auto_prefix01` is the second temporary, the 2nd digit is used for the
    unique id). These temporary values are returned from the function.
@@ -62,10 +53,8 @@ during the `inline_combinational` rewrite process:
    def logic():
        if io.invert:
            _auto_prefix_00 = ~reg.O
-           _auto_prefix_01 = ~reg.O
        else:
            _auto_prefix_00 = reg.O
-           _auto_prefix_01 = reg.O
        return _auto_prefix_00, _auto_prefix_01
    ```
 2. Run the standard combinational passes.  This removes the if statements by
@@ -75,17 +64,13 @@ during the `inline_combinational` rewrite process:
    @m.inline_combinational(debug=True, file_name='inline_comb.py')
    def logic():
        _auto_prefix_000 = ~reg.O
-       _auto_prefix_010 = ~reg.O
        _auto_prefix_001 = reg.O
-       _auto_prefix_011 = reg.O
        _auto_prefix_002 = __phi(io.invert, _auto_prefix_000, _auto_prefix_001)
-       _auto_prefix_012 = __phi(io.invert, _auto_prefix_010, _auto_prefix_011)
-       __return_value0 = _auto_prefix_002, _auto_prefix_012
+       __return_value0 = _auto_prefix_002
        return __return_value0
    ```
 
 After this rewrite process, the `inline_combinational` logic calls the function
 to produce the return value.  The function execution uses the enclosing scope
 (so references like `reg.O` should behave as expected).  The return values are
-either wired to their target (e.g. `reg.I @= _auto_prefix_002`) or assigned to
-their target value in the enclosing scope (e.g. `O1 = auto_prefix012`).
+wired to their target (e.g. `reg.I @= _auto_prefix_002`).

--- a/tests/test_syntax/test_inline_comb.py
+++ b/tests/test_syntax/test_inline_comb.py
@@ -12,14 +12,16 @@ def test_inline_comb_basic():
         io += m.ClockIO()
         reg = m.Register(m.Bit)()
 
+        O1 = m.Bit()
+
         @m.inline_combinational(debug=True, file_name="inline_comb.py")
         def logic():
             if io.invert:
                 reg.I @= ~reg.O
-                O1 = ~reg.O
+                O1 @= ~reg.O
             else:
                 reg.I @= reg.O
-                O1 = reg.O
+                O1 @= reg.O
 
         io.O0 @= reg.O
         io.O1 @= O1
@@ -63,10 +65,10 @@ def test_inline_comb_list():
                 O = [~reg.O, reg.O]
             else:
                 O = [reg.O, ~reg.O]
-        reg.I @= O[0]
+            reg.I @= O[0]
 
-        io.O0 @= O[0]
-        io.O1 @= O[1]
+            io.O0 @= O[0]
+            io.O1 @= O[1]
 
     m.compile("build/test_inline_comb_list", Main, inline=True)
     assert check_files_equal(__file__, f"build/test_inline_comb_list.v",
@@ -85,9 +87,9 @@ def test_inline_comb_bv_bit_bool():
             else:
                 x = [BitVector[2](1), Bit(0), False]
 
-        io.O0 @= x[0]
-        io.O1 @= x[1]
-        io.O2 @= x[2]
+            io.O0 @= x[0]
+            io.O1 @= x[1]
+            io.O2 @= x[2]
 
     m.compile("build/test_inline_comb_bv_bit_bool", Main, inline=True)
     assert check_files_equal(__file__, f"build/test_inline_comb_bv_bit_bool.v",


### PR DESCRIPTION
Avoids the problem discussed in #812

Since we cannot guarantee that the assignment values can be used in the
outer scope, we restrict that the user use wiring.  If the user wants a
value to "escape" to the outer scope, they can create a temporary value
and wire up to it.

Also fixes a wiring bug in the inline comb logic (it should be wire
driver to drivee, this matters for using temporary values)

Fixes #812