### PR TITLE
Add fix for inline veriloq unique

### DIFF
--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -31,10 +31,10 @@ def _make_hash_struct(definition):
     inline_verilog = ((), (), (), ())
     for s, args, st, prefix in definition._context_._inline_verilog:
         inline_verilog += (
-            (s, ),
-            (", ".join(str(arg) for arg in args), ),
-            (str(st), ),
-            (prefix, )
+            (s,),
+            (", ".join(str(arg) for arg in args),),
+            (str(st),),
+            (prefix,)
         )
     if hasattr(definition, "verilogFile") and definition.verilogFile:
         return _HashStruct(repr_, True, definition.verilogFile, inline_verilog)

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -23,15 +23,22 @@ class _HashStruct:
     defn_repr: str
     is_verilog: bool
     verilog_str: bool
+    inline_verilog: tuple
 
 
 def _make_hash_struct(definition):
     repr_ = repr(definition)
+    inline_verilog = ((), (), (), ())
     for s, args, st, prefix in definition._context_._inline_verilog:
-        repr_ += s + ", ".join(str(arg) for arg in args) + str(st) + prefix
+        inline_verilog += (
+            (s, ),
+            (", ".join(str(arg) for arg in args), ),
+            (str(st), ),
+            (prefix, )
+        )
     if hasattr(definition, "verilogFile") and definition.verilogFile:
-        return _HashStruct(repr_, True, definition.verilogFile)
-    return _HashStruct(repr_, False, "")
+        return _HashStruct(repr_, True, definition.verilogFile, inline_verilog)
+    return _HashStruct(repr_, False, "", inline_verilog)
 
 
 def _hash(definition):

--- a/magma/uniquification.py
+++ b/magma/uniquification.py
@@ -27,6 +27,8 @@ class _HashStruct:
 
 def _make_hash_struct(definition):
     repr_ = repr(definition)
+    for s, args, st, prefix in definition._context_._inline_verilog:
+        repr_ += s + ", ".join(str(arg) for arg in args) + str(st) + prefix
     if hasattr(definition, "verilogFile") and definition.verilogFile:
         return _HashStruct(repr_, True, definition.verilogFile)
     return _HashStruct(repr_, False, "")

--- a/tests/test_verilog/gold/test_inline_verilog_unique.v
+++ b/tests/test_verilog/gold/test_inline_verilog_unique.v
@@ -1,0 +1,29 @@
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module Foo_unq1 (
+    input I
+);
+always @(*) $display("%x\n", I);
+endmodule
+
+module Foo (
+    input I
+);
+always @(*) $display("%d\n", I);
+endmodule
+
+module Top (
+    input I
+);
+Foo Foo_inst0 (
+    .I(I)
+);
+Foo_unq1 Foo_inst1 (
+    .I(I)
+);
+endmodule
+

--- a/tests/test_verilog/test_inline.py
+++ b/tests/test_verilog/test_inline.py
@@ -148,3 +148,25 @@ def test_clock_inline_verilog():
 
     # Should not throw a coreir error
     m.compile("build/Foo", Foo, inline=True)
+
+
+def test_inline_verilog_unique():
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bit))
+        m.inline_verilog('always @(*) $display("%d\\n", {io.I});')
+
+    Bar = Foo
+
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bit))
+        m.inline_verilog('always @(*) $display("%x\\n", {io.I});')
+
+    class Top(m.Circuit):
+        io = m.IO(I=m.In(m.Bit))
+        Bar()(io.I)
+        Foo()(io.I)
+
+    m.compile("build/test_inline_verilog_unique", Top)
+    assert m.testing.check_files_equal(__file__,
+                                       f"build/test_inline_verilog_unique.v",
+                                       f"gold/test_inline_verilog_unique.v")


### PR DESCRIPTION
Ensures inline verilog is considered for uniquification by adding the
string to the repr when computing the circuit hash.  Also includes the
str of the kwargs, symbol table, and inline_verilog_string to catch the
(unlikely) case where there's identical inline verilog strings but
different kwargs or prefix.