### PR TITLE
Add API to reset generator cache

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,3 +9,4 @@ def magma_test():
     magma.config.set_compile_dir('callee_file_dir')
     clear_cachedFunctions()
     magma.frontend.coreir_.ResetCoreIR()
+    magma.generator.reset_generator_cache()

--- a/magma/generator.py
+++ b/magma/generator.py
@@ -110,3 +110,7 @@ class Generator2(metaclass=_Generator2Meta):
 
     def __call__(cls, *args, **kwargs):
         return DefineCircuitKind.__call__(cls, *args, **kwargs)
+
+
+def reset_generator_cache():
+    _Generator2Meta._cache = weakref.WeakValueDictionary()


### PR DESCRIPTION
Needed for testing where coreir context is reset (it seems that
generators are keeping around circuits in the cache that break when
trying to compile, clearing the cache alongside the coreir context fixes
this)