### PR TITLE
Restrict Clock wiring

### DIFF
--- a/magma/clock.py
+++ b/magma/clock.py
@@ -5,6 +5,7 @@ from .digital import DigitalMeta, Digital
 from .wire import wire
 from magma.bit import Bit
 from magma.array import Array
+from magma.debug import debug_wire
 from magma.tuple import Tuple
 
 
@@ -18,6 +19,14 @@ class _ClockType(Digital):
 
     def undriven(self):
         Bit.undriven(self)
+
+    @debug_wire
+    def wire(self, other, debug_info=None):
+        # Wiring requires strict subclasses
+        if not isinstance(other, type(self).qualify(Direction.Undirected)):
+            raise TypeError(f"Cannot wire {other} (T={type(other)}) to {self}"
+                            f" (T={type(self)})")
+        return super().wire(other, debug_info)
 
 
 class Clock(_ClockType, metaclass=DigitalMeta):

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -23,6 +23,8 @@ class _ClockType(Digital):
     @debug_wire
     def wire(self, other, debug_info=None):
         # Wiring requires strict subclasses
+        # Note: we use the standard wiring logic to enforce directionality,
+        # so we just check with the undirected type here
         if not isinstance(other, type(self).qualify(Direction.Undirected)):
             raise TypeError(f"Cannot wire {other} (T={type(other)}) to {self}"
                             f" (T={type(self)})")

--- a/magma/passes/insert_coreir_wires.py
+++ b/magma/passes/insert_coreir_wires.py
@@ -106,7 +106,7 @@ class InsertCoreIRWires(DefinitionPass):
                         w @= d
             else:
                 wire_input @= driver
-        if (isinstance(value, _ClockType) and 
+        if (isinstance(value, _ClockType) and
                 not isinstance(wire_output, type(value))):
             # This mean it was cast by the user (e.g. m.clock(value)), so we
             # need to "recast" the wire output

--- a/magma/primitives/memory.py
+++ b/magma/primitives/memory.py
@@ -94,7 +94,7 @@ class Memory(Generator2):
         else:
             waddr = Bits[addr_width](0)
             wdata = Bits[data_width](0)
-            wen = Bit(0)
+            wen = Enable(0)
         coreir_mem = CoreIRMemory(height, data_width, init=init,
                                   sync_read=read_latency > 0)()
         coreir_mem.waddr @= waddr

--- a/tests/test_higher/test_fold.py
+++ b/tests/test_higher/test_fold.py
@@ -6,7 +6,7 @@ def test_fold_shift_register(caplog):
     class EnableShiftRegister(m.Circuit):
         io = m.IO(
             I=m.In(m.UInt[4]),
-            shift=m.In(m.Bit),
+            shift=m.In(m.Enable),
             O=m.Out(m.UInt[4])
         ) + m.ClockIO(has_async_reset=True)
         regs = [m.Register(m.UInt[4], reset_type=m.AsyncReset,
@@ -24,7 +24,7 @@ def test_fold_reset_shift_register():
     class ResetShiftRegister(m.Circuit):
         io = m.IO(
             I=m.In(m.UInt[4]),
-            shift=m.In(m.Bit),
+            shift=m.In(m.Enable),
             O=m.Out(m.UInt[4])
         ) + m.ClockIO(has_resetn=True)
         regs = [m.Register(m.UInt[4], has_enable=True, reset_type=m.ResetN)()

--- a/tests/test_type/gold/test_insert_wrap_casts_temporary.v
+++ b/tests/test_type/gold/test_insert_wrap_casts_temporary.v
@@ -19,23 +19,43 @@ module corebit_term (
 
 endmodule
 
+module WireClock (
+    input I,
+    output O
+);
+wire Wire_inst0_out;
+wire coreir_wrapInClock_inst0_out;
+wire coreir_wrapOutClock_inst0_out;
+corebit_wire Wire_inst0 (
+    .in(coreir_wrapInClock_inst0_out),
+    .out(Wire_inst0_out)
+);
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(I),
+    .out(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(Wire_inst0_out),
+    .out(coreir_wrapOutClock_inst0_out)
+);
+assign O = coreir_wrapOutClock_inst0_out;
+endmodule
+
 module Bar (
     input CLK,
     input RESETN
 );
-wire _magma_inline_wire0_out;
+wire _magma_inline_wire0_O;
 wire _magma_inline_wire1_out;
 wire coreir_wrapInClock_inst0_out;
-wire coreir_wrapInClock_inst1_out;
 wire coreir_wrapOutClock_inst0_out;
-wire coreir_wrapOutClock_inst1_out;
 wire temp1_out;
 Foo Foo_inst0 (
     .CLK(coreir_wrapOutClock_inst0_out)
 );
-corebit_wire _magma_inline_wire0 (
-    .in(coreir_wrapInClock_inst0_out),
-    .out(_magma_inline_wire0_out)
+WireClock _magma_inline_wire0 (
+    .I(CLK),
+    .O(_magma_inline_wire0_O)
 );
 corebit_wire _magma_inline_wire1 (
     .in(RESETN),
@@ -45,22 +65,14 @@ coreir_wrap coreir_wrapInClock_inst0 (
     .in(CLK),
     .out(coreir_wrapInClock_inst0_out)
 );
-coreir_wrap coreir_wrapInClock_inst1 (
-    .in(CLK),
-    .out(coreir_wrapInClock_inst1_out)
-);
 coreir_wrap coreir_wrapOutClock_inst0 (
     .in(temp1_out),
     .out(coreir_wrapOutClock_inst0_out)
 );
-coreir_wrap coreir_wrapOutClock_inst1 (
-    .in(_magma_inline_wire0_out),
-    .out(coreir_wrapOutClock_inst1_out)
-);
 corebit_wire temp1 (
-    .in(coreir_wrapInClock_inst1_out),
+    .in(coreir_wrapInClock_inst0_out),
     .out(temp1_out)
 );
-always @(posedge coreir_wrapOutClock_inst1_out) disable iff (! _magma_inline_wire1_out) $display("Hello");
+always @(posedge _magma_inline_wire0_O) disable iff (! _magma_inline_wire1_out) $display("Hello");
 endmodule
 

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -413,3 +413,11 @@ def test_insert_wrap_casts_temporary():
     assert check_files_equal(__file__,
                              f"build/test_insert_wrap_casts_temporary.v",
                              f"gold/test_insert_wrap_casts_temporary.v")
+
+
+def test_wire_error():
+    with pytest.raises(TypeError) as e:
+        class Foo(m.Circuit):
+            io = m.IO(I=m.In(m.Clock), O=m.Out(m.Reset))
+            m.wire(io.I, io.O)
+    assert str(e.value) == "Cannot wire I (T=Out(Clock)) to O (T=In(Reset))"


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/651

Enforces nominal typing for clock types. Clocks (and
resets/enables/etc...) can only be wired to values that are instances of
the same type (i.e. not instances of Digital).

Includes updates to portions of the code base that were relying on the
ability to wire Digital/Bit to clock types.  Mainly the change requires
using an explicit `m.clock` or `convertbit(value, T)` (for a generic
conversion of value to T) to connect a bit to a clock type.