### PR TITLE
Improve error message for right hand operators

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -228,6 +228,14 @@ class Array(Type, metaclass=ArrayMeta):
                     if not issubclass(self.T, Bit):
                         raise TypeError(f"Can only instantiate Array[N, Bit] "
                                         f"with int/bv, not Array[N, {self.T}]")
+                    if (isinstance(args[0], BitVector) and
+                            len(args[0]) != self.N):
+                        raise TypeError(
+                            f"Cannot create a value of type {type(self)} with"
+                            f" a BitVector of length {len(args[0])} (the sizes"
+                            " must match)"
+                        )
+
                     n = args[0]
                     bits = (int2seq(n, self.N)
                             if isinstance(n, int)

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -28,13 +28,18 @@ from magma.generator import Generator2
 _logger = root_logger()
 
 
+def _check_size(val, T):
+    if len(val) != len(T):
+        raise InconsistentSizeError('Inconsistent size')
+
+
 def _coerce(T: tp.Type['Bits'], val: tp.Any) -> 'Bits':
     if isinstance(val, ht.BitVector):
+        _check_size(val, T)
         val = val.bits()
     if not isinstance(val, Bits):
         return T(val)
-    if len(val) != len(T):
-        raise InconsistentSizeError('Inconsistent size')
+    _check_size(val, T)
     return val
 
 
@@ -412,7 +417,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return NotImplemented
 
     def __rand__(self, other):
-        return self & other
+        try:
+            return self & other
+        except TypeError:
+            return NotImplemented
 
     def __or__(self, other):
         try:
@@ -423,7 +431,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return NotImplemented
 
     def __ror__(self, other):
-        return self | other
+        try:
+            return self | other
+        except TypeError:
+            return NotImplemented
 
     def __xor__(self, other):
         try:
@@ -434,7 +445,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return NotImplemented
 
     def __rxor__(self, other):
-        return self ^ other
+        try:
+            return self ^ other
+        except TypeError:
+            return NotImplemented
 
     def __lshift__(self, other):
         try:
@@ -445,7 +459,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return NotImplemented
 
     def __rlshift__(self, other):
-        return type(self)(other) << self
+        try:
+            return type(self)(other) << self
+        except TypeError:
+            return NotImplemented
 
     def __rshift__(self, other):
         try:
@@ -456,7 +473,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return NotImplemented
 
     def __rrshift__(self, other):
-        return type(self)(other) >> self
+        try:
+            return type(self)(other) >> self
+        except TypeError:
+            return NotImplemented
 
     def __eq__(self, other):
         try:
@@ -486,7 +506,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return NotImplemented
 
     def __radd__(self, other):
-        return self + other
+        try:
+            return self + other
+        except TypeError:
+            return NotImplemented
 
     def __sub__(self, other):
         try:
@@ -497,7 +520,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return NotImplemented
 
     def __rsub__(self, other):
-        return type(self)(other) - self
+        try:
+            return type(self)(other) - self
+        except TypeError:
+            return NotImplemented
 
     def __mul__(self, other):
         try:
@@ -508,7 +534,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return NotImplemented
 
     def __rmul__(self, other):
-        return self * other
+        try:
+            return self * other
+        except TypeError:
+            return NotImplemented
 
     @classmethod
     def get_family(cls):
@@ -582,13 +611,22 @@ class Int(Bits):
     Defines shared right-hand operators for UInt/SInt
     """
     def __rfloordiv__(self, other):
-        return type(self)(other) // self
+        try:
+            return type(self)(other) // self
+        except TypeError:
+            return NotImplemented
 
     def __rtruediv__(self, other):
-        return type(self)(other) / self
+        try:
+            return type(self)(other) / self
+        except TypeError:
+            return NotImplemented
 
     def __rmod__(self, other):
-        return type(self)(other) % self
+        try:
+            return type(self)(other) % self
+        except TypeError:
+            return NotImplemented
 
 
 class UInt(Int):

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -25,6 +25,18 @@ from magma.logging import root_logger
 from magma.generator import Generator2
 
 
+def _error_handler(fn):
+    @functools.wraps(fn)
+    def _wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except InconsistentSizeError as e:
+            raise e from None
+        except TypeError:
+            return NotImplemented
+    return _wrapper
+
+
 _logger = root_logger()
 
 
@@ -408,136 +420,80 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def __invert__(self):
         return self.bvnot()
 
+    @_error_handler
     def __and__(self, other):
-        try:
-            return self.bvand(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvand(other)
 
+    @_error_handler
     def __rand__(self, other):
-        try:
-            return self & other
-        except TypeError:
-            return NotImplemented
+        return self & other
 
+    @_error_handler
     def __or__(self, other):
-        try:
-            return self.bvor(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvor(other)
 
+    @_error_handler
     def __ror__(self, other):
-        try:
-            return self | other
-        except TypeError:
-            return NotImplemented
+        return self | other
 
+    @_error_handler
     def __xor__(self, other):
-        try:
-            return self.bvxor(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvxor(other)
 
+    @_error_handler
     def __rxor__(self, other):
-        try:
-            return self ^ other
-        except TypeError:
-            return NotImplemented
+        return self ^ other
 
+    @_error_handler
     def __lshift__(self, other):
-        try:
-            return self.bvshl(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvshl(other)
 
+    @_error_handler
     def __rlshift__(self, other):
-        try:
-            return type(self)(other) << self
-        except TypeError:
-            return NotImplemented
+        return type(self)(other) << self
 
+    @_error_handler
     def __rshift__(self, other):
-        try:
-            return self.bvlshr(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvlshr(other)
 
+    @_error_handler
     def __rrshift__(self, other):
-        try:
-            return type(self)(other) >> self
-        except TypeError:
-            return NotImplemented
+        return type(self)(other) >> self
 
+    @_error_handler
     def __eq__(self, other):
-        try:
-            return self.bveq(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bveq(other)
 
+    @_error_handler
     def __ne__(self, other):
-        try:
-            return self.bvne(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvne(other)
 
     def __neg__(self):
         return self.bvneg()
 
+    @_error_handler
     def __add__(self, other):
-        try:
-            return self.bvadd(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvadd(other)
 
+    @_error_handler
     def __radd__(self, other):
-        try:
-            return self + other
-        except TypeError:
-            return NotImplemented
+        return self + other
 
+    @_error_handler
     def __sub__(self, other):
-        try:
-            return self.bvsub(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvsub(other)
 
+    @_error_handler
     def __rsub__(self, other):
-        try:
-            return type(self)(other) - self
-        except TypeError:
-            return NotImplemented
+        return type(self)(other) - self
 
+    @_error_handler
     def __mul__(self, other):
-        try:
-            return self.bvmul(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvmul(other)
 
+    @_error_handler
     def __rmul__(self, other):
-        try:
-            return self * other
-        except TypeError:
-            return NotImplemented
+        return self * other
 
     @classmethod
     def get_family(cls):
@@ -610,23 +566,17 @@ class Int(Bits):
     """
     Defines shared right-hand operators for UInt/SInt
     """
+    @_error_handler
     def __rfloordiv__(self, other):
-        try:
-            return type(self)(other) // self
-        except TypeError:
-            return NotImplemented
+        return type(self)(other) // self
 
+    @_error_handler
     def __rtruediv__(self, other):
-        try:
-            return type(self)(other) / self
-        except TypeError:
-            return NotImplemented
+        return type(self)(other) / self
 
+    @_error_handler
     def __rmod__(self, other):
-        try:
-            return type(self)(other) % self
-        except TypeError:
-            return NotImplemented
+        return type(self)(other) % self
 
 
 class UInt(Int):
@@ -640,61 +590,33 @@ class UInt(Int):
         ts = [repr(t) for t in self.ts]
         return 'uint([{}])'.format(', '.join(ts))
 
+    @_error_handler
     def __floordiv__(self, other):
-        try:
-            return self.bvudiv(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvudiv(other)
 
+    @_error_handler
     def __truediv__(self, other):
-        try:
-            return self.bvudiv(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvudiv(other)
 
+    @_error_handler
     def __mod__(self, other):
-        try:
-            return self.bvurem(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvurem(other)
 
+    @_error_handler
     def __ge__(self, other):
-        try:
-            return self.bvuge(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvuge(other)
 
+    @_error_handler
     def __gt__(self, other):
-        try:
-            return self.bvugt(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvugt(other)
 
+    @_error_handler
     def __le__(self, other):
-        try:
-            return self.bvule(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvule(other)
 
+    @_error_handler
     def __lt__(self, other):
-        try:
-            return self.bvult(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvult(other)
 
 
 class SInt(Int):
@@ -742,69 +664,37 @@ class SInt(Int):
     def bvashr(self, other) -> 'AbstractBitVector':
         return self.declare_binary_op("ashr")()(self, other)
 
+    @_error_handler
     def __mod__(self, other):
-        try:
-            return self.bvsrem(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvsrem(other)
 
+    @_error_handler
     def __floordiv__(self, other):
-        try:
-            return self.bvsdiv(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvsdiv(other)
 
+    @_error_handler
     def __truediv__(self, other):
-        try:
-            return self.bvsdiv(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvsdiv(other)
 
+    @_error_handler
     def __ge__(self, other):
-        try:
-            return self.bvsge(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvsge(other)
 
+    @_error_handler
     def __gt__(self, other):
-        try:
-            return self.bvsgt(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvsgt(other)
 
+    @_error_handler
     def __le__(self, other):
-        try:
-            return self.bvsle(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvsle(other)
 
+    @_error_handler
     def __lt__(self, other):
-        try:
-            return self.bvslt(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvslt(other)
 
+    @_error_handler
     def __rshift__(self, other):
-        try:
-            return self.bvashr(other)
-        except InconsistentSizeError as e:
-            raise e from None
-        except TypeError:
-            return NotImplemented
+        return self.bvashr(other)
 
     def adc(self, other: 'Bits', carry: Bit) -> tp.Tuple['Bits', Bit]:
         """

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -426,7 +426,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
 
     @_error_handler
     def __rand__(self, other):
-        return self & other
+        return self.bvand(other)
 
     @_error_handler
     def __or__(self, other):
@@ -434,7 +434,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
 
     @_error_handler
     def __ror__(self, other):
-        return self | other
+        return self.bvor(other)
 
     @_error_handler
     def __xor__(self, other):
@@ -442,7 +442,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
 
     @_error_handler
     def __rxor__(self, other):
-        return self ^ other
+        return self.bvxor(other)
 
     @_error_handler
     def __lshift__(self, other):
@@ -477,7 +477,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
 
     @_error_handler
     def __radd__(self, other):
-        return self + other
+        return self.bvadd(other)
 
     @_error_handler
     def __sub__(self, other):
@@ -493,7 +493,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
 
     @_error_handler
     def __rmul__(self, other):
-        return self * other
+        return self.bvmul(other)
 
     @classmethod
     def get_family(cls):

--- a/tests/test_type/test_bits.py
+++ b/tests/test_type/test_bits.py
@@ -419,3 +419,12 @@ def test_rop_type_error(op, op_str):
             f"unsupported operand type(s) for {op_str}: 'BitVector[32]' and "
             "'Bits[(2, Out(Bit))]'"
         )
+
+        x = m.Bits[5]()
+        y = m.Bits[4]()
+        with pytest.raises(TypeError) as e:
+            op(x, y)
+        assert str(e.value) == (
+            f"unsupported operand type(s) for {op_str}: 'Bits[(5, Bit)]' and "
+            "'Bits[(4, Bit)]'"
+        )

--- a/tests/test_type/test_bits.py
+++ b/tests/test_type/test_bits.py
@@ -398,3 +398,24 @@ def test_rops(op):
     sim.set_value(Main.I, I)
     sim.evaluate()
     assert sim.get_value(Main.O) == op(x, I)
+
+
+@pytest.mark.parametrize("op, op_str", [
+    (operator.and_, "&"),
+    (operator.or_, "|"),
+    (operator.xor, "^"),
+    (operator.lshift, "<<"),
+    (operator.rshift, ">>"),
+    (operator.add, "+"),
+    (operator.sub, "-"),
+    (operator.mul, "*")
+])
+def test_rop_type_error(op, op_str):
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[2]))
+        with pytest.raises(TypeError) as e:
+            print(op(BitVector[32](0xDEADBEEF), io.I))
+        assert str(e.value) == (
+            f"unsupported operand type(s) for {op_str}: 'BitVector[32]' and "
+            "'Bits[(2, Out(Bit))]'"
+        )

--- a/tests/test_type/test_sint.py
+++ b/tests/test_type/test_sint.py
@@ -261,3 +261,18 @@ def test_rops(op):
     sim.set_value(Main.I, I)
     sim.evaluate()
     assert sim.get_value(Main.O) == op(x, I)
+
+
+@pytest.mark.parametrize("op, op_str", [
+    (operator.floordiv, "//"),
+    (operator.mod, "%")
+])
+def test_rop_type_error(op, op_str):
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.SInt[2]))
+        with pytest.raises(TypeError) as e:
+            print(op(SIntVector[32](0xDEADBEEF), io.I))
+        assert str(e.value) == (
+            f"unsupported operand type(s) for {op_str}: 'SIntVector[32]' and "
+            "'SInt[(2, Out(Bit))]'"
+        )

--- a/tests/test_type/test_sint.py
+++ b/tests/test_type/test_sint.py
@@ -276,3 +276,12 @@ def test_rop_type_error(op, op_str):
             f"unsupported operand type(s) for {op_str}: 'SIntVector[32]' and "
             "'SInt[(2, Out(Bit))]'"
         )
+
+        x = m.SInt[5]()
+        y = m.SInt[4]()
+        with pytest.raises(TypeError) as e:
+            op(x, y)
+        assert str(e.value) == (
+            f"unsupported operand type(s) for {op_str}: 'SInt[(5, Bit)]' and "
+            "'SInt[(4, Bit)]'"
+        )

--- a/tests/test_type/test_uint.py
+++ b/tests/test_type/test_uint.py
@@ -234,3 +234,18 @@ def test_rops(op):
     sim.set_value(Main.I, I)
     sim.evaluate()
     assert sim.get_value(Main.O) == op(x, I)
+
+
+@pytest.mark.parametrize("op, op_str", [
+    (operator.floordiv, "//"),
+    (operator.mod, "%")
+])
+def test_rop_type_error(op, op_str):
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.UInt[2]))
+        with pytest.raises(TypeError) as e:
+            print(op(UIntVector[32](0xDEADBEEF), io.I))
+        assert str(e.value) == (
+            f"unsupported operand type(s) for {op_str}: 'UIntVector[32]' and "
+            "'UInt[(2, Out(Bit))]'"
+        )

--- a/tests/test_type/test_uint.py
+++ b/tests/test_type/test_uint.py
@@ -249,3 +249,12 @@ def test_rop_type_error(op, op_str):
             f"unsupported operand type(s) for {op_str}: 'UIntVector[32]' and "
             "'UInt[(2, Out(Bit))]'"
         )
+
+        x = m.UInt[5]()
+        y = m.UInt[4]()
+        with pytest.raises(TypeError) as e:
+            op(x, y)
+        assert str(e.value) == (
+            f"unsupported operand type(s) for {op_str}: 'UInt[(5, Bit)]' and "
+            "'UInt[(4, Bit)]'"
+        )


### PR DESCRIPTION
This adds logic to the right operator definitions to return
NotImplemented if they encounter a TypeError that is raised in
implementation.  As a result, you get a nice error message such as:
```
>       io.evec @= mtvec + (PRV.O << 6)
E       TypeError: unsupported operand type(s) for +: 'BitVector[32]' and 'UInt[(2, Out(Bit))]'
```
Note this is the default error message from Python when both __add__ and
__radd__ return NotImplemented.  It uses the type name which has the
redundant Out(Bit) inside UInt which I will look into fixing in a
separate PR.

Before this change, we would instead get a message such as
```
    def test_radd_type_error():
>       class Main(m.Circuit):

tests/test_type/test_bits.py:404:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/test_type/test_bits.py:407: in Main
    BitVector[32](0xDEADBEEF) + io.I
magma/bits.py:494: in __radd__
    return self + other
magma/bits.py:487: in __add__
    return self.bvadd(other)
magma/bits.py:51: in wrapped
    other = _coerce(type(self), other)
magma/bits.py:41: in _coerce
    return T(val)
magma/bits.py:63: in __call__
    result = super().__call__(*args, **kwargs)
../hwtypes/hwtypes/bit_vector_abc.py:28: in __call__
    return super().__call__(value, *args, **kwargs)
magma/bits.py:111: in __init__
    Array.__init__(self, *args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = bits(0, 2), args = ([1, 1, 1, 1, 0, 1, ...],), kwargs = {}

    def __init__(self, *args, **kwargs):
        Type.__init__(self, **kwargs)
        self.ts = []
        if args:
            if len(args) == 1 and isinstance(args[0], (list, Array, int,
                                                       BitVector)):
                if isinstance(args[0], list):
                    if len(args[0]) != self.N:
>                       raise ValueError("Array list constructor can only be used "
                                         "with list equal to array length")
E                       ValueError: Array list constructor can only be used with list equal to array length

```

Note that the problematic source line is buried deep inside the stack
trace leading to a confusing error message.

As a part of this change, I improved the Array constructor to raise
TypeError rather than a ValueError (as shown above) when encountering a
BitVector initializer with an inconsistent size (so it would be caught
by the NotImplemented logic).