### PR TITLE
Support renaming register input/output ports

### DIFF
--- a/magma/common.py
+++ b/magma/common.py
@@ -113,3 +113,11 @@ def setattrs(obj, dct, pred=None):
     for k, v in dct.items():
         if pred is None or pred(k, v):
             setattr(obj, k, v)
+
+
+class ParamDict(dict):
+    """
+    Hashable dictionary for simple key: value parameters
+    """
+    def __hash__(self):
+        return hash(tuple(sorted(self.items())))

--- a/magma/generator.py
+++ b/magma/generator.py
@@ -4,14 +4,7 @@ import functools
 import weakref
 from .circuit import DefineCircuitKind, Circuit
 from . import cache_definition
-
-
-class ParamDict(dict):
-    """
-    Hashable dictionary for simple key: value parameters
-    """
-    def __hash__(self):
-        return hash(tuple(sorted(self.items())))
+from magma.common import ParamDict
 
 
 class GeneratorMeta(type):

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -6,11 +6,12 @@ import hwtypes as ht
 from magma.array import Array
 from magma.bit import Bit
 from magma.clock import Enable
+from magma.common import ParamDict
 from magma.bits import Bits, UInt, SInt
 from magma.circuit import coreir_port_mapping
 from magma.conversions import as_bits, from_bits, bit
 from magma.interface import IO
-from magma.generator import Generator2, ParamDict
+from magma.generator import Generator2
 from magma.t import Type, Kind, In, Out, Direction
 from magma.tuple import Tuple
 from magma.clock import (AbstractReset,

--- a/tests/test_circuit/test_reg_enable_call.py
+++ b/tests/test_circuit/test_reg_enable_call.py
@@ -1,11 +1,13 @@
 import magma as m
+from magma.generator import ParamDict
 
 
 def test_reg_enable_call():
     class test_reg_enable_call(m.Circuit):
         io = m.IO(I=m.In(m.Bits[5]), O=m.Out(m.Bits[5]), nen=m.In(m.Bit))
         io += m.ClockIO()
-        reg = m.Register(m.Bits[5], has_enable=True, enable_name="en")()
+        reg = m.Register(m.Bits[5], has_enable=True,
+                         name_map=ParamDict(CE="en"))()
         io.O @= reg(io.I, ~io.nen)
 
     assert repr(test_reg_enable_call) == """\


### PR DESCRIPTION
Needed for PEak since they use an alternative naming convention

Note we need to use ParamDict (rather than a standard dict) so the generator arguments are hashable