### PR TITLE
Make register init/coreir_init consistent

### DIFF
--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -62,7 +62,9 @@ def convertbit(value, totype):
     assert isinstance(value, (IntegerTypes, Digital))
 
     if isinstance(value, IntegerTypes):
-        value = totype(1) if value else totype(0)
+        # Just return VCC or GND here, otherwise we lose VCC/GND singleton
+        # invariant
+        return totype(1) if value else totype(0)
 
     if value.is_input():
         b = In(totype)(name=value.name)

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -178,10 +178,7 @@ class Register(Generator2):
         if isinstance(init, int):
             init = _zero_init(T, init)
 
-        if has_async_reset or has_async_resetn:
-            coreir_init = int(as_bits(init))
-        else:
-            coreir_init = 0
+        coreir_init = int(as_bits(init))
 
         reg = _CoreIRRegister(T.flat_length(), init=coreir_init,
                               has_async_reset=has_async_reset,

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -178,7 +178,10 @@ class Register(Generator2):
         if isinstance(init, int):
             init = _zero_init(T, init)
 
-        coreir_init = int(as_bits(init))
+        coreir_init = init
+        if isinstance(coreir_init, Type):
+            coreir_init = as_bits(init)
+        coreir_init = int(coreir_init)
 
         reg = _CoreIRRegister(T.flat_length(), init=coreir_init,
                               has_async_reset=has_async_reset,

--- a/tests/test_primitives/gold/test_basic_reg.v
+++ b/tests/test_primitives/gold/test_basic_reg.v
@@ -94,7 +94,7 @@ coreir_const #(
 );
 coreir_reg #(
     .clk_posedge(1'b1),
-    .init(8'h00),
+    .init(8'hde),
     .width(8)
 ) reg_P_inst0 (
     .clk(CLK),

--- a/tests/test_primitives/gold/test_enable_reg.v
+++ b/tests/test_primitives/gold/test_enable_reg.v
@@ -102,7 +102,7 @@ Mux2xBits8 enable_mux (
 );
 coreir_reg #(
     .clk_posedge(1'b1),
-    .init(8'h00),
+    .init(8'hde),
     .width(8)
 ) reg_P_inst0 (
     .clk(CLK),

--- a/tests/test_primitives/gold/test_reg_of_nested_array.v
+++ b/tests/test_primitives/gold/test_reg_of_nested_array.v
@@ -153,7 +153,7 @@ wire [23:0] reg_P_inst0_in;
 assign reg_P_inst0_in = {Mux2xArray3_Bits8_inst0_O[2][7:0],Mux2xArray3_Bits8_inst0_O[1][7:0],Mux2xArray3_Bits8_inst0_O[0][7:0]};
 coreir_reg #(
     .clk_posedge(1'b1),
-    .init(24'h000000),
+    .init(24'hbeadde),
     .width(24)
 ) reg_P_inst0 (
     .clk(CLK),

--- a/tests/test_primitives/gold/test_reg_of_product.v
+++ b/tests/test_primitives/gold/test_reg_of_product.v
@@ -216,7 +216,7 @@ wire [11:0] reg_P_inst0_in;
 assign reg_P_inst0_in = {Mux2xTuplex_Bits8_y_Bits4_inst0_O_y_out[3:0],Mux2xTuplex_Bits8_y_Bits4_inst0_O_x_out[7:0]};
 coreir_reg #(
     .clk_posedge(1'b1),
-    .init(12'h000),
+    .init(12'hade),
     .width(12)
 ) reg_P_inst0 (
     .clk(CLK),

--- a/tests/test_primitives/test_register.py
+++ b/tests/test_primitives/test_register.py
@@ -273,3 +273,25 @@ def test_resetn():
     tester.compile_and_run("verilator", skip_compile=True,
                            directory=os.path.join(os.path.dirname(__file__),
                                                   "build"))
+
+
+def test_reg_init_uniq():
+    class test_reg_init_uniq(m.Circuit):
+        io = m.IO(O0=m.Out(m.Bit), O1=m.Out(m.Bit)) + m.ClockIO()
+        reg0 = m.Register(m.Bit, init=0)()
+        reg0.I @= reg0.O
+        io.O0 @= reg0.O
+        reg1 = m.Register(m.Bit, init=1)()
+        reg1.I @= reg1.O
+        io.O1 @= reg1.O
+
+    m.compile("build/test_reg_init_uniq", test_reg_init_uniq)
+
+    tester = fault.Tester(test_reg_init_uniq, test_reg_init_uniq.CLK)
+    # Eval to propogate register value
+    tester.eval()
+    tester.circuit.O0.expect(0)
+    tester.circuit.O1.expect(1)
+    tester.compile_and_run("verilator", skip_compile=True,
+                           directory=os.path.join(os.path.dirname(__file__),
+                                                  "build"))


### PR DESCRIPTION
Before, if we had a synchronous reset or no reset, we skipped setting
the coreir_init variable (set it to 0 instead).  I think the reasoning
may have been with a synchronous reset, the init value is also provided
to the mux logic.  This changes the behavior so that the coreir init
matches the actual init in the sync reset or no reset cases.  I can't
think of a reason why we shouldn't do this, whereas the current behavior
provides unexpected results (e.g. if I don't specify a reset, the
register init value is just completely ignored, rather than being used
to initialize the register contents)