### PR TITLE
Fix deprecation warning from bfloat code

### DIFF
--- a/magma/bfloat.py
+++ b/magma/bfloat.py
@@ -1,15 +1,8 @@
 from functools import lru_cache
 from magma.bit import Bit
 from magma.bits import UInt
-from magma.circuit import Circuit, coreir_port_mapping
-from magma.interface import IO
+from magma.circuit import declare_coreir_circuit
 from magma.t import In, Out
-
-
-class CoreIRFloatOp(Circuit):
-    renamed_ports = coreir_port_mapping
-    coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
-    coreir_lib = "float"
 
 
 class BFloat(UInt):
@@ -19,18 +12,13 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-
-        class _BFloatOp(CoreIRFloatOp):
-            # Have to explicitly inherit class variables, but at least we can
-            # keep one copy if we ever have to change them
-            renamed_ports = CoreIRFloatOp.renamed_ports
-            coreir_genargs = CoreIRFloatOp.coreir_genargs
-            coreir_lib = CoreIRFloatOp.coreir_lib
-
-            name = f"magma_BFloat_{N}_{op}"
-            io = IO(I=In(cls), O=Out(cls))
-            coreir_name = op
-        return _BFloatOp
+        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
+        return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
+                                      {"I": In(cls),
+                                       "O": Out(cls)},
+                                      coreir_name=op,
+                                      coreir_genargs=coreir_genargs,
+                                      coreir_lib="float")
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -38,18 +26,14 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-
-        class _BFloatOp(CoreIRFloatOp):
-            renamed_ports = CoreIRFloatOp.renamed_ports
-            coreir_genargs = CoreIRFloatOp.coreir_genargs
-            coreir_lib = CoreIRFloatOp.coreir_lib
-
-            name = f"magma_BFloat_{N}_{op}"
-            io = IO(I0=In(cls), I1=In(cls), O=Out(cls))
-            coreir_name = op
-            coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
-            coreir_lib = "float"
-        return _BFloatOp
+        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
+        return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
+                                      {"I0": In(cls),
+                                       "I1": In(cls),
+                                       "O": Out(cls)},
+                                      coreir_name=op,
+                                      coreir_genargs=coreir_genargs,
+                                      coreir_lib="float")
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -57,18 +41,14 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-
-        class _BFloatOp(CoreIRFloatOp):
-            renamed_ports = CoreIRFloatOp.renamed_ports
-            coreir_genargs = CoreIRFloatOp.coreir_genargs
-            coreir_lib = CoreIRFloatOp.coreir_lib
-
-            name = f"magma_BFloat_{N}_{op}"
-            io = IO(I0=In(cls), I1=In(cls), O=Out(Bit))
-            coreir_name = op
-            coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
-            coreir_lib = "float"
-        return _BFloatOp
+        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
+        return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
+                                      {"I0", In(cls),
+                                       "I1", In(cls),
+                                       "O", Out(Bit)},
+                                      coreir_name=op,
+                                      coreir_genargs=coreir_genargs,
+                                      coreir_lib="float")
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -82,15 +62,12 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-
-        class _BFloatOp(CoreIRFloatOp):
-            renamed_ports = CoreIRFloatOp.renamed_ports
-            coreir_genargs = CoreIRFloatOp.coreir_genargs
-            coreir_lib = CoreIRFloatOp.coreir_lib
-
-            name = f"magma_BFloat_{N}_ite_{t_str}"
-            io = IO(I0=T, I1=T, S=In(Bit), O=Out(T))
-            coreir_name = "mux"
-            coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
-            coreir_lib = "float"
-        return _BFloatOp
+        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
+        return declare_coreir_circuit(f"magma_BFloat_{N}_ite_{t_str}",
+                                      {"I0": In(T),
+                                       "I1": In(T),
+                                       "S": In(Bit),
+                                       "O": Out(T)},
+                                      coreir_name="mux",
+                                      coreir_genargs=coreir_genargs,
+                                      coreir_lib="float")

--- a/magma/bfloat.py
+++ b/magma/bfloat.py
@@ -1,8 +1,15 @@
 from functools import lru_cache
 from magma.bit import Bit
 from magma.bits import UInt
-from magma.circuit import DeclareCoreirCircuit
+from magma.circuit import Circuit, coreir_port_mapping
+from magma.interface import IO
 from magma.t import In, Out
+
+
+class CoreIRFloatOp(Circuit):
+    renamed_ports = coreir_port_mapping
+    coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
+    coreir_lib = "float"
 
 
 class BFloat(UInt):
@@ -12,13 +19,18 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
-        return DeclareCoreirCircuit(f"magma_BFloat_{N}_{op}",
-                                    "I", In(cls),
-                                    "O", Out(cls),
-                                    coreir_name=op,
-                                    coreir_genargs=coreir_genargs,
-                                    coreir_lib="float")
+
+        class _BFloatOp(CoreIRFloatOp):
+            # Have to explicitly inherit class variables, but at least we can
+            # keep one copy if we ever have to change them
+            renamed_ports = CoreIRFloatOp.renamed_ports
+            coreir_genargs = CoreIRFloatOp.coreir_genargs
+            coreir_lib = CoreIRFloatOp.coreir_lib
+
+            name = f"magma_BFloat_{N}_{op}"
+            io = IO(I=In(cls), O=Out(cls))
+            coreir_name = op
+        return _BFloatOp
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -26,14 +38,18 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
-        return DeclareCoreirCircuit(f"magma_BFloat_{N}_{op}",
-                                    "I0", In(cls),
-                                    "I1", In(cls),
-                                    "O", Out(cls),
-                                    coreir_name=op,
-                                    coreir_genargs=coreir_genargs,
-                                    coreir_lib="float")
+
+        class _BFloatOp(CoreIRFloatOp):
+            renamed_ports = CoreIRFloatOp.renamed_ports
+            coreir_genargs = CoreIRFloatOp.coreir_genargs
+            coreir_lib = CoreIRFloatOp.coreir_lib
+
+            name = f"magma_BFloat_{N}_{op}"
+            io = IO(I0=In(cls), I1=In(cls), O=Out(cls))
+            coreir_name = op
+            coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
+            coreir_lib = "float"
+        return _BFloatOp
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -41,14 +57,18 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
-        return DeclareCoreirCircuit(f"magma_BFloat_{N}_{op}",
-                                    "I0", In(cls),
-                                    "I1", In(cls),
-                                    "O", Out(Bit),
-                                    coreir_name=op,
-                                    coreir_genargs=coreir_genargs,
-                                    coreir_lib="float")
+
+        class _BFloatOp(CoreIRFloatOp):
+            renamed_ports = CoreIRFloatOp.renamed_ports
+            coreir_genargs = CoreIRFloatOp.coreir_genargs
+            coreir_lib = CoreIRFloatOp.coreir_lib
+
+            name = f"magma_BFloat_{N}_{op}"
+            io = IO(I0=In(cls), I1=In(cls), O=Out(Bit))
+            coreir_name = op
+            coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
+            coreir_lib = "float"
+        return _BFloatOp
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -62,12 +82,15 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
-        return DeclareCoreirCircuit(f"magma_BFloat_{N}_ite_{t_str}",
-                                    "I0", In(T),
-                                    "I1", In(T),
-                                    "S", In(Bit),
-                                    "O", Out(T),
-                                    coreir_name="mux",
-                                    coreir_genargs=coreir_genargs,
-                                    coreir_lib="float")
+
+        class _BFloatOp(CoreIRFloatOp):
+            renamed_ports = CoreIRFloatOp.renamed_ports
+            coreir_genargs = CoreIRFloatOp.coreir_genargs
+            coreir_lib = CoreIRFloatOp.coreir_lib
+
+            name = f"magma_BFloat_{N}_ite_{t_str}"
+            io = IO(I0=T, I1=T, S=In(Bit), O=Out(T))
+            coreir_name = "mux"
+            coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
+            coreir_lib = "float"
+        return _BFloatOp

--- a/magma/bfloat.py
+++ b/magma/bfloat.py
@@ -5,7 +5,9 @@ from magma.circuit import declare_coreir_circuit
 from magma.t import In, Out
 
 
-BFLOAT_GENARGS = {"exp_bits": 8, "frac_bits": 7}
+def declare_bfloat_circuit(name: str, ports: dict, coreir_name: str):
+    return declare_coreir_circuit(name, ports, coreir_name,
+                                  {"exp_bits": 8, "frac_bits": 7}, "float")
 
 
 class BFloat(UInt):
@@ -15,9 +17,8 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
-                                      {"I": In(cls), "O": Out(cls)},
-                                      op, BFLOAT_GENARGS, "float")
+        return declare_bfloat_circuit(f"magma_BFloat_{N}_{op}",
+                                      {"I": In(cls), "O": Out(cls)}, op)
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -25,10 +26,9 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
+        return declare_bfloat_circuit(f"magma_BFloat_{N}_{op}",
                                       {"I0": In(cls), "I1": In(cls),
-                                       "O": Out(cls)},
-                                      op, BFLOAT_GENARGS, "float")
+                                       "O": Out(cls)}, op)
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -36,10 +36,9 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
+        return declare_bfloat_circuit(f"magma_BFloat_{N}_{op}",
                                       {"I0", In(cls), "I1", In(cls),
-                                       "O", Out(Bit)},
-                                      op, BFLOAT_GENARGS, "float")
+                                       "O", Out(Bit)}, op)
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -53,7 +52,6 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        return declare_coreir_circuit(f"magma_BFloat_{N}_ite_{t_str}",
+        return declare_bfloat_circuit(f"magma_BFloat_{N}_ite_{t_str}",
                                       {"I0": In(T), "I1": In(T),
-                                       "S": In(Bit), "O": Out(T)},
-                                      "mux", BFLOAT_GENARGS, "float")
+                                       "S": In(Bit), "O": Out(T)}, "mux")

--- a/magma/bfloat.py
+++ b/magma/bfloat.py
@@ -1,4 +1,4 @@
-from functools import lru_cache
+from functools import lru_cache, wraps
 from magma.bit import Bit
 from magma.bits import UInt
 from magma.circuit import declare_coreir_circuit
@@ -10,38 +10,42 @@ def declare_bfloat_circuit(name: str, ports: dict, coreir_name: str):
                                   {"exp_bits": 8, "frac_bits": 7}, "float")
 
 
+def check_len(fn):
+    @wraps(fn)
+    def wrapper(cls, op):
+        if len(cls) != 16:
+            raise NotImplementedError("Only BFloat16 supported")
+        return fn(cls, op)
+    return wrapper
+
+
 class BFloat(UInt):
     @classmethod
     @lru_cache(maxsize=None)
+    @check_len
     def declare_unary_op(cls, op):
-        N = len(cls)
-        if N != 16:
-            raise NotImplementedError("Only BFloat16 supported")
-        return declare_bfloat_circuit(f"magma_BFloat_{N}_{op}",
+        return declare_bfloat_circuit(f"magma_BFloat_{len(cls)}_{op}",
                                       {"I": In(cls), "O": Out(cls)}, op)
 
     @classmethod
     @lru_cache(maxsize=None)
+    @check_len
     def declare_binary_op(cls, op):
-        N = len(cls)
-        if N != 16:
-            raise NotImplementedError("Only BFloat16 supported")
-        return declare_bfloat_circuit(f"magma_BFloat_{N}_{op}",
+        return declare_bfloat_circuit(f"magma_BFloat_{len(cls)}_{op}",
                                       {"I0": In(cls), "I1": In(cls),
                                        "O": Out(cls)}, op)
 
     @classmethod
     @lru_cache(maxsize=None)
+    @check_len
     def declare_compare_op(cls, op):
-        N = len(cls)
-        if N != 16:
-            raise NotImplementedError("Only BFloat16 supported")
-        return declare_bfloat_circuit(f"magma_BFloat_{N}_{op}",
+        return declare_bfloat_circuit(f"magma_BFloat_{len(cls)}_{op}",
                                       {"I0", In(cls), "I1", In(cls),
                                        "O", Out(Bit)}, op)
 
     @classmethod
     @lru_cache(maxsize=None)
+    @check_len
     def declare_ite(cls, T):
         t_str = str(T)
         # Sanitize
@@ -49,9 +53,6 @@ class BFloat(UInt):
         t_str = t_str.replace(")", "")
         t_str = t_str.replace("[", "_")
         t_str = t_str.replace("]", "")
-        N = len(cls)
-        if N != 16:
-            raise NotImplementedError("Only BFloat16 supported")
-        return declare_bfloat_circuit(f"magma_BFloat_{N}_ite_{t_str}",
+        return declare_bfloat_circuit(f"magma_BFloat_{len(cls)}_ite_{t_str}",
                                       {"I0": In(T), "I1": In(T),
                                        "S": In(Bit), "O": Out(T)}, "mux")

--- a/magma/bfloat.py
+++ b/magma/bfloat.py
@@ -5,6 +5,9 @@ from magma.circuit import declare_coreir_circuit
 from magma.t import In, Out
 
 
+BFLOAT_GENARGS = {"exp_bits": 8, "frac_bits": 7}
+
+
 class BFloat(UInt):
     @classmethod
     @lru_cache(maxsize=None)
@@ -12,12 +15,11 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
         return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
                                       {"I": In(cls),
                                        "O": Out(cls)},
                                       coreir_name=op,
-                                      coreir_genargs=coreir_genargs,
+                                      coreir_genargs=BFLOAT_GENARGS,
                                       coreir_lib="float")
 
     @classmethod
@@ -26,13 +28,12 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
         return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
                                       {"I0": In(cls),
                                        "I1": In(cls),
                                        "O": Out(cls)},
                                       coreir_name=op,
-                                      coreir_genargs=coreir_genargs,
+                                      coreir_genargs=BFLOAT_GENARGS,
                                       coreir_lib="float")
 
     @classmethod
@@ -41,13 +42,12 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
         return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
                                       {"I0", In(cls),
                                        "I1", In(cls),
                                        "O", Out(Bit)},
                                       coreir_name=op,
-                                      coreir_genargs=coreir_genargs,
+                                      coreir_genargs=BFLOAT_GENARGS,
                                       coreir_lib="float")
 
     @classmethod
@@ -62,12 +62,11 @@ class BFloat(UInt):
         N = len(cls)
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
-        coreir_genargs = {"exp_bits": 8, "frac_bits": 7}
         return declare_coreir_circuit(f"magma_BFloat_{N}_ite_{t_str}",
                                       {"I0": In(T),
                                        "I1": In(T),
                                        "S": In(Bit),
                                        "O": Out(T)},
                                       coreir_name="mux",
-                                      coreir_genargs=coreir_genargs,
+                                      coreir_genargs=BFLOAT_GENARGS,
                                       coreir_lib="float")

--- a/magma/bfloat.py
+++ b/magma/bfloat.py
@@ -16,11 +16,8 @@ class BFloat(UInt):
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
         return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
-                                      {"I": In(cls),
-                                       "O": Out(cls)},
-                                      coreir_name=op,
-                                      coreir_genargs=BFLOAT_GENARGS,
-                                      coreir_lib="float")
+                                      {"I": In(cls), "O": Out(cls)},
+                                      op, BFLOAT_GENARGS, "float")
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -29,12 +26,9 @@ class BFloat(UInt):
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
         return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
-                                      {"I0": In(cls),
-                                       "I1": In(cls),
+                                      {"I0": In(cls), "I1": In(cls),
                                        "O": Out(cls)},
-                                      coreir_name=op,
-                                      coreir_genargs=BFLOAT_GENARGS,
-                                      coreir_lib="float")
+                                      op, BFLOAT_GENARGS, "float")
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -43,12 +37,9 @@ class BFloat(UInt):
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
         return declare_coreir_circuit(f"magma_BFloat_{N}_{op}",
-                                      {"I0", In(cls),
-                                       "I1", In(cls),
+                                      {"I0", In(cls), "I1", In(cls),
                                        "O", Out(Bit)},
-                                      coreir_name=op,
-                                      coreir_genargs=BFLOAT_GENARGS,
-                                      coreir_lib="float")
+                                      op, BFLOAT_GENARGS, "float")
 
     @classmethod
     @lru_cache(maxsize=None)
@@ -63,10 +54,6 @@ class BFloat(UInt):
         if N != 16:
             raise NotImplementedError("Only BFloat16 supported")
         return declare_coreir_circuit(f"magma_BFloat_{N}_ite_{t_str}",
-                                      {"I0": In(T),
-                                       "I1": In(T),
-                                       "S": In(Bit),
-                                       "O": Out(T)},
-                                      coreir_name="mux",
-                                      coreir_genargs=BFLOAT_GENARGS,
-                                      coreir_lib="float")
+                                      {"I0": In(T), "I1": In(T),
+                                       "S": In(Bit), "O": Out(T)},
+                                      "mux", BFLOAT_GENARGS, "float")

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -778,6 +778,19 @@ def DeclareCoreirCircuit(*args, **kwargs):
                           renamed_ports=coreir_port_mapping)
 
 
+def declare_coreir_circuit(name_: str, ports: dict, coreir_name: str,
+                           coreir_genargs: dict, coreir_lib: str):
+    class CoreIRCircuit(Circuit):
+        name = name_
+        renamed_ports = coreir_port_mapping
+        io = IO(**ports)
+        coreir_name = coreir_name
+        coreir_genargs = coreir_genargs
+        coreir_lib = coreir_lib
+
+    return CoreIRCircuit
+
+
 class _CircuitBuilderMeta(type):
     pass
 

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -778,15 +778,19 @@ def DeclareCoreirCircuit(*args, **kwargs):
                           renamed_ports=coreir_port_mapping)
 
 
-def declare_coreir_circuit(name_: str, ports: dict, coreir_name: str,
-                           coreir_genargs: dict, coreir_lib: str):
+def declare_coreir_circuit(name_: str, ports: dict, coreir_name_: str,
+                           coreir_genargs_: dict, coreir_lib_: str):
+    """
+    parameter names are suffixed with `_` otherwise we get a NameError inside
+    the class definition
+    """
     class CoreIRCircuit(Circuit):
         name = name_
         renamed_ports = coreir_port_mapping
         io = IO(**ports)
-        coreir_name = coreir_name
-        coreir_genargs = coreir_genargs
-        coreir_lib = coreir_lib
+        coreir_name = coreir_name_
+        coreir_genargs = coreir_genargs_
+        coreir_lib = coreir_lib_
 
     return CoreIRCircuit
 

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -772,6 +772,7 @@ coreir_port_mapping = {
 }
 
 
+@deprecated
 def DeclareCoreirCircuit(*args, **kwargs):
     return DeclareCircuit(*args, **kwargs,
                           renamed_ports=coreir_port_mapping)


### PR DESCRIPTION
Also add deprecation decorator to DeclareCoreIRCircuit.  @deprecation
uses stacklevel=2 which means that the DeclareCircuit deprecation will
just show up in DeclareCoreIRCircuit.  Adding the decorator to
DeclareCoreIRCircuit will also show the warning where it occurs for the
user of DeclareCoreIRCircuit (in this case, was in the bfloat code).