### PR TITLE
Make drive_undriven be auto clock wiring aware

### DIFF
--- a/magma/backend/coreir_utils.py
+++ b/magma/backend/coreir_utils.py
@@ -128,18 +128,6 @@ def make_cparams(context, params):
     return context.newParams(cparams)
 
 
-def is_clock_or_nested_clock(p):
-    if issubclass(p, ClockTypes):
-        return True
-    if issubclass(p, Array):
-        return is_clock_or_nested_clock(p.T)
-    if issubclass(p, Tuple):
-        for item in p.types():
-            if is_clock_or_nested_clock(item):
-                return True
-    return False
-
-
 def attach_debug_info(coreir_obj, debug_info, a=None, b=None):
     def fn(k, v):
         if a and b:

--- a/magma/passes/drive_undriven.py
+++ b/magma/passes/drive_undriven.py
@@ -1,30 +1,37 @@
 from .passes import EditDefinitionPass
 from ..is_definition import isdefinition
+from magma.clock import (wire_default_clock, is_clock_or_nested_clock,
+                         get_default_clocks)
 
 
-def _drive_if_undriven_input(port):
+def _drive_if_undriven_input(port, clocks):
     if port.is_mixed():
         # list comp so it doesn't short circuit
-        undrivens = [_drive_if_undriven_input(p) for p in port]
+        undrivens = [_drive_if_undriven_input(p, clocks) for p in port]
         return any(undrivens)
     if port.is_input() and port.trace() is None:
-        port.undriven()
+        if (not is_clock_or_nested_clock(type(port)) or
+                not wire_default_clock(port, clocks)):
+            port.undriven()
+        # We always return True, even if we do default clock wiring since in
+        # this case, it should be a definition now
         return True
     return False
 
 
-def _drive_undriven(interface):
+def _drive_undriven(interface, clocks):
     undriven = False
     for port in interface.ports.values():
-        undriven |= _drive_if_undriven_input(port)
+        undriven |= _drive_if_undriven_input(port, clocks)
     return undriven
 
 
 class DriveUndrivenPass(EditDefinitionPass):
     def edit(self, circuit):
-        if _drive_undriven(circuit.interface):
+        clocks = get_default_clocks(circuit)
+        if _drive_undriven(circuit.interface, clocks):
             circuit._is_definition = True
         if not isdefinition(circuit):
             return
         for inst in circuit.instances:
-            _drive_undriven(inst.interface)
+            _drive_undriven(inst.interface, clocks)

--- a/tests/test_circuit/gold/test_ignore_undriven_coreir.json
+++ b/tests/test_circuit/gold/test_ignore_undriven_coreir.json
@@ -6,15 +6,25 @@
         "type":["Record",[
           ["I0","BitIn"],
           ["O0","Bit"],
-          ["O1","Bit"]
+          ["O1","Bit"],
+          ["CLK",["Named","coreir.clkIn"]]
         ]],
         "instances":{
+          "corebit_term_inst0":{
+            "modref":"corebit.term"
+          },
           "corebit_undriven_inst0":{
             "modref":"corebit.undriven"
+          },
+          "coreir_wrapInClock_inst0":{
+            "genref":"coreir.wrap",
+            "genargs":{"type":["CoreIRType",["Named","coreir.clkIn"]]}
           }
         },
         "connections":[
+          ["coreir_wrapInClock_inst0.out","corebit_term_inst0.in"],
           ["self.O0","corebit_undriven_inst0.out"],
+          ["self.CLK","coreir_wrapInClock_inst0.in"],
           ["self.O1","self.I0"]
         ]
       },
@@ -23,7 +33,8 @@
           ["I0",["Array",2,"BitIn"]],
           ["I1",["Array",2,"BitIn"]],
           ["O0","Bit"],
-          ["O1","Bit"]
+          ["O1","Bit"],
+          ["CLK",["Named","coreir.clkIn"]]
         ]],
         "instances":{
           "Foo_inst0":{
@@ -41,6 +52,7 @@
           }
         },
         "connections":[
+          ["self.CLK","Foo_inst0.CLK"],
           ["magma_Bits_2_eq_inst0.out","Foo_inst0.I0"],
           ["self.O0","Foo_inst0.O0"],
           ["corebit_term_inst0.in","Foo_inst0.O1"],

--- a/tests/test_circuit/test_undriven_unused.py
+++ b/tests/test_circuit/test_undriven_unused.py
@@ -56,13 +56,14 @@ def test_ignore_undriven_coreir():
     class Foo(m.Circuit):
         _ignore_undriven_ = True
         io = m.IO(I0=m.In(m.Bit), O0=m.Out(m.Bit), O1=m.Out(m.Bit))
+        io += m.ClockIO()
 
         io.O1 @= io.I0
 
     class Main(m.Circuit):
         _ignore_undriven_ = True
         io = m.IO(I0=m.In(m.Bits[2]), I1=m.In(m.Bits[2]), O0=m.Out(m.Bit),
-                  O1=m.Out(m.Bit))
+                  O1=m.Out(m.Bit)) + m.ClockIO()
 
         foo = Foo()
         foo.I0 @= io.I0 == io.I1

--- a/tests/test_verilog/gold/bind_uniq_test.v
+++ b/tests/test_verilog/gold/bind_uniq_test.v
@@ -344,8 +344,6 @@ wire corebit_undriven_inst17_out;
 wire corebit_undriven_inst18_out;
 wire corebit_undriven_inst19_out;
 wire corebit_undriven_inst2_out;
-wire corebit_undriven_inst20_out;
-wire corebit_undriven_inst21_out;
 wire corebit_undriven_inst3_out;
 wire corebit_undriven_inst4_out;
 wire corebit_undriven_inst5_out;
@@ -353,26 +351,23 @@ wire corebit_undriven_inst6_out;
 wire corebit_undriven_inst7_out;
 wire corebit_undriven_inst8_out;
 wire corebit_undriven_inst9_out;
-wire coreir_wrapInClock_inst0_out;
-wire coreir_wrapOutClock_inst0_out;
-wire coreir_wrapOutClock_inst1_out;
 wire [3:0] undriven_inst0_out;
 wire [3:0] undriven_inst1_out;
 wire [4:0] undriven_inst2_out;
 wire [4:0] undriven_inst3_out;
 wire [1:0] RTL_inst0_ndarr [2:0];
-assign RTL_inst0_ndarr[2] = {corebit_undriven_inst10_out,corebit_undriven_inst9_out};
-assign RTL_inst0_ndarr[1] = {corebit_undriven_inst8_out,corebit_undriven_inst7_out};
-assign RTL_inst0_ndarr[0] = {corebit_undriven_inst6_out,corebit_undriven_inst5_out};
+assign RTL_inst0_ndarr[2] = {corebit_undriven_inst9_out,corebit_undriven_inst8_out};
+assign RTL_inst0_ndarr[1] = {corebit_undriven_inst7_out,corebit_undriven_inst6_out};
+assign RTL_inst0_ndarr[0] = {corebit_undriven_inst5_out,corebit_undriven_inst4_out};
 foo_RTL RTL_inst0 (
-    .CLK(coreir_wrapOutClock_inst0_out),
-    .handshake_arr_0_ready(corebit_undriven_inst2_out),
+    .CLK(CLK),
+    .handshake_arr_0_ready(corebit_undriven_inst1_out),
     .handshake_arr_0_valid(RTL_inst0_handshake_arr_0_valid),
-    .handshake_arr_1_ready(corebit_undriven_inst3_out),
+    .handshake_arr_1_ready(corebit_undriven_inst2_out),
     .handshake_arr_1_valid(RTL_inst0_handshake_arr_1_valid),
-    .handshake_arr_2_ready(corebit_undriven_inst4_out),
+    .handshake_arr_2_ready(corebit_undriven_inst3_out),
     .handshake_arr_2_valid(RTL_inst0_handshake_arr_2_valid),
-    .handshake_ready(corebit_undriven_inst1_out),
+    .handshake_ready(corebit_undriven_inst0_out),
     .handshake_valid(RTL_inst0_handshake_valid),
     .in1(undriven_inst0_out),
     .in2(undriven_inst1_out),
@@ -380,18 +375,18 @@ foo_RTL RTL_inst0 (
     .out(RTL_inst0_out)
 );
 wire [1:0] RTL_inst1_ndarr [2:0];
-assign RTL_inst1_ndarr[2] = {corebit_undriven_inst21_out,corebit_undriven_inst20_out};
-assign RTL_inst1_ndarr[1] = {corebit_undriven_inst19_out,corebit_undriven_inst18_out};
-assign RTL_inst1_ndarr[0] = {corebit_undriven_inst17_out,corebit_undriven_inst16_out};
+assign RTL_inst1_ndarr[2] = {corebit_undriven_inst19_out,corebit_undriven_inst18_out};
+assign RTL_inst1_ndarr[1] = {corebit_undriven_inst17_out,corebit_undriven_inst16_out};
+assign RTL_inst1_ndarr[0] = {corebit_undriven_inst15_out,corebit_undriven_inst14_out};
 foo_RTL_unq1 RTL_inst1 (
-    .CLK(coreir_wrapOutClock_inst1_out),
-    .handshake_arr_0_ready(corebit_undriven_inst13_out),
+    .CLK(CLK),
+    .handshake_arr_0_ready(corebit_undriven_inst11_out),
     .handshake_arr_0_valid(RTL_inst1_handshake_arr_0_valid),
-    .handshake_arr_1_ready(corebit_undriven_inst14_out),
+    .handshake_arr_1_ready(corebit_undriven_inst12_out),
     .handshake_arr_1_valid(RTL_inst1_handshake_arr_1_valid),
-    .handshake_arr_2_ready(corebit_undriven_inst15_out),
+    .handshake_arr_2_ready(corebit_undriven_inst13_out),
     .handshake_arr_2_valid(RTL_inst1_handshake_arr_2_valid),
-    .handshake_ready(corebit_undriven_inst12_out),
+    .handshake_ready(corebit_undriven_inst10_out),
     .handshake_valid(RTL_inst1_handshake_valid),
     .in1(undriven_inst2_out),
     .in2(undriven_inst3_out),
@@ -399,37 +394,34 @@ foo_RTL_unq1 RTL_inst1 (
     .out(RTL_inst1_out)
 );
 corebit_term corebit_term_inst0 (
-    .in(coreir_wrapInClock_inst0_out)
-);
-corebit_term corebit_term_inst1 (
     .in(RTL_inst0_out)
 );
-corebit_term corebit_term_inst10 (
-    .in(RTL_inst1_handshake_arr_2_valid)
-);
-corebit_term corebit_term_inst2 (
+corebit_term corebit_term_inst1 (
     .in(RTL_inst0_handshake_valid)
 );
-corebit_term corebit_term_inst3 (
+corebit_term corebit_term_inst2 (
     .in(RTL_inst0_handshake_arr_0_valid)
 );
-corebit_term corebit_term_inst4 (
+corebit_term corebit_term_inst3 (
     .in(RTL_inst0_handshake_arr_1_valid)
 );
-corebit_term corebit_term_inst5 (
+corebit_term corebit_term_inst4 (
     .in(RTL_inst0_handshake_arr_2_valid)
 );
-corebit_term corebit_term_inst6 (
+corebit_term corebit_term_inst5 (
     .in(RTL_inst1_out)
 );
-corebit_term corebit_term_inst7 (
+corebit_term corebit_term_inst6 (
     .in(RTL_inst1_handshake_valid)
 );
-corebit_term corebit_term_inst8 (
+corebit_term corebit_term_inst7 (
     .in(RTL_inst1_handshake_arr_0_valid)
 );
-corebit_term corebit_term_inst9 (
+corebit_term corebit_term_inst8 (
     .in(RTL_inst1_handshake_arr_1_valid)
+);
+corebit_term corebit_term_inst9 (
+    .in(RTL_inst1_handshake_arr_2_valid)
 );
 corebit_undriven corebit_undriven_inst0 (
     .out(corebit_undriven_inst0_out)
@@ -470,12 +462,6 @@ corebit_undriven corebit_undriven_inst19 (
 corebit_undriven corebit_undriven_inst2 (
     .out(corebit_undriven_inst2_out)
 );
-corebit_undriven corebit_undriven_inst20 (
-    .out(corebit_undriven_inst20_out)
-);
-corebit_undriven corebit_undriven_inst21 (
-    .out(corebit_undriven_inst21_out)
-);
 corebit_undriven corebit_undriven_inst3 (
     .out(corebit_undriven_inst3_out)
 );
@@ -496,18 +482,6 @@ corebit_undriven corebit_undriven_inst8 (
 );
 corebit_undriven corebit_undriven_inst9 (
     .out(corebit_undriven_inst9_out)
-);
-coreir_wrap coreir_wrapInClock_inst0 (
-    .in(CLK),
-    .out(coreir_wrapInClock_inst0_out)
-);
-coreir_wrap coreir_wrapOutClock_inst0 (
-    .in(corebit_undriven_inst0_out),
-    .out(coreir_wrapOutClock_inst0_out)
-);
-coreir_wrap coreir_wrapOutClock_inst1 (
-    .in(corebit_undriven_inst11_out),
-    .out(coreir_wrapOutClock_inst1_out)
 );
 coreir_undriven #(
     .width(4)


### PR DESCRIPTION
Before, using the drive_undriven option would cause clocks to be marked
as undriven, which would then block the automatic clock wiring logic
from being performed later in the backend.  This issue was introduced
when we moved the automatic clock wiring logic to be done in the backend
rather than as a pass (which could be done before the drive_undriven
pass).

To avoid re-introducing a performance hit from having a generic clock
wiring pass, this adds the automatic clock wiring logic to the
drive_undriven pass (since we're already traversing the instances at
this point, we can do the automatic clock wiring logic and then skip the
undriven marker if it's a clock that's being automatically wired).

I think this is a reasonable option for supporting auto clock wiring
with the drive_undriven pass without having to incur the cost of a full
clock wiring pass.  Another option would be to just skip marking clocks
all together, which has the downside of triggering an "undriven error"
downstream which seems like odd behavior given the semantics of this
pass.  With this, we will mark clocks as undriven if they are not wired
automatically.