### PR TITLE
Fix invalid escape sequence \_ warning

### DIFF
--- a/magma/backend/verilog.py
+++ b/magma/backend/verilog.py
@@ -176,7 +176,7 @@ def compiledefinition(cls):
         if cls.verilogLib:
             import re
             for libName in cls.verilogLib:
-                if re.search("\.v$",libName):
+                if re.search("\\.v$",libName):
                     with open(libName,'r') as libFile:
                         s = libFile.read() + s
                 else:

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -49,15 +49,15 @@ circuit_type_method = namedtuple('circuit_type_method', ['name', 'definition'])
 _logger = root_logger()
 
 _VERILOG_FILE_OPEN = """
-integer \_file_{filename} ;
-initial \_file_{filename} = $fopen(\"{filename}\", \"{mode}\");
+integer \\_file_{filename} ;
+initial \\_file_{filename} = $fopen(\"{filename}\", \"{mode}\");
 """  # noqa
 
 _VERILOG_FILE_CLOSE = """
-final $fclose(\_file_{filename} );
+final $fclose(\\_file_{filename} );
 """  # noqa
 
-_DEFAULT_VERILOG_LOG_STR = f"""
+_DEFAULT_VERILOG_LOG_STR = """
 `ifndef MAGMA_LOG_LEVEL
     `define MAGMA_LOG_LEVEL 1
 `endif"""

--- a/magma/display.py
+++ b/magma/display.py
@@ -122,7 +122,7 @@ class Display:
 
         display_str = f"$display("
         if self.file is not None:
-            display_str = f"$fdisplay(\_file_{self.file.filename} , "  # noqa
+            display_str = f"$fdisplay(\\_file_{self.file.filename} , "  # noqa
         format_str = f"""\
 always @({event_str}) begin
     {cond_str}{display_str}\"{self.display_str}\"{display_args_str});


### PR DESCRIPTION
E.g.
```
magma/circuit.py:54: DeprecationWarning: invalid escape sequence \_
    """  # noqa
```