### PR TITLE
Fix undriven bug for partial connected values

### DIFF
--- a/magma/passes/drive_undriven.py
+++ b/magma/passes/drive_undriven.py
@@ -1,11 +1,13 @@
 from .passes import EditDefinitionPass
 from ..is_definition import isdefinition
+from magma.array import Array
 from magma.clock import (wire_default_clock, is_clock_or_nested_clock,
                          get_default_clocks)
+from magma.tuple import Tuple
 
 
 def _drive_if_undriven_input(port, clocks):
-    if port.is_mixed():
+    if isinstance(port, (Tuple, Array)):
         # list comp so it doesn't short circuit
         undrivens = [_drive_if_undriven_input(p, clocks) for p in port]
         return any(undrivens)

--- a/tests/test_circuit/gold/test_ignore_unused_undriven_hierarchy.v
+++ b/tests/test_circuit/gold/test_ignore_unused_undriven_hierarchy.v
@@ -30,13 +30,17 @@ module Main (
     input I0,
     input I1,
     output O0,
-    output O1
+    output O1,
+    output O2__0,
+    output O2__1,
+    output [1:0] O3
 );
 wire Foo_inst0_O1;
-wire corebit_undriven_inst1_out;
+wire corebit_undriven_inst2_out;
+wire corebit_undriven_inst3_out;
 Foo Foo_inst0 (
     .I0(I0),
-    .I1(corebit_undriven_inst1_out),
+    .I1(corebit_undriven_inst3_out),
     .O0(O0),
     .O1(Foo_inst0_O1)
 );
@@ -50,7 +54,15 @@ corebit_undriven corebit_undriven_inst0 (
     .out(O1)
 );
 corebit_undriven corebit_undriven_inst1 (
-    .out(corebit_undriven_inst1_out)
+    .out(O2__1)
 );
+corebit_undriven corebit_undriven_inst2 (
+    .out(corebit_undriven_inst2_out)
+);
+corebit_undriven corebit_undriven_inst3 (
+    .out(corebit_undriven_inst3_out)
+);
+assign O2__0 = 1'b1;
+assign O3 = {corebit_undriven_inst2_out,1'b1};
 endmodule
 

--- a/tests/test_circuit/test_undriven_unused.py
+++ b/tests/test_circuit/test_undriven_unused.py
@@ -38,11 +38,16 @@ def test_ignore_unused_undriven_hierarchy():
     class Main(m.Circuit):
         _ignore_undriven_ = True
         io = m.IO(I0=m.In(m.Bit), I1=m.In(m.Bit),
-                  O0=m.Out(m.Bit), O1=m.Out(m.Bit))
+                  O0=m.Out(m.Bit), O1=m.Out(m.Bit),
+                  O2=m.Out(m.Tuple[m.Bit, m.Bit]),
+                  O3=m.Out(m.Array[2, m.Bit]))
 
         foo = Foo()
         foo.I0 @= io.I0
         io.O0 @= foo.O0
+        # partially undriven
+        io.O2[0] @= 1
+        io.O3[0] @= 1
 
 
     m.compile("build/test_ignore_unused_undriven_hierarchy", Main, inline=True,


### PR DESCRIPTION
Before, if a value was partially driven, `port.value()` would return
None and the pass would mark all the children undriven.  Now, we recurse
over Array/Tuple values to handle the case when parts of the value may
be driven (preventing them from being overriden by an `undriven`
instance).