### PR TITLE
Add __setitem__/__getitem__ support for memory primitive

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -64,6 +64,35 @@ Mem `__init__` arguments:
 * `init: Optional[tuple]` - (optional) initial contents of the memory as a
                             tuple containing an initial value for each entry 
 
+The memory provides a convenience interface following the Python
+`__getitem__`/`__setitem__` pattern, here is an example:
+
+```python
+class MemoryGetItemSetItem(m.Circuit):
+    io = m.IO(
+        raddr=m.In(m.Bits[2]),
+        rdata=m.Out(m.Bits[5]),
+        waddr=m.In(m.Bits[2]),
+        wdata=m.In(m.Bits[5]),
+        clk=m.In(m.Clock),
+        wen=m.In(m.Enable)
+
+    )
+    Mem4x5 = m.Memory(4, m.Bits[5])()
+    io.rdata @= Mem4x5[io.raddr]
+    Mem4x5[io.waddr] @= io.wdata
+```
+
+Reading from a memory using the `__getitem__` syntax (e.g. `Mem4x5[io.raddr]`)
+is equivalent to wiring the `RADDR` port to the `__getitem__` key/index and
+returning the `RDATA` port.  Note that writing to a memory uses `@=` with
+`__getitem__` on the left hand side (as opposed to the standard `=` and
+`__setitem__` pattern used in Python).  This is so that writing to a memory is
+consistent with standard wiring using the `@=` syntax.  Writing to a memory
+(e.g. `Mem4x5[io.waddr] @= io.wdata`) is equivalent to wiring the key/index
+(`io.waddr`) to the `WADDR` port and the value (`io.wdata`) to the `WDATA`
+port.
+
 ### Mux
 The `Mux(N, T)` primitive creates a mux circuit that selects between `N` input
 values of type `T`.  Here's a simple example that selects between two bits:

--- a/magma/protocol_type.py
+++ b/magma/protocol_type.py
@@ -1,7 +1,6 @@
 import abc
 
 from magma.debug import debug_wire
-from magma.t import Direction, Type
 
 
 class MagmaProtocolMeta(type):
@@ -11,7 +10,7 @@ class MagmaProtocolMeta(type):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def _qualify_magma_(cls, direction: Direction):
+    def _qualify_magma_(cls, direction: 'Direction'):
         # To qualify underlying type (e.g. give me a Foo with the underlying
         # type qualified to be an input).
         raise NotImplementedError()
@@ -22,11 +21,11 @@ class MagmaProtocolMeta(type):
         # flipped).
         raise NotImplementedError()
 
-    def qualify(cls, direction: Direction):
+    def qualify(cls, direction: 'Direction'):
         return cls._qualify_magma_(direction)
 
     @abc.abstractmethod
-    def _from_magma_value_(cls, val: Type):
+    def _from_magma_value_(cls, val: 'Type'):
         # To create an instance from a value.
         raise NotImplementedError()
 

--- a/magma/t.py
+++ b/magma/t.py
@@ -3,6 +3,7 @@ import enum
 from magma.common import deprecated
 from magma.compatibility import IntegerTypes, StringTypes
 from magma.ref import AnonRef, NamedRef, DefnRef, InstRef
+from magma.protocol_type import magma_value
 
 
 class Direction(enum.Enum):
@@ -99,9 +100,11 @@ class Type(object):
             raise TypeError(f"Cannot use <= to assign to output: "
                             f"{self.debug_name} (trying to assign "
                             f"{other.debug_name})")
+        other = magma_value(other)
         self.wire(other)
 
     def __imatmul__(self, other):
+        other = magma_value(other)
         if self.is_output():
             raise TypeError(f"Cannot use @= to assign to output: {self} "
                             f"(trying to assign {other})")

--- a/tests/test_primitives/test_memory.py
+++ b/tests/test_primitives/test_memory.py
@@ -19,10 +19,8 @@ def test_memory_basic():
 
         )
         Mem4x5 = m.Memory(4, m.Bits[5])()
-        Mem4x5.RADDR @= io.raddr
-        io.rdata @= Mem4x5.RDATA
-        Mem4x5.WADDR @= io.waddr
-        Mem4x5.WDATA @= io.wdata
+        io.rdata @= Mem4x5[io.raddr]
+        Mem4x5[io.waddr] = io.wdata
 
     m.compile("build/test_memory_basic", test_memory_basic)
 
@@ -204,3 +202,25 @@ def test_memory_read_only():
     tester.compile_and_run("verilator", skip_compile=True,
                            directory=os.path.join(os.path.dirname(__file__),
                                                   "build"))
+
+
+def test_memory_warning(caplog):
+    class test_memory_basic(m.Circuit):
+        io = m.IO(
+            raddr=m.In(m.Bits[2]),
+            rdata=m.Out(m.Bits[5]),
+            waddr=m.In(m.Bits[2]),
+            wdata=m.In(m.Bits[5]),
+            clk=m.In(m.Clock),
+            wen=m.In(m.Enable)
+
+        )
+        Mem4x5 = m.Memory(4, m.Bits[5])()
+        io.rdata @= Mem4x5[io.raddr]
+        Mem4x5[io.waddr] = io.wdata
+
+        io.rdata @= Mem4x5[io.raddr]
+        Mem4x5[io.waddr] = io.wdata
+
+    assert "Calling __getitem__ on a Memory instance with RADDR already driven, will overwrite previous values" in caplog.messages  # noqa
+    assert "Calling __setitem__ on a Memory instance with WADDR or WDATA already driven, will overwrite previous values" in caplog.messages  # noqa

--- a/tests/test_primitives/test_memory.py
+++ b/tests/test_primitives/test_memory.py
@@ -20,7 +20,7 @@ def test_memory_basic():
         )
         Mem4x5 = m.Memory(4, m.Bits[5])()
         io.rdata @= Mem4x5[io.raddr]
-        Mem4x5[io.waddr] = io.wdata
+        Mem4x5[io.waddr] @= io.wdata
 
     m.compile("build/test_memory_basic", test_memory_basic)
 
@@ -217,10 +217,10 @@ def test_memory_warning(caplog):
         )
         Mem4x5 = m.Memory(4, m.Bits[5])()
         io.rdata @= Mem4x5[io.raddr]
-        Mem4x5[io.waddr] = io.wdata
+        Mem4x5[io.waddr] @= io.wdata
 
         io.rdata @= Mem4x5[io.raddr]
-        Mem4x5[io.waddr] = io.wdata
+        Mem4x5[io.waddr] @= io.wdata
 
-    assert "Calling __getitem__ on a Memory instance with RADDR already driven, will overwrite previous values" in caplog.messages  # noqa
-    assert "Calling __setitem__ on a Memory instance with WADDR or WDATA already driven, will overwrite previous values" in caplog.messages  # noqa
+    assert "Reading __getitem__ result from a Memory instance with RADDR already driven, will overwrite previous value" in caplog.messages  # noqa
+    assert "Wiring __getitem__ result from a Memory instance with WADDR or WDATA already driven, will overwrite previous values" in caplog.messages  # noqa


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/820

For now, we provide a warning when the read/write ports are already
driven.  When we add support for the conditional wiring syntax, we can
improve this check to handle the conditional wiring cases.