### PR TITLE
Fix clock undriven bug

### DIFF
--- a/magma/clock.py
+++ b/magma/clock.py
@@ -15,10 +15,27 @@ class _ClockType(Digital):
         return True
 
     def unused(self):
+        # TODO: We don't have to convert here since we can wire a clock to a
+        # bit (but we can't wire a bit to a clock).  Is this desired? One view
+        # is it's an "upcast" (remove clock restriction, so a bit can't behave
+        # as a clock implicitly, but a clock can behave as a bit).  However,
+        # this doesn't fit into our type hierarchy (so we'd need rearrange
+        # that).  Unfortunately, implementing the type check in the other
+        # direction is a bit harder (Bit needs to be aware of what it can't be
+        # wired to, so defining a new Digital with wiring restrictions needs to
+        # change Bit, not a great pattern)
+        # Perhaps the way to go is some sort of "wireable" API for a type that
+        # is checked in the wire logic, allowing types to define their
+        # "wireability", rather than defining wireability inside the `wire`
+        # method (the problem here is the Bit wire method is called since it's
+        # the input, and inside the Bit wire method there's no type check)
         Bit.unused(self)
 
     def undriven(self):
-        Bit.undriven(self)
+        # Circular import because conversions imports clock, not sure if
+        # there's a good way around this
+        from magma.conversions import bit
+        Bit.undriven(bit(self))
 
     @debug_wire
     def wire(self, other, debug_info=None):

--- a/tests/test_type/test_clock.py
+++ b/tests/test_type/test_clock.py
@@ -421,3 +421,12 @@ def test_wire_error():
             io = m.IO(I=m.In(m.Clock), O=m.Out(m.Reset))
             m.wire(io.I, io.O)
     assert str(e.value) == "Cannot wire I (T=Out(Clock)) to O (T=In(Reset))"
+
+
+def test_clock_undriven():
+    class Foo(m.Circuit):
+        io = m.ClockIO()
+
+    class Bar(m.Circuit):
+        foo = Foo()
+        foo.CLK.undriven()


### PR DESCRIPTION
See comment about unused and why it doesn't need the same change.  I
think we need to add a wireable API to handle the clock wiring
restriction cleanly, or reorganize the type hierarchy if we want to
allow the current pattern.