### PR TITLE
Guard update_register pass for user defined init

### DIFF
--- a/magma/syntax/sequential2.py
+++ b/magma/syntax/sequential2.py
@@ -409,9 +409,11 @@ def sequential2(pre_passes=[], post_passes=[],
         if reset_type:
             update_register = _UpdateRegister(reset_type,
                                               has_enable, reset_priority)
-            cls.__init__ = apply_ast_passes(passes=[update_register],
-                                            debug=debug, env=env, path=path,
-                                            file_name=file_name)(cls.__init__)
+            if cls.__init__ is not object.__init__:
+                cls.__init__ = apply_ast_passes(
+                    passes=[update_register], debug=debug, env=env, path=path,
+                    file_name=file_name
+                )(cls.__init__)
 
         cls.__call__ = apply_ast_passes(passes, debug=debug, env=env,
                                         path=path,

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -831,3 +831,12 @@ def test_u_ops(op):
     dir_ = os.path.join(os.path.dirname(__file__), "build")
     tester.compile_and_run("verilator", flags=['-Wno-unused'],
                            skip_compile=True, directory=dir_)
+
+
+def test_reset_no_init():
+    Data = m.UInt[8]
+
+    @m.sequential2(reset_type=m.AsyncReset)
+    class Inc:
+        def __call__(self, i: Data) -> Data:
+            return i + 1


### PR DESCRIPTION
Fixes #894

Only run the update_register pass (for the automatic reset logic) when
the user defines an __init__ method.

Note: all objects will inherit the default object.__init__, so we check
whether the __init__ defined is different.  This hasn't been tested with
inherited __init__ methods from user defined classes.