### PR TITLE
conversion operators should extend to n

### DIFF
--- a/magma/bits.py
+++ b/magma/bits.py
@@ -412,7 +412,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def ext_to(self, n):
         if n < len(self):
             raise TypeError(f"Cannot ext {self} of len={len(self)} to {n}")
-        return self.ext(other, n - len(n))
+        return self.ext(n - len(self))
 
     def zext(self, other) -> 'AbstractBitVector':
         ext = int(other)

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -409,6 +409,11 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def ext(self, other) -> 'AbstractBitVector':
         return self.zext(other)
 
+    def ext_to(self, n):
+        if n < len(self):
+            raise TypeError(f"Cannot ext {self} of len={len(self)} to {n}")
+        return self.ext(other, n - len(n))
+
     def zext(self, other) -> 'AbstractBitVector':
         ext = int(other)
         if ext < 0:

--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -172,10 +172,7 @@ def convertbits(value, n, totype, checkbit):
 
     value = totype[len(Ts), T](ts)
     if n is not None and len(value) < n:
-        if isinstance(value, SInt):
-            value = sext_to(value, n)
-        else:
-            value = zext_to(value, n)
+        value = value.ext_to(n)
     return value
 
 

--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -170,7 +170,13 @@ def convertbits(value, n, totype, checkbit):
             Direction.InOut: InOut
         }[T.direction](Bit)
 
-    return totype[len(Ts), T](ts)
+    value = totype[len(Ts), T](ts)
+    if n is not None and len(value) < n:
+        if isinstance(value, SInt):
+            value = sext_to(value, n)
+        else:
+            value = zext_to(value, n)
+    return value
 
 
 def array(value, n=None):

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -32,3 +32,15 @@ def test_ext():
 def test_concat_type_error():
     with pytest.raises(TypeError):
         m.concat(object(), object())
+
+
+@pytest.mark.parametrize('op', [m.uint, m.sint])
+def test_convert_extend(op):
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[5]))
+        value = op(io.I, 32)
+        assert len(value) == 32
+        if op is m.sint:
+            # Check sext logic
+            for x in value[5:]:
+                assert x is io.I[4]


### PR DESCRIPTION
This adds logic to the conversion operators to extend to the user
specified `n`.  Before, it would simply just convert to the type without
extension.