### PR TITLE
Use Kind.__eq__ for structural equality

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -115,7 +115,7 @@ class ArrayMeta(ABCMeta, Kind):
 
 
         if cls.is_concrete:
-            if index[0] is cls.N and index[1] is cls.T:
+            if index[0] == cls.N and index[1] is cls.T:
                 return cls
             else:
                 return cls.abstract_t[index]

--- a/magma/array.py
+++ b/magma/array.py
@@ -115,7 +115,7 @@ class ArrayMeta(ABCMeta, Kind):
 
 
         if cls.is_concrete:
-            if index == (cls.N, cls.T):
+            if index[0] is cls.N and index[1] is cls.T:
                 return cls
             else:
                 return cls.abstract_t[index]

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from .t import Direction, In
 from .digital import DigitalMeta, Digital
 from .wire import wire
@@ -160,16 +162,18 @@ def wireclock(define, circuit):
     wireclocktype(define, circuit, Enable)
 
 
-def get_reset_args(reset_type: AbstractReset = None):
+def get_reset_args(reset_type: Optional[AbstractReset]):
     if reset_type is not None and not issubclass(reset_type, AbstractReset):
         raise TypeError(
             f"Expected subclass of AbstractReset for argument reset_type, "
             f"not {type(reset_type)}")
 
-    has_async_reset = reset_type == AsyncReset
-    has_async_resetn = reset_type == AsyncResetN
-    has_reset = reset_type == Reset
-    has_resetn = reset_type == ResetN
+    if reset_type is None:
+        return tuple(False for _ in range(4))
+    has_async_reset = issubclass(reset_type, AsyncReset)
+    has_async_resetn = issubclass(reset_type, AsyncResetN)
+    has_reset = issubclass(reset_type, Reset)
+    has_resetn = issubclass(reset_type, ResetN)
     return (has_async_reset, has_async_resetn, has_reset, has_resetn)
 
 

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -163,13 +163,13 @@ def wireclock(define, circuit):
 
 
 def get_reset_args(reset_type: Optional[AbstractReset]):
-    if reset_type is not None and not issubclass(reset_type, AbstractReset):
+    if reset_type is None:
+        return tuple(False for _ in range(4))
+    if not issubclass(reset_type, AbstractReset):
         raise TypeError(
             f"Expected subclass of AbstractReset for argument reset_type, "
             f"not {type(reset_type)}")
 
-    if reset_type is None:
-        return tuple(False for _ in range(4))
     has_async_reset = issubclass(reset_type, AsyncReset)
     has_async_resetn = issubclass(reset_type, AsyncResetN)
     has_reset = issubclass(reset_type, Reset)

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -127,9 +127,6 @@ class DigitalMeta(ABCMeta, Kind):
         return cls[direction]
 
     def __eq__(cls, rhs):
-        # if cls is not rhs:
-        #     assert not isinstance(rhs, DigitalMeta)
-
         return isinstance(rhs, DigitalMeta)
 
     def is_wireable(cls, rhs):

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -127,7 +127,10 @@ class DigitalMeta(ABCMeta, Kind):
         return cls[direction]
 
     def __eq__(cls, rhs):
-        return cls is rhs
+        # if cls is not rhs:
+        #     assert not isinstance(rhs, DigitalMeta)
+
+        return isinstance(rhs, DigitalMeta)
 
     def is_wireable(cls, rhs):
         rhs = magma_type(rhs)

--- a/magma/syntax/sequential2.py
+++ b/magma/syntax/sequential2.py
@@ -39,6 +39,7 @@ class _SequentialListWrapper(list):
 
 
 class _SequentialRegisterWrapperMeta(MagmaProtocolMeta):
+    _cache = {}
     def _to_magma_(cls):
         return cls.T
 
@@ -55,7 +56,10 @@ class _SequentialRegisterWrapperMeta(MagmaProtocolMeta):
         return cls.T.is_oriented(direction)
 
     def __getitem__(cls, T):
-        return type(cls)(f"_SequentialRegisterWrapper{T}", (cls, ), {"T": T})
+        if T not in cls._cache:
+            cls._cache[T] = type(cls)(f"_SequentialRegisterWrapper{T}", (cls, ),
+                                  {"T": T})
+        return cls._cache[T]
 
     def __eq__(cls, rhs):
         if not isinstance(rhs, _SequentialRegisterWrapperMeta):

--- a/magma/syntax/sequential2.py
+++ b/magma/syntax/sequential2.py
@@ -40,6 +40,7 @@ class _SequentialListWrapper(list):
 
 class _SequentialRegisterWrapperMeta(MagmaProtocolMeta):
     _cache = {}
+
     def _to_magma_(cls):
         return cls.T
 
@@ -57,8 +58,8 @@ class _SequentialRegisterWrapperMeta(MagmaProtocolMeta):
 
     def __getitem__(cls, T):
         if T not in cls._cache:
-            cls._cache[T] = type(cls)(f"_SequentialRegisterWrapper{T}", (cls, ),
-                                  {"T": T})
+            cls._cache[T] = type(cls)(f"_SequentialRegisterWrapper{T}",
+                                      (cls, ), {"T": T})
         return cls._cache[T]
 
     def __eq__(cls, rhs):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -98,7 +98,6 @@ class TupleKind(TupleMeta, Kind):
             raise TypeError('Type is already bound')
 
         undirected_idx = tuple(v.qualify(Direction.Undirected) for v in idx)
-        print(idx, undirected_idx)
         if any(x is not y for x, y in zip(undirected_idx, idx)):
             bases = [cls[undirected_idx]]
         else:

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -474,8 +474,8 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
         for k, v in cls.field_dict.items():
             if not issubclass(new_fields[k], v):
                 base = cls.unbound_t
-        if base.is_bound and all(v is base.field_dict[k] for k, v in
-                                 new_fields.items()):
+        if base.is_bound and all(v is base.field_dict[k]
+                                 for k, v in new_fields.items()):
             return base
 
         if cls.unbound_t is AnonProduct:

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -98,7 +98,8 @@ class TupleKind(TupleMeta, Kind):
             raise TypeError('Type is already bound')
 
         undirected_idx = tuple(v.qualify(Direction.Undirected) for v in idx)
-        if undirected_idx != idx:
+        print(idx, undirected_idx)
+        if any(x is not y for x, y in zip(undirected_idx, idx)):
             bases = [cls[undirected_idx]]
         else:
             bases = [cls]
@@ -158,6 +159,17 @@ class TupleKind(TupleMeta, Kind):
             if not T.is_bindable(rhs[idx]):
                 return False
         return True
+
+    def __eq__(cls, rhs):
+        if not isinstance(rhs, TupleKind):
+            return False
+
+        if not cls.is_bound:
+            return not rhs.is_bound
+
+        return cls.fields == rhs.fields
+
+    __hash__ = TupleMeta.__hash__
 
 
 class Tuple(Type, Tuple_, metaclass=TupleKind):
@@ -463,7 +475,7 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
         for k, v in cls.field_dict.items():
             if not issubclass(new_fields[k], v):
                 base = cls.unbound_t
-        if base.is_bound and all(v == base.field_dict[k] for k, v in
+        if base.is_bound and all(v is base.field_dict[k] for k, v in
                                  new_fields.items()):
             return base
 
@@ -494,11 +506,7 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
         if not cls.is_bound:
             return not rhs.is_bound
 
-        for k, v in cls.field_dict.items():
-            if getattr(rhs, k) is not v:
-                return False
-
-        return True
+        return cls.field_dict == rhs.field_dict
 
     def is_wireable(cls, rhs):
         rhs = magma_type(rhs)

--- a/tests/test_type/test_array.py
+++ b/tests/test_type/test_array.py
@@ -17,9 +17,15 @@ def test_array():
     assert B2 == B2
     assert C2 == C2
 
-    assert A2 != B2
-    assert A2 != C2
-    assert B2 != C2
+    # Structural equality
+    assert A2 == B2
+    assert A2 == C2
+    assert B2 == C2
+
+    # Nominal equality
+    assert A2 is not B2
+    assert A2 is not C2
+    assert B2 is not C2
 
     A4 = Array[4,Bit]
     assert A4 == Array4
@@ -81,6 +87,7 @@ def test_val():
 
     a3 = a1[0:2]
 
+
 def test_flip():
     AIn = In(Array2)
     AOut = Out(Array2)
@@ -88,9 +95,13 @@ def test_flip():
     print(AIn)
     print(AOut)
 
-    assert AIn  != Array2
-    assert AOut != Array2
-    assert AIn != AOut
+    assert AIn == Array2
+    assert AOut == Array2
+    assert AIn == AOut
+
+    assert AIn is not Array2
+    assert AOut is not Array2
+    assert AIn is not AOut
 
     A = In(AOut)
     assert A == AIn

--- a/tests/test_type/test_bit.py
+++ b/tests/test_type/test_bit.py
@@ -15,9 +15,13 @@ def test_bit():
     assert m.BitIn == m.BitIn
     assert m.BitOut == m.BitOut
 
-    assert m.Bit != m.BitIn
-    assert m.Bit != m.BitOut
-    assert m.BitIn != m.BitOut
+    assert m.Bit == m.BitIn
+    assert m.Bit == m.BitOut
+    assert m.BitIn == m.BitOut
+
+    assert m.Bit is not m.BitIn
+    assert m.Bit is not m.BitOut
+    assert m.BitIn is not m.BitOut
 
     assert str(m.Bit) == 'Bit'
     assert str(m.BitIn) == 'In(Bit)'

--- a/tests/test_type/test_bits.py
+++ b/tests/test_type/test_bits.py
@@ -26,9 +26,13 @@ def test_bits_basic():
     assert bits_in_2 == m.In(bits_2)
     assert bits_out_2 == m.Out(bits_2)
 
-    assert bits_2 != bits_in_2
-    assert bits_2 != bits_out_2
-    assert bits_in_2 != bits_out_2
+    assert bits_2 == bits_in_2
+    assert bits_2 == bits_out_2
+    assert bits_in_2 == bits_out_2
+
+    assert bits_2 is not bits_in_2
+    assert bits_2 is not bits_out_2
+    assert bits_in_2 is not bits_out_2
 
     bits_4 = m.Bits[4]
     assert bits_4 == ARRAY4
@@ -90,9 +94,13 @@ def test_flip():
     print(a_in)
     print(a_out)
 
-    assert a_in != ARRAY2
-    assert a_out != ARRAY2
-    assert a_in != a_out
+    assert a_in == ARRAY2
+    assert a_out == ARRAY2
+    assert a_in == a_out
+
+    assert a_in is not ARRAY2
+    assert a_out is not ARRAY2
+    assert a_in is not a_out
 
     in_a_out = m.In(a_out)
     assert in_a_out == a_in

--- a/tests/test_type/test_equality.py
+++ b/tests/test_type/test_equality.py
@@ -1,0 +1,32 @@
+import magma as m
+
+
+def test_struct_eq():
+    assert m.Array[3, m.In(m.Bit)] == m.Array[3, m.Out(m.Bit)], """\
+Direction should not matter when checking structural equality\
+"""
+
+    class T1(m.Product):
+        x = m.Bit
+        y = m.Out(m.Bits[1])
+
+    class T2(m.Product):
+        x = m.In(m.Bit)
+        y = m.Bits[1]
+    assert T1 is not T2, "Different names are not nominally equal"
+    assert m.Array[3, T1] == m.Array[3, T2], """\
+Products should match structurally, direction does not matter
+"""
+
+    class T3(m.Product):
+        x = m.In(m.Bit)
+    assert m.Array[3, T1] != m.Array[3, T3], """\
+Missing field should not match
+"""
+
+    class T4(m.Product):
+        x = m.In(m.Bit)
+        z = m.Bits[1]
+    assert m.Array[3, T1] != m.Array[3, T4], """\
+Different fields should not match
+"""

--- a/tests/test_type/test_sint.py
+++ b/tests/test_type/test_sint.py
@@ -19,13 +19,17 @@ def test():
     assert B2 == B2
     assert C2 == C2
 
-    assert A2 != B2
-    assert A2 != C2
-    assert B2 != C2
+    assert A2 == B2
+    assert A2 == C2
+    assert B2 == C2
 
-    # A4 = SInt[4]
-    # assert A4 == Array4
-    # assert A2 != A4
+    assert A2 is not B2
+    assert A2 is not C2
+    assert B2 is not C2
+
+    A4 = SInt[4]
+    assert A4 == Array4
+    assert A2 != A4
 
 
 def test_val():
@@ -56,9 +60,13 @@ def test_flip():
     print(AIn)
     print(AOut)
 
-    assert AIn != Array2
-    assert AOut != Array2
-    assert AIn != AOut
+    assert AIn == Array2
+    assert AOut == Array2
+    assert AIn == AOut
+
+    assert AIn is not Array2
+    assert AOut is not Array2
+    assert AIn is not AOut
 
     A = In(AOut)
     assert A == AIn

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -102,9 +102,13 @@ def test_dict():
     #assert str(C2) == 'Tuple(x=Out(Bit),y=Out(Bit))'
     assert C2 == C2
 
-    assert A2 != B2
-    assert A2 != C2
-    assert B2 != C2
+    assert A2 == B2
+    assert A2 == C2
+    assert B2 == C2
+
+    assert A2 is not B2
+    assert A2 is not C2
+    assert B2 is not C2
 
 
 def test_flip():
@@ -120,9 +124,13 @@ def test_flip():
     print(Tin)
     print(Tout)
 
-    assert Tin != Product2
-    assert Tout != Product2
-    assert Tin != Tout
+    assert Tin == Product2
+    assert Tout == Product2
+    assert Tin == Tout
+
+    assert Tin is not Product2
+    assert Tout is not Product2
+    assert Tin is not Tout
 
     T = In(Tout)
     assert T == Tin

--- a/tests/test_type/test_uint.py
+++ b/tests/test_type/test_uint.py
@@ -19,13 +19,17 @@ def test():
     assert B2 == B2
     assert C2 == C2
 
-    assert A2 != B2
-    assert A2 != C2
-    assert B2 != C2
+    assert A2 == B2
+    assert A2 == C2
+    assert B2 == C2
 
-    # A4 = UInt[4]
-    # assert A4 == Array4
-    # assert A2 != A4
+    assert A2 is not B2
+    assert A2 is not C2
+    assert B2 is not C2
+
+    A4 = UInt[4]
+    assert A4 == Array4
+    assert A2 != A4
 
 
 def test_val():
@@ -56,9 +60,13 @@ def test_flip():
     print(AIn)
     print(AOut)
 
-    assert AIn != Array2
-    assert AOut != Array2
-    assert AIn != AOut
+    assert AIn == Array2
+    assert AOut == Array2
+    assert AIn == AOut
+
+    assert AIn is not Array2
+    assert AOut is not Array2
+    assert AIn is not AOut
 
     A = In(AOut)
     assert A == AIn


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/845
Fixes https://github.com/phanrahan/magma/issues/459

Minor updates in various parts of the code base that were using __eq__
for nominal equality.