### PR TITLE
Fix CoreIR name error for inline verilog temporary

### DIFF
--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -44,7 +44,7 @@ def _make_temporary(defn, value, num, inline_wire_prefix, parent=None):
     with defn.open():
         # Insert a wire so it can't be inlined out
         temp_name = f"{inline_wire_prefix}{num}"
-        temp = Wire(type(value))(name=temp_name)
+        temp = Wire(type(value).undirected_t)(name=temp_name)
         temp.I @= value
     if parent is not None:
         return PortView(temp.O, parent)

--- a/magma/passes/insert_coreir_wires.py
+++ b/magma/passes/insert_coreir_wires.py
@@ -23,6 +23,8 @@ def _simulate_wire(self, value_store, state_store):
 
 class Wire(Generator2):
     def __init__(self, T):
+        if T.is_directed:
+            raise TypeError("Wire can only be generated with undirected type")
         if issubclass(T, (AsyncReset, AsyncResetN, Clock)):
             self._gen_named_type_wrapper(T)
             # Standalone return to avoid return-in-init lint warning

--- a/magma/t.py
+++ b/magma/t.py
@@ -164,6 +164,10 @@ class Kind(type):
     def undirected_t(cls):
         return cls.qualify(Direction.Undirected)
 
+    @property
+    def is_directed(cls):
+        return cls is not cls.qualify(Direction.Undirected)
+
 
 def In(T):
     return T.qualify(Direction.In)

--- a/tests/test_verilog/test_inline.py
+++ b/tests/test_verilog/test_inline.py
@@ -1,7 +1,6 @@
 import magma as m
 import magma.testing
 import pytest
-import os
 
 
 def test_inline_verilog():


### PR DESCRIPTION
Before, inserting a temporary wire for the inline verilog logic could
trigger a CoreIR name error by using a directed type for the wire name
(e.g. `Out(Clock)`) since the Wire genertor logic generates a name
`"Wire{T}"`.  It doesn't really make sense to generate a Wire of type
`Out(T)`, rather it should be some undirected type `T`.  This updates
the Wire generator raise an error if you try to construct it with a
directed type, and updates the inline verilog code to use the undirected
type for the intermediate wire.