### PR TITLE
Add support for coreir_module metadata

### DIFF
--- a/magma/backend/coreir_transformer.py
+++ b/magma/backend/coreir_transformer.py
@@ -396,4 +396,6 @@ class DeclarationTransformer(LeafTransformer):
             self.decl.coreir_name, module_type, **kwargs)
         if get_codegen_debug_info() and self.decl.debug_info:
             attach_debug_info(coreir_module, self.decl.debug_info)
+        for key, value in self.decl.coreir_metadata.items():
+            coreir_module.add_metadata(key, json.dumps(value))
         return coreir_module

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -235,6 +235,7 @@ class CircuitKind(type):
         dct.setdefault('primitive', False)
         dct.setdefault('coreir_lib', 'global')
         dct.setdefault("inline_verilog_strs", [])
+        dct.setdefault("coreir_metadata", {})
         dct["inline_verilog_generated"] = False
         dct["bind_modules"] = {}
         dct["compiled_bind_modules"] = {}

--- a/tests/test_circuit/gold/test_inline_single_instances_metadata.v
+++ b/tests/test_circuit/gold/test_inline_single_instances_metadata.v
@@ -1,0 +1,36 @@
+module mux_aoi_2_16 ( 
+	input logic  [15 : 0] I0, 
+	input logic  [15 : 0] I1, 
+input logic S, 
+	output logic [15 : 0] O); 
+
+	logic  [1 : 0] out_sel;
+	logic  [15 : 0] O_int0;
+
+precoder_16_2 u_precoder ( 
+	.S(S), 
+	.out_sel(out_sel)); 
+
+mux_logic_16_2 u_mux_logic ( 
+	.I0 (I0),
+	.I1 (I1),
+	.out_sel(out_sel), 
+	.O0(O_int0)); 
+	assign O = (  	O_int0 	); 
+
+endmodule
+module Top (
+    input [15:0] I [1:0],
+    output [15:0] O,
+    input [0:0] S
+);
+wire [15:0] MuxWrapperAOIImpl_2_16_inst0$mux_aoi_2_16_inst0_O;
+mux_aoi_2_16 MuxWrapperAOIImpl_2_16_inst0$mux_aoi_2_16_inst0 (
+    .I0(I[0]),
+    .I1(I[1]),
+    .S(S[0]),
+    .O(MuxWrapperAOIImpl_2_16_inst0$mux_aoi_2_16_inst0_O)
+);
+assign O = MuxWrapperAOIImpl_2_16_inst0$mux_aoi_2_16_inst0_O;
+endmodule
+

--- a/tests/test_circuit/gold/test_inline_single_instances_metadata.v
+++ b/tests/test_circuit/gold/test_inline_single_instances_metadata.v
@@ -19,18 +19,35 @@ mux_logic_16_2 u_mux_logic (
     assign O = (  	O_int0 	);
 
 endmodule
+module MuxWrapperAOIImpl_2_16 (
+    input [15:0] I [1:0],
+    output [15:0] O,
+    input [0:0] S
+);
+wire [15:0] mux_aoi_2_16_inst0_O;
+mux_aoi_2_16 mux_aoi_2_16_inst0 (
+    .I0(I[0]),
+    .I1(I[1]),
+    .S(S[0]),
+    .O(mux_aoi_2_16_inst0_O)
+);
+assign O = mux_aoi_2_16_inst0_O;
+endmodule
+
 module Top (
     input [15:0] I [1:0],
     output [15:0] O,
     input [0:0] S
 );
-wire [15:0] MuxWrapperAOIImpl_2_16_inst0$mux_aoi_2_16_inst0_O;
-mux_aoi_2_16 MuxWrapperAOIImpl_2_16_inst0$mux_aoi_2_16_inst0 (
-    .I0(I[0]),
-    .I1(I[1]),
-    .S(S[0]),
-    .O(MuxWrapperAOIImpl_2_16_inst0$mux_aoi_2_16_inst0_O)
+wire [15:0] MuxWrapperAOIImpl_2_16_inst0_O;
+wire [15:0] MuxWrapperAOIImpl_2_16_inst0_I [1:0];
+assign MuxWrapperAOIImpl_2_16_inst0_I[1] = I[1];
+assign MuxWrapperAOIImpl_2_16_inst0_I[0] = I[0];
+MuxWrapperAOIImpl_2_16 MuxWrapperAOIImpl_2_16_inst0 (
+    .I(MuxWrapperAOIImpl_2_16_inst0_I),
+    .O(MuxWrapperAOIImpl_2_16_inst0_O),
+    .S(S)
 );
-assign O = MuxWrapperAOIImpl_2_16_inst0$mux_aoi_2_16_inst0_O;
+assign O = MuxWrapperAOIImpl_2_16_inst0_O;
 endmodule
 

--- a/tests/test_circuit/gold/test_inline_single_instances_metadata.v
+++ b/tests/test_circuit/gold/test_inline_single_instances_metadata.v
@@ -1,22 +1,22 @@
-module mux_aoi_2_16 ( 
-	input logic  [15 : 0] I0, 
-	input logic  [15 : 0] I1, 
-input logic S, 
-	output logic [15 : 0] O); 
+module mux_aoi_2_16 (
+    input logic  [15 : 0] I0,
+    input logic  [15 : 0] I1,
+    input logic S,
+    output logic [15 : 0] O);
 
-	logic  [1 : 0] out_sel;
-	logic  [15 : 0] O_int0;
+    logic  [1 : 0] out_sel;
+    logic  [15 : 0] O_int0;
 
-precoder_16_2 u_precoder ( 
-	.S(S), 
-	.out_sel(out_sel)); 
+precoder_16_2 u_precoder (
+    .S(S),
+    .out_sel(out_sel));
 
-mux_logic_16_2 u_mux_logic ( 
-	.I0 (I0),
-	.I1 (I1),
-	.out_sel(out_sel), 
-	.O0(O_int0)); 
-	assign O = (  	O_int0 	); 
+mux_logic_16_2 u_mux_logic (
+    .I0 (I0),
+    .I1 (I1),
+    .out_sel(out_sel),
+    .O0(O_int0));
+    assign O = (  	O_int0 	);
 
 endmodule
 module Top (

--- a/tests/test_circuit/test_coreir_metadata.py
+++ b/tests/test_circuit/test_coreir_metadata.py
@@ -1,0 +1,43 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_inline_single_instances_metadata():
+    mux_aoi_2_16 = m.define_from_verilog("""
+module mux_aoi_2_16 ( 
+	input logic  [15 : 0] I0, 
+	input logic  [15 : 0] I1, 
+input logic S, 
+	output logic [15 : 0] O); 
+
+	logic  [1 : 0] out_sel;
+	logic  [15 : 0] O_int0;
+
+precoder_16_2 u_precoder ( 
+	.S(S), 
+	.out_sel(out_sel)); 
+
+mux_logic_16_2 u_mux_logic ( 
+	.I0 (I0),
+	.I1 (I1),
+	.out_sel(out_sel), 
+	.O0(O_int0)); 
+	assign O = (  	O_int0 	); 
+
+endmodule""")[0]
+
+    class MuxWrapperAOIImpl_2_16(m.Circuit):
+        coreir_metadata = {"inline_single_instances": False}
+        io = m.IO(I=m.In(m.Array[2, m.Bits[16]]), O=m.Out(m.Array[16, m.Bit]),
+                  S=m.In(m.Array[1, m.Bit]))
+        io.O @= mux_aoi_2_16()(io.I[0], io.I[1], io.S[0])
+
+    class Top(m.Circuit):
+        io = m.IO(I=m.In(m.Array[2, m.Bits[16]]), O=m.Out(m.Array[16, m.Bit]),
+                  S=m.In(m.Array[1, m.Bit]))
+        io.O @= MuxWrapperAOIImpl_2_16()(io.I, io.S)
+
+    m.compile('build/test_inline_single_instances_metadata', Top, passes=["inline_single_instances"])
+    assert check_files_equal(__file__,
+                             "build/test_inline_single_instances_metadata.v",
+                             "gold/test_inline_single_instances_metadata.v")

--- a/tests/test_circuit/test_coreir_metadata.py
+++ b/tests/test_circuit/test_coreir_metadata.py
@@ -27,7 +27,7 @@ mux_logic_16_2 u_mux_logic (
 endmodule""")[0]
 
     class MuxWrapperAOIImpl_2_16(m.Circuit):
-        coreir_metadata = {"inline_single_instances": False}
+        coreir_metadata = {"inline_single_instance": False}
         io = m.IO(I=m.In(m.Array[2, m.Bits[16]]), O=m.Out(m.Array[16, m.Bit]),
                   S=m.In(m.Array[1, m.Bit]))
         io.O @= mux_aoi_2_16()(io.I[0], io.I[1], io.S[0])

--- a/tests/test_circuit/test_coreir_metadata.py
+++ b/tests/test_circuit/test_coreir_metadata.py
@@ -4,25 +4,25 @@ from magma.testing import check_files_equal
 
 def test_inline_single_instances_metadata():
     mux_aoi_2_16 = m.define_from_verilog("""
-module mux_aoi_2_16 ( 
-	input logic  [15 : 0] I0, 
-	input logic  [15 : 0] I1, 
-input logic S, 
-	output logic [15 : 0] O); 
+module mux_aoi_2_16 (
+    input logic  [15 : 0] I0,
+    input logic  [15 : 0] I1,
+    input logic S,
+    output logic [15 : 0] O);
 
-	logic  [1 : 0] out_sel;
-	logic  [15 : 0] O_int0;
+    logic  [1 : 0] out_sel;
+    logic  [15 : 0] O_int0;
 
-precoder_16_2 u_precoder ( 
-	.S(S), 
-	.out_sel(out_sel)); 
+precoder_16_2 u_precoder (
+    .S(S),
+    .out_sel(out_sel));
 
-mux_logic_16_2 u_mux_logic ( 
-	.I0 (I0),
-	.I1 (I1),
-	.out_sel(out_sel), 
-	.O0(O_int0)); 
-	assign O = (  	O_int0 	); 
+mux_logic_16_2 u_mux_logic (
+    .I0 (I0),
+    .I1 (I1),
+    .out_sel(out_sel),
+    .O0(O_int0));
+    assign O = (  	O_int0 	);
 
 endmodule""")[0]
 
@@ -37,7 +37,8 @@ endmodule""")[0]
                   S=m.In(m.Array[1, m.Bit]))
         io.O @= MuxWrapperAOIImpl_2_16()(io.I, io.S)
 
-    m.compile('build/test_inline_single_instances_metadata', Top, passes=["inline_single_instances"])
+    m.compile('build/test_inline_single_instances_metadata', Top,
+              passes=["inline_single_instances"])
     assert check_files_equal(__file__,
                              "build/test_inline_single_instances_metadata.v",
                              "gold/test_inline_single_instances_metadata.v")


### PR DESCRIPTION
Adds support for a user defined class variable coreir_metadata that
contains a dictionary to be passed through to coreir.  For each
dictionary item the key must be a string and the value must be
convertible to json (with `json.dumps`).

Depends on https://github.com/rdaly525/coreir/pull/965