### PR TITLE
Update enable type for PEak compatability

### DIFF
--- a/magma/clock.py
+++ b/magma/clock.py
@@ -81,7 +81,7 @@ AsyncResetNOut = AsyncResetN[Direction.Out]
 
 # Preset
 # Clear
-class Enable(_ClockType, metaclass=DigitalMeta):
+class Enable(Bit):
     pass
 
 

--- a/tests/test_circuit/test_reg_enable_call.py
+++ b/tests/test_circuit/test_reg_enable_call.py
@@ -1,0 +1,22 @@
+import magma as m
+
+
+def test_reg_enable_call():
+    class test_reg_enable_call(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[5]), O=m.Out(m.Bits[5]), nen=m.In(m.Bit))
+        io += m.ClockIO()
+        reg = m.Register(m.Bits[5], has_enable=True, enable_name="en")()
+        io.O @= reg(io.I, ~io.nen)
+
+    assert repr(test_reg_enable_call) == """\
+test_reg_enable_call = DefineCircuit("test_reg_enable_call", "I", In(Bits[5]), \
+"O", Out(Bits[5]), "nen", In(Bit), "CLK", In(Clock))
+Register_inst0 = Register()
+magma_Bit_not_inst0 = magma_Bit_not()
+wire(test_reg_enable_call.I, Register_inst0.I)
+wire(magma_Bit_not_inst0.out, Register_inst0.en)
+wire(test_reg_enable_call.nen, magma_Bit_not_inst0.in)
+wire(Register_inst0.O, test_reg_enable_call.O)
+EndCircuit()\
+"""
+    m.compile("build/test_reg_enable_call", test_reg_enable_call)

--- a/tests/test_primitives/gold/test_enable_reg.v
+++ b/tests/test_primitives/gold/test_enable_reg.v
@@ -74,8 +74,8 @@ endmodule
 module Register (
     input [7:0] I,
     output [7:0] O,
-    input CLK,
     input CE,
+    input CLK,
     input RESET
 );
 wire [7:0] Mux2xBits8_inst0_O;
@@ -123,8 +123,8 @@ wire [7:0] Register_inst0_O;
 Register Register_inst0 (
     .I(I),
     .O(Register_inst0_O),
-    .CLK(CLK),
     .CE(CE),
+    .CLK(CLK),
     .RESET(RESET)
 );
 assign O = Register_inst0_O;

--- a/tests/test_primitives/gold/test_memory_read_latency_False.v
+++ b/tests/test_primitives/gold/test_memory_read_latency_False.v
@@ -110,8 +110,8 @@ endmodule
 module Register (
     input [4:0] I,
     output [4:0] O,
-    input CLK,
-    input CE
+    input CE,
+    input CLK
 );
 wire [4:0] enable_mux_O;
 wire [4:0] reg_P_inst0_out;
@@ -147,8 +147,8 @@ wire [4:0] coreir_mem4x5_inst0_rdata;
 Register Register_inst0 (
     .I(coreir_mem4x5_inst0_rdata),
     .O(Register_inst0_O),
-    .CLK(CLK),
-    .CE(bit_const_1_None_out)
+    .CE(bit_const_1_None_out),
+    .CLK(CLK)
 );
 corebit_const #(
     .value(1'b1)

--- a/tests/test_primitives/gold/test_memory_read_latency_True.v
+++ b/tests/test_primitives/gold/test_memory_read_latency_True.v
@@ -102,8 +102,8 @@ endmodule
 module Register (
     input [4:0] I,
     output [4:0] O,
-    input CLK,
-    input CE
+    input CE,
+    input CLK
 );
 wire [4:0] enable_mux_O;
 wire [4:0] reg_P_inst0_out;
@@ -139,8 +139,8 @@ wire [4:0] coreir_mem4x5_inst0_rdata;
 Register Register_inst0 (
     .I(coreir_mem4x5_inst0_rdata),
     .O(Register_inst0_O),
-    .CLK(CLK),
-    .CE(RE)
+    .CE(RE),
+    .CLK(CLK)
 );
 coreir_sync_read_mem #(
     .depth(4),

--- a/tests/test_syntax/gold/TestSequential2Reset.v
+++ b/tests/test_syntax/gold/TestSequential2Reset.v
@@ -42,8 +42,8 @@ endmodule
 module Register (
     input [2:0] I,
     output [2:0] O,
-    input CLK,
     input CE,
+    input CLK,
     input ASYNCRESET
 );
 wire [2:0] enable_mux_O;
@@ -77,8 +77,8 @@ wire [2:0] magma_Bits_3_add_inst0_out;
 Register Register_inst0 (
     .I(magma_Bits_3_add_inst0_out),
     .O(Register_inst0_O),
-    .CLK(CLK),
     .CE(CE),
+    .CLK(CLK),
     .ASYNCRESET(ASYNCRESET)
 );
 assign magma_Bits_3_add_inst0_out = 3'(Register_inst0_O + 3'h1);


### PR DESCRIPTION
* Enable subclasses Bit to make logic on the enable signal easier (see
  https://github.com/phanrahan/magma/issues/870 for some discussion)
* Add a parameter to the register generator for the name of the enable
  signal (PEak uses `en` instead of the default magma `CE`).  A more
  general solution to this problem might be to add the ability to alias
  port names (rather than having to parametrize generators with the port
  names).  Another option is to provide some library routine that takes
  as circuit and mapping from old to new port names and generates a
  wrapper.  However since PEak just needs this for the register, this is
  a simple stopgap solution.
* A side effect of making Enable a Bit instead of a Clock is now it is
  explicitly required when using the `__call__` syntax.  We think this
  is good because in the common case you'll want to provide an enable
  signal when calling a register to update it.  The only time that you
  wouldn't want to do this is when you want the enable to be implicitly
  wired by the automatic clock wiring logic, which I would say is the
  uncommon case.  Similar to the motivation described in
  https://github.com/phanrahan/magma/issues/870, I think we should just
  requires the user explicitly pass through the enable for the uncommon
  case rather than rely on the automatic wiring.  This has the benefit
  of catching bugs where the user forgets to pass an enable signal when
  calling a register to update it.

For now, we leave some of the clock type related logic for Enables
around for backwards compatability, but we should plan to deprecate it
moving forward (e.g. automatic Enable wiring logic).