### PR TITLE
Fix bind bug with ndarrays on nested instances

### DIFF
--- a/magma/verilog_utils.py
+++ b/magma/verilog_utils.py
@@ -16,9 +16,15 @@ def is_nd_array(T, skip=True):
     return False
 
 
+def _should_recurse(value, disable_ndarray):
+    if isinstance(value, PortView):
+        value = value.port
+    return (isinstance(value, Array) and not issubclass(value.T, Digital) and
+            is_nd_array(type(value)) and disable_ndarray)
+
+
 def value_to_verilog_name(value, disable_ndarray=False):
-    if (isinstance(value, Array) and not issubclass(value.T, Digital) and
-            is_nd_array(type(value)) and disable_ndarray):
+    if _should_recurse(value, disable_ndarray):
         elems = ", ".join(value_to_verilog_name(t, disable_ndarray)
                           for t in reversed(value))
         return f"'{{{elems}}}"

--- a/magma/view.py
+++ b/magma/view.py
@@ -59,6 +59,9 @@ class PortView(MagmaProtocol, metaclass=PortViewMeta):
         self.__iter = iter(self.port)
         return self
 
+    def __len__(self):
+        return len(self.port)
+
     def __next__(self):
         n = next(self.__iter)
         return PortView[type(n)](n, self.parent)

--- a/tests/test_verilog/gold/RTLMonitor.sv
+++ b/tests/test_verilog/gold/RTLMonitor.sv
@@ -39,7 +39,8 @@ module foo_RTLMonitor (
     input mon_temp2,
     input mon_temp3,
     input [1:0] ndarr [2:0],
-    input out
+    input out,
+    input [19:0] tuple_arr [0:0]
 );
 wire _magma_inline_wire0;
 wire [3:0] _magma_inline_wire1;
@@ -87,5 +88,6 @@ bind foo_RTL foo_RTLMonitor foo_RTLMonitor_inst (
     .intermediate_tuple__1(_magma_bind_wire_2_1),
     .inst_input(_magma_bind_wire_3),
     .mon_temp3(_magma_bind_wire_4),
-    .intermediate_ndarr('{_magma_bind_wire_5_1, _magma_bind_wire_5_0})
+    .intermediate_ndarr('{_magma_bind_wire_5_1, _magma_bind_wire_5_0}),
+    .tuple_arr('{nested_other_circ._magma_bind_wire_0_0})
 );

--- a/tests/test_verilog/gold/RTLMonitor_unq1.sv
+++ b/tests/test_verilog/gold/RTLMonitor_unq1.sv
@@ -39,7 +39,8 @@ module foo_RTLMonitor_unq1 (
     input mon_temp2,
     input mon_temp3,
     input [1:0] ndarr [2:0],
-    input out
+    input out,
+    input [19:0] tuple_arr [0:0]
 );
 wire _magma_inline_wire0;
 wire [4:0] _magma_inline_wire1;
@@ -87,5 +88,6 @@ bind foo_RTL_unq1 foo_RTLMonitor_unq1 foo_RTLMonitor_unq1_inst (
     .intermediate_tuple__1(_magma_bind_wire_2_1),
     .inst_input(_magma_bind_wire_3),
     .mon_temp3(_magma_bind_wire_4),
-    .intermediate_ndarr('{_magma_bind_wire_5_1, _magma_bind_wire_5_0})
+    .intermediate_ndarr('{_magma_bind_wire_5_1, _magma_bind_wire_5_0}),
+    .tuple_arr('{nested_other_circ._magma_bind_wire_0_0})
 );

--- a/tests/test_verilog/gold/bind_test.v
+++ b/tests/test_verilog/gold/bind_test.v
@@ -7,6 +7,26 @@ endmodule
 module andr_4 (input [3:0] I, output O);
 assign O = &(I);
 endmodule
+module coreir_undriven #(
+    parameter width = 1
+) (
+    output [width-1:0] out
+);
+
+endmodule
+
+module foo_OtherCircuit (
+    output [19:0] x_y [0:0]
+);
+wire [19:0] undriven_inst0_out;
+coreir_undriven #(
+    .width(20)
+) undriven_inst0 (
+    .out(undriven_inst0_out)
+);
+assign x_y[0] = undriven_inst0_out;
+endmodule
+
 module coreir_term #(
     parameter width = 1
 ) (
@@ -22,6 +42,21 @@ coreir_term #(
     .width(4)
 ) term_inst0 (
     .in(I)
+);
+endmodule
+
+module foo_NestedOtherCircuit (
+    output [19:0] x_y [0:0]
+);
+wire [19:0] _magma_bind_wire_0_0;
+assign _magma_bind_wire_0_0 = x_y[0];
+foo_OtherCircuit other_circ (
+    .x_y(x_y)
+);
+coreir_term #(
+    .width(20)
+) term_inst0 (
+    .in(_magma_bind_wire_0_0)
 );
 endmodule
 
@@ -58,6 +93,7 @@ wire andr_4_inst0_O;
 wire [2:0] intermediate_ndarr_0;
 wire [2:0] intermediate_ndarr_1;
 wire [3:0] magma_Bits_4_xor_inst0_out;
+wire [19:0] nested_other_circ_x_y [0:0];
 wire orr_4_inst0_O;
 wire [1:0] self_ndarr_0;
 wire [1:0] self_ndarr_1;
@@ -122,6 +158,9 @@ logical_and logical_and_inst0 (
     .O(out)
 );
 assign magma_Bits_4_xor_inst0_out = in1 ^ in2;
+foo_NestedOtherCircuit nested_other_circ (
+    .x_y(nested_other_circ_x_y)
+);
 orr_4 orr_4_inst0 (
     .I(in1),
     .O(orr_4_inst0_O)

--- a/tests/test_verilog/gold/bind_uniq_test.v
+++ b/tests/test_verilog/gold/bind_uniq_test.v
@@ -13,6 +13,18 @@ module coreir_undriven #(
 
 endmodule
 
+module foo_OtherCircuit (
+    output [19:0] x_y [0:0]
+);
+wire [19:0] undriven_inst0_out;
+coreir_undriven #(
+    .width(20)
+) undriven_inst0 (
+    .out(undriven_inst0_out)
+);
+assign x_y[0] = undriven_inst0_out;
+endmodule
+
 module coreir_term #(
     parameter width = 1
 ) (
@@ -38,6 +50,21 @@ coreir_term #(
     .width(4)
 ) term_inst0 (
     .in(I)
+);
+endmodule
+
+module foo_NestedOtherCircuit (
+    output [19:0] x_y [0:0]
+);
+wire [19:0] _magma_bind_wire_0_0;
+assign _magma_bind_wire_0_0 = x_y[0];
+foo_OtherCircuit other_circ (
+    .x_y(x_y)
+);
+coreir_term #(
+    .width(20)
+) term_inst0 (
+    .in(_magma_bind_wire_0_0)
 );
 endmodule
 
@@ -96,6 +123,7 @@ wire coreir_wrapInClock_inst0_out;
 wire [2:0] intermediate_ndarr_0;
 wire [2:0] intermediate_ndarr_1;
 wire [4:0] magma_Bits_5_xor_inst0_out;
+wire [19:0] nested_other_circ_x_y [0:0];
 wire orr_5_inst0_O;
 wire [1:0] self_ndarr_0;
 wire [1:0] self_ndarr_1;
@@ -167,6 +195,9 @@ logical_and logical_and_inst0 (
     .O(out)
 );
 assign magma_Bits_5_xor_inst0_out = in1 ^ in2;
+foo_NestedOtherCircuit nested_other_circ (
+    .x_y(nested_other_circ_x_y)
+);
 orr_5 orr_5_inst0 (
     .I(in1),
     .O(orr_5_inst0_O)
@@ -186,6 +217,11 @@ coreir_term #(
     .width(5)
 ) term_inst1 (
     .in(_magma_bind_wire_3)
+);
+coreir_term #(
+    .width(20)
+) term_inst2 (
+    .in(nested_other_circ_x_y[0])
 );
 assign handshake_arr_0_valid = handshake_arr_2_ready;
 assign handshake_arr_1_valid = handshake_arr_1_ready;
@@ -221,6 +257,7 @@ wire coreir_wrapInClock_inst0_out;
 wire [2:0] intermediate_ndarr_0;
 wire [2:0] intermediate_ndarr_1;
 wire [3:0] magma_Bits_4_xor_inst0_out;
+wire [19:0] nested_other_circ_x_y [0:0];
 wire orr_4_inst0_O;
 wire [1:0] self_ndarr_0;
 wire [1:0] self_ndarr_1;
@@ -292,6 +329,9 @@ logical_and logical_and_inst0 (
     .O(out)
 );
 assign magma_Bits_4_xor_inst0_out = in1 ^ in2;
+foo_NestedOtherCircuit nested_other_circ (
+    .x_y(nested_other_circ_x_y)
+);
 orr_4 orr_4_inst0 (
     .I(in1),
     .O(orr_4_inst0_O)
@@ -311,6 +351,11 @@ coreir_term #(
     .width(4)
 ) term_inst1 (
     .in(_magma_bind_wire_3)
+);
+coreir_term #(
+    .width(20)
+) term_inst2 (
+    .in(nested_other_circ_x_y[0])
 );
 assign handshake_arr_0_valid = handshake_arr_2_ready;
 assign handshake_arr_1_valid = handshake_arr_1_ready;

--- a/tests/test_verilog/rtl.py
+++ b/tests/test_verilog/rtl.py
@@ -26,6 +26,18 @@ endmodule
             io = m.IO(I=m.In(m.Bits[width]))
             io.I.unused()
 
+        class T(m.Product):
+            y = m.Array[1, m.UInt[20]]
+
+        class OtherCircuit(m.Circuit):
+            io = m.IO(x=m.Out(T))
+            io.x.undriven()
+
+        class NestedOtherCircuit(m.Circuit):
+            io = m.IO(x=m.Out(T))
+            other_circ = OtherCircuit(name="other_circ")
+            io.x @= other_circ.x
+
         class RTL(m.Circuit):
             io = m.IO(CLK=m.In(m.Clock),
                       in1=m.In(m.Bits[width]),
@@ -41,6 +53,7 @@ endmodule
             intermediate_ndarr = m.Array[(3, 2), m.Bit](
                 name="intermediate_ndarr"
             )
+            nested_other_circ = NestedOtherCircuit(name="nested_other_circ")
             for i in range(3):
                 for j in range(2):
                     intermediate_ndarr[i, j] @= io.ndarr[j, i]

--- a/tests/test_verilog/rtl_monitor.py
+++ b/tests/test_verilog/rtl_monitor.py
@@ -14,8 +14,8 @@ class RTLMonitor(m.MonitorGenerator):
                       intermediate_tuple=m.In(m.Tuple[m.Bit, m.Bit]),
                       inst_input=m.In(m.Bits[width]),
                       mon_temp3=m.In(m.Bit),
-                      intermediate_ndarr=m.In(m.Array[(3, 2), m.Bit])
-                      )
+                      intermediate_ndarr=m.In(m.Array[(3, 2), m.Bit]),
+                      tuple_arr=m.In(m.Array[1, m.UInt[20]]))
 
             # NOTE: Needs to have a name
             arr_2d = m.Array[2, m.Bits[width]](name="arr_2d")
@@ -38,7 +38,8 @@ assign temp5 = {io.intermediate_ndarr[1, 1]};
 
         circuit.bind(RTLMonitor, circuit.temp1, circuit.temp2,
                      circuit.intermediate_tuple, circuit.some_circ.I,
-                     circuit.temp3, circuit.intermediate_ndarr)
+                     circuit.temp3, circuit.intermediate_ndarr,
+                     circuit.nested_other_circ.other_circ.x.y)
 
 
 RTL.bind(RTLMonitor)


### PR DESCRIPTION
Before, the bind logic was not properly handling ndarrays found in
nested instances.  This because the type of the values was PortView
rather than Array, so the various checks were failing to detect the
underlying type.  This changes the logic to unpack PortView values into
their underlying values for these checks.