### PR TITLE
Improve error message when calling == or != on input values

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -13,6 +13,7 @@ from .debug import debug_wire, get_callee_frame_info
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
+from magma.operator_utils import output_only
 from magma.wire_container import WiringLog
 from magma.protocol_type import MagmaProtocol
 
@@ -300,10 +301,15 @@ class Array(Type, metaclass=ArrayMeta):
     def isoriented(cls, direction):
         return cls.is_oriented(direction)
 
+    @output_only("Cannot use == on an input")
     def __eq__(self, rhs):
         if not isinstance(rhs, ArrayType):
             return False
         return self.ts == rhs.ts
+
+    @output_only("Cannot use != on an input")
+    def __ne__(self, rhs):
+        return ~(self == rhs)
 
     __hash__ = Type.__hash__
 

--- a/magma/bit.py
+++ b/magma/bit.py
@@ -17,6 +17,7 @@ from magma.circuit import Circuit, coreir_port_mapping
 from magma.family import get_family
 from magma.interface import IO
 from magma.language_utils import primitive_to_python
+from magma.operator_utils import output_only
 
 
 def bit_cast(fn: tp.Callable[['Bit', 'Bit'], 'Bit']) -> \
@@ -115,11 +116,13 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
         return self.declare_unary_op("not")()(self)
 
     @bit_cast
+    @output_only("Cannot use == on an input")
     def __eq__(self, other):
         # CoreIR doesn't define an eq primitive for bits
         return ~(self ^ other)
 
     @bit_cast
+    @output_only("Cannot use != on an input")
     def __ne__(self, other):
         # CoreIR doesn't define an ne primitive for bits
         return self ^ other

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -23,6 +23,7 @@ from magma.interface import IO
 from magma.language_utils import primitive_to_python
 from magma.logging import root_logger
 from magma.generator import Generator2
+from magma.operator_utils import output_only
 
 
 def _error_handler(fn):
@@ -460,10 +461,12 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def __rrshift__(self, other):
         return type(self)(other) >> self
 
+    @output_only("Cannot use == on an input")
     @_error_handler
     def __eq__(self, other):
         return self.bveq(other)
 
+    @output_only("Cannot use != on an input")
     @_error_handler
     def __ne__(self, other):
         return self.bvne(other)

--- a/magma/operator_utils.py
+++ b/magma/operator_utils.py
@@ -4,7 +4,7 @@ import functools
 def output_only(msg):
 
     def _wrapper(fn):
-    
+
         @functools.wraps(fn)
         def _wrapped(self, *args, **kwargs):
             if self.is_input():

--- a/magma/operator_utils.py
+++ b/magma/operator_utils.py
@@ -1,0 +1,12 @@
+import functools
+
+
+def output_only(err_msg):
+    def wrapper(fn):
+        @functools.wraps(fn)
+        def wrapped(self, *args, **kwargs):
+            if self.is_input():
+                raise TypeError(err_msg)
+            return fn(self, *args, **kwargs)
+        return wrapped
+    return wrapper

--- a/magma/operator_utils.py
+++ b/magma/operator_utils.py
@@ -1,12 +1,16 @@
 import functools
 
 
-def output_only(err_msg):
-    def wrapper(fn):
+def output_only(msg):
+
+    def _wrapper(fn):
+    
         @functools.wraps(fn)
-        def wrapped(self, *args, **kwargs):
+        def _wrapped(self, *args, **kwargs):
             if self.is_input():
-                raise TypeError(err_msg)
+                raise TypeError(msg)
             return fn(self, *args, **kwargs)
-        return wrapped
-    return wrapper
+
+        return _wrapped
+
+    return _wrapper

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -21,6 +21,7 @@ from .protocol_type import magma_type, magma_value
 from magma.wire_container import WiringLog
 from magma.wire import wire
 from magma.protocol_type import MagmaProtocol
+from magma.operator_utils import output_only
 
 
 _logger = root_logger()
@@ -215,11 +216,16 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
     def keys(cls):
         return [str(i) for i in range(len(cls.fields))]
 
+    @output_only("Cannot use == on an input")
     def __eq__(self, rhs):
         if not isinstance(rhs, type(self)):
             return NotImplemented
         else:
             return self.ts == rhs.ts
+
+    @output_only("Cannot use != on an input")
+    def __ne__(self, rhs):
+        return ~(self == rhs)
 
     def __repr__(self):
         if not self.name.anon():

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -72,3 +72,14 @@ def test_assign_error_1(width):
                 TypeError,
                 match=rf"Cannot use @= to assign to output: a \(trying to assign O\)"):  # noqa
             io.a @= and2.O
+
+
+@pytest.mark.parametrize('T', [m.Bit, m.Array[5, m.Bit], m.Bits[5],
+                               m.Tuple[m.Bit, m.Bits[5]]])
+def test_eq_neq_input(T):
+    class Foo(m.Circuit):
+        io = m.IO(O=m.Out(T))
+        with pytest.raises(TypeError, match="Cannot use == on an input"):
+            io.O == 1
+        with pytest.raises(TypeError, match="Cannot use != on an input"):
+            io.O != 1


### PR DESCRIPTION
Before, in some cases, the operator would return True or False rather
than raising an error.  We probably want to make this consistent for all
operators, but I think this is an important hotfix since the current
return value (bool rather than a magma value) can cause downstream
errors that are confusing and making tracing the root cause harder
(might get some typeerror related to the bool returned, which might lead
you to start debugging at the wrong place)