### PR TITLE
Return coreir module from coreir compiler

### DIFF
--- a/magma/backend/coreir_compiler.py
+++ b/magma/backend/coreir_compiler.py
@@ -63,6 +63,7 @@ class CoreIRCompiler(Compiler):
         self.backend = coreir_frontend.GetCoreIRBackend()
 
     def compile(self):
+        result = {}
         InsertCoreIRWires(self.main).run()
         InsertWrapCasts(self.main).run()
         backend = self.backend
@@ -91,7 +92,8 @@ class CoreIRCompiler(Compiler):
             _logger.warning("[coreir-compiler] header/footer only supported "
                             "when output_verilog=True, ignoring")
         if isdefinition(self.main):
-            return backend.modules[self.main.coreir_name]
+            result["coreir_module"] = backend.modules[self.main.coreir_name]
+        return result
 
     def _compile_verilog(self):
         cmd = _make_verilog_cmd(self.deps, self.basename, self.opts)

--- a/magma/backend/coreir_compiler.py
+++ b/magma/backend/coreir_compiler.py
@@ -90,6 +90,8 @@ class CoreIRCompiler(Compiler):
         if has_header_or_footer:
             _logger.warning("[coreir-compiler] header/footer only supported "
                             "when output_verilog=True, ignoring")
+        if isdefinition(self.main):
+            return backend.modules[self.main.coreir_name]
 
     def _compile_verilog(self):
         cmd = _make_verilog_cmd(self.deps, self.basename, self.opts)

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -60,6 +60,7 @@ def compile(basename, main, output="coreir-verilog", **kwargs):
         TerminateUnusedPass(main).run()
 
     result = compiler.compile()
+    result = {} if result is None else result
 
     if hasattr(main, "fpga"):
         main.fpga.constraints(basename)

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -59,7 +59,9 @@ def compile(basename, main, output="coreir-verilog", **kwargs):
     if opts.get("terminate_unused", False):
         TerminateUnusedPass(main).run()
 
-    compiler.compile()
+    result = compiler.compile()
 
     if hasattr(main, "fpga"):
         main.fpga.constraints(basename)
+
+    return result


### PR DESCRIPTION
Useful if we want to compile a circuit then interact with it using another library via the coreir API (e.g. Pono), ideally we'd also skip the save to file logic, but this adds the baseline functionality.  For now, other compile options will return None