### PR TITLE
Update hwtypes to 1.4.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "numpy",
         "graphviz",
         "coreir>=2.0.125",
-        "hwtypes>=1.0.*",
+        "hwtypes>=1.4.4",
         "ast_tools>=0.0.16",
         "staticfg"
     ],


### PR DESCRIPTION
tests/test_primitives/test_set_index.py fails with hwtypes 1.4.3 or earlier

    __________________________________________ test_set_index __________________________________________

        def test_set_index():
            class test_set_index(m.Circuit):
                io = m.IO(I=m.In(m.Bits[4]),
                          val=m.In(m.Bit),
                          idx=m.In(m.UInt[2]),
                          O=m.Out(m.Bits[4]))
                io.O @= m.set_index(io.I, io.val, io.idx)

            tester = fault.Tester(test_set_index)
            for i in range(5):
                tester.circuit.I = I = BitVector.random(4)
    >           tester.circuit.val = val = Bit.random()
    E           AttributeError: type object 'Bit' has no attribute 'random'

    tests/test_primitives/test_set_index.py:20: AttributeError