### PR TITLE
[seq2] add magma reference if not available in env

### DIFF
--- a/magma/syntax/sequential2.py
+++ b/magma/syntax/sequential2.py
@@ -335,7 +335,7 @@ class _UpdateRegister(Pass):
                 break
         if magma_id is None:
             magma_id = gen_free_name(tree, env)
-            env[magma_id] = magma_module
+            env.locals[magma_id] = magma_module
         return env, magma_id
 
     def rewrite(

--- a/magma/syntax/sequential2.py
+++ b/magma/syntax/sequential2.py
@@ -327,14 +327,14 @@ class _UpdateRegister(Pass):
         self.has_enable = has_enable
         self.reset_priority = reset_priority
 
-    def _get_or_add_magma_module(self, env: SymbolTable):
+    def _get_or_add_magma_module(self, tree: ast.AST, env: SymbolTable):
         magma_id = None
         for k, v in env.items():
             if v is magma_module:
                 magma_id = k
                 break
         if magma_id is None:
-            magma_id = gen_free_name(env)
+            magma_id = gen_free_name(tree, env)
             env[magma_id] = magma_module
         return env, magma_id
 
@@ -342,7 +342,7 @@ class _UpdateRegister(Pass):
         self, tree: ast.AST, env: SymbolTable, metadata: MutableMapping
     ) -> PASS_ARGS_T:
 
-        env, magma_id = self._get_or_add_magma_module(env)
+        env, magma_id = self._get_or_add_magma_module(tree, env)
         updater = _RegisterUpdater(env, self.reset_type,
                                    self.has_enable, self.reset_priority,
                                    magma_id)

--- a/magma/syntax/sequential2.py
+++ b/magma/syntax/sequential2.py
@@ -333,7 +333,7 @@ class _UpdateRegister(Pass):
             if v is magma_module:
                 magma_id = k
                 break
-        if not magma_id is None:
+        if magma_id is None:
             magma_id = gen_free_name(env)
             env[magma_id] = magma_module
         return env, magma_id

--- a/tests/test_syntax/test_sequential2.py
+++ b/tests/test_syntax/test_sequential2.py
@@ -13,6 +13,8 @@ import magma as m
 from test_sequential import Register, DualClockRAM
 from magma.testing import check_files_equal
 
+from ast_tools import SymbolTable
+
 
 def test_sequential2_basic():
     @m.sequential2()
@@ -838,5 +840,19 @@ def test_reset_no_init():
 
     @m.sequential2(reset_type=m.AsyncReset)
     class Inc:
+        def __call__(self, i: Data) -> Data:
+            return i + 1
+
+
+def test_magma_not_in_env():
+
+    Data = m.UInt[8]
+    env = SymbolTable({}, {'Data': Data})
+
+    @m.sequential2(env=env, reset_type=m.AsyncReset)
+    class Inc:
+        def __init__(self):
+            pass
+
         def __call__(self, i: Data) -> Data:
             return i + 1


### PR DESCRIPTION
Before, we searched for a reference to magma in the sequential2
environment (we need this to add references to types when generating the
reset code).  If we didn't find one, we raised an error.  This changes
the logic to insert a reference to magma with a free name when we can't
find an existing one.

Fixes #896 