### PR TITLE
Add `when` parameter to Memory.write method

### DIFF
--- a/magma/primitives/memory.py
+++ b/magma/primitives/memory.py
@@ -192,7 +192,8 @@ class Memory(Generator2):
         self.read = read
 
         if not read_only:
-            def write(self, data, addr):
+            def write(self, data, addr, when):
                 self.WDATA @= data
                 self.WADDR @= addr
+                self.WE @= when
             self.write = write

--- a/tests/test_primitives/test_memory.py
+++ b/tests/test_primitives/test_memory.py
@@ -157,7 +157,7 @@ def test_memory_read_latency(en):
         else:
             rdata = Mem4x5.read(io.raddr)
         io.rdata @= Mem4x5.RDATA
-        Mem4x5.write(io.wdata, io.waddr)
+        Mem4x5.write(io.wdata, io.waddr, io.wen)
 
     m.compile(f"build/test_memory_read_latency_{en}",
               test_memory_read_latency)


### PR DESCRIPTION
Before, the `WE` port was being automatically wired by the clock wiring
logic (since Enable is considered a clock type).  Since the `WE` port is
an explicit part of the memory interface, we should expose the enable
parameter to the `write` method.