### PR TITLE
Add namespace logic to coreir backend module dict

### DIFF
--- a/magma/backend/coreir/coreir_backend.py
+++ b/magma/backend/coreir/coreir_backend.py
@@ -25,18 +25,20 @@ class CoreIRBackend:
         if context is not singleton:
             _logger.warning("Creating CoreIRBackend with non-singleton CoreIR "
                             "context.")
-        self._modules = module_map().setdefault(context, {})
+        self._namespaces = module_map().setdefault(context, {})
         self._context = context
         self._lib_cache = {}
         self._included_libs = set()
         self._bound_modules = {}
 
     def add_module(self, magma_module, coreir_module):
-        self._modules[magma_module.coreir_name] = coreir_module
+        modules = self._namespaces.setdefault(magma_module.coreir_lib, {})
+        modules[magma_module.coreir_name] = coreir_module
 
     def get_module(self, magma_module):
         # NOTE(rsetaluri): Throws KeyError if @magma_module has not been added.
-        return self._modules[magma_module.coreir_name]
+        modules = self._namespaces[magma_module.coreir_lib]
+        return modules[magma_module.coreir_name]
 
     def include_lib_or_libs(self, lib_or_libs):
         try:
@@ -72,7 +74,7 @@ class CoreIRBackend:
         opts = opts if opts is not None else {}
         transformer = DefnOrDeclTransformer(self, opts, defn_or_decl)
         transformer.run()
-        return self._modules
+        return self._namespaces
 
 
 def compile(main, file_name=None, context=None):

--- a/magma/backend/coreir/coreir_backend.py
+++ b/magma/backend/coreir/coreir_backend.py
@@ -1,5 +1,5 @@
 from magma.config import config, EnvConfig
-from magma.backend.coreir.coreir_runtime import coreir_context, module_map
+from magma.backend.coreir.coreir_runtime import coreir_context, namespace_module_map
 from magma.backend.coreir.coreir_transformer import DefnOrDeclTransformer
 from magma.backend.coreir.insert_wrap_casts import insert_wrap_casts
 from magma.logging import root_logger
@@ -25,7 +25,7 @@ class CoreIRBackend:
         if context is not singleton:
             _logger.warning("Creating CoreIRBackend with non-singleton CoreIR "
                             "context.")
-        self._namespaces = module_map().setdefault(context, {})
+        self._namespaces = namespace_module_map().setdefault(context, {})
         self._context = context
         self._lib_cache = {}
         self._included_libs = set()

--- a/magma/backend/coreir/coreir_backend.py
+++ b/magma/backend/coreir/coreir_backend.py
@@ -1,5 +1,6 @@
 from magma.config import config, EnvConfig
-from magma.backend.coreir.coreir_runtime import coreir_context, namespace_module_map
+from magma.backend.coreir.coreir_runtime import (coreir_context,
+                                                 namespace_module_map)
 from magma.backend.coreir.coreir_transformer import DefnOrDeclTransformer
 from magma.backend.coreir.insert_wrap_casts import insert_wrap_casts
 from magma.logging import root_logger

--- a/magma/backend/coreir/coreir_backend.py
+++ b/magma/backend/coreir/coreir_backend.py
@@ -36,7 +36,8 @@ class CoreIRBackend:
         modules[magma_module.coreir_name] = coreir_module
 
     def get_module(self, magma_module):
-        # NOTE(rsetaluri): Throws KeyError if @magma_module has not been added.
+        # Throws KeyError if @magma_module or its namespace (coreir_lib) has
+        # not been added.
         modules = self._namespaces[magma_module.coreir_lib]
         return modules[magma_module.coreir_name]
 

--- a/magma/backend/coreir/coreir_backend.py
+++ b/magma/backend/coreir/coreir_backend.py
@@ -1,6 +1,5 @@
 from magma.config import config, EnvConfig
-from magma.backend.coreir.coreir_runtime import (coreir_context,
-                                                 namespace_module_map)
+from magma.backend.coreir.coreir_runtime import coreir_context, namespace_module_map
 from magma.backend.coreir.coreir_transformer import DefnOrDeclTransformer
 from magma.backend.coreir.insert_wrap_casts import insert_wrap_casts
 from magma.logging import root_logger

--- a/magma/backend/coreir/coreir_backend.py
+++ b/magma/backend/coreir/coreir_backend.py
@@ -1,5 +1,5 @@
 from magma.config import config, EnvConfig
-from magma.backend.coreir.coreir_runtime import coreir_context, namespace_module_map
+from magma.backend.coreir.coreir_runtime import coreir_context, module_map
 from magma.backend.coreir.coreir_transformer import DefnOrDeclTransformer
 from magma.backend.coreir.insert_wrap_casts import insert_wrap_casts
 from magma.logging import root_logger
@@ -25,7 +25,7 @@ class CoreIRBackend:
         if context is not singleton:
             _logger.warning("Creating CoreIRBackend with non-singleton CoreIR "
                             "context.")
-        self._namespaces = namespace_module_map().setdefault(context, {})
+        self._namespaces = module_map().setdefault(context, {})
         self._context = context
         self._lib_cache = {}
         self._included_libs = set()

--- a/magma/backend/coreir/coreir_runtime.py
+++ b/magma/backend/coreir/coreir_runtime.py
@@ -2,7 +2,7 @@ from coreir import Context
 
 
 _coreir_context = Context()
-_namespace_module_map = {}  # map from context to namespaces to modules
+_module_map = {}  # map from context to modules
 
 
 def coreir_context():
@@ -12,15 +12,15 @@ def coreir_context():
 
 def reset_coreir_context():
     global _coreir_context
-    global _namespace_module_map
+    global _module_map
     try:
-        del _namespace_module_map[_coreir_context]
+        del _module_map[_coreir_context]
     except KeyError:  # _coreir_context (singleton) not mapped
         pass
     _coreir_context.delete()
     _coreir_context = Context()
 
 
-def namespace_module_map():
-    global _namespace_module_map
-    return _namespace_module_map
+def module_map():
+    global _module_map
+    return _module_map

--- a/magma/backend/coreir/coreir_runtime.py
+++ b/magma/backend/coreir/coreir_runtime.py
@@ -2,7 +2,7 @@ from coreir import Context
 
 
 _coreir_context = Context()
-_module_map = {}  # map from context to modules
+_namespace_module_map = {}  # map from context to namespaces to modules
 
 
 def coreir_context():
@@ -12,15 +12,15 @@ def coreir_context():
 
 def reset_coreir_context():
     global _coreir_context
-    global _module_map
+    global _namespace_module_map
     try:
-        del _module_map[_coreir_context]
+        del _namespace_module_map[_coreir_context]
     except KeyError:  # _coreir_context (singleton) not mapped
         pass
     _coreir_context.delete()
     _coreir_context = Context()
 
 
-def module_map():
-    global _module_map
-    return _module_map
+def namespace_module_map():
+    global _namespace_module_map
+    return _namespace_module_map

--- a/magma/frontend/coreir_.py
+++ b/magma/frontend/coreir_.py
@@ -110,7 +110,8 @@ def GetCoreIRModule(cirb: CoreIRBackend, circuit: DefineCircuitKind):
             circuitNotInstance = circuit.__class__
         else:
             circuitNotInstance = circuit
-        moduleOrGenerator = cirb.compile(circuitNotInstance)[circuitNotInstance.name]
+        namespaces = cirb.compile(circuitNotInstance)
+        moduleOrGenerator = namespaces[circuitNotInstance.coreir_lib][circuitNotInstance.name]
         # compile can giv eme back the coreIR module or the coreIR generator. if this is
         # the CoreIR generator, call it with the Magma arguments converted to CoreIR ones.
         if isinstance(moduleOrGenerator, Generator):

--- a/tests/test_compile/test_coreir_backend.py
+++ b/tests/test_compile/test_coreir_backend.py
@@ -1,0 +1,10 @@
+import magma as m
+
+
+def test_namespace_collision():
+    # global namespace add shouldn't collide with coreir lib add
+    @m.combinational2()
+    def add(x: m.UInt[16], y: m.UInt[16]) -> m.UInt[16]:
+        return x + y
+
+    m.compile("build/add", add.circuit_definition)


### PR DESCRIPTION
Fixes an error such as:
```
../magma/magma/compile.py:64: in compile
    result = compiler.compile()
../magma/magma/backend/coreir/coreir_compiler.py:71: in compile
    backend.compile(self.main, opts)
../magma/magma/backend/coreir/coreir_backend.py:75: in compile
    transformer.run()
../magma/magma/backend/coreir/coreir_transformer.py:97: in run
    child.run()
../magma/magma/backend/coreir/coreir_transformer.py:98: in run
    self.run_self()
../magma/magma/backend/coreir/coreir_transformer.py:240: in run_self
    self.coreir_module.definition = self.get_coreir_defn()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <magma.backend.coreir.coreir_transformer.DefinitionTransformer object at 0x7f727dba8880>

    def get_coreir_defn(self):
>       coreir_defn = self.coreir_module.new_definition()
E       AttributeError: 'Generator' object has no attribute 'new_definition'

../magma/magma/backend/coreir/coreir_transformer.py:243: AttributeError
```

that is encountered when using a circuit named `add` since it is
clobbered by a module of the same name (the coreir.add primitive).  Does
this by storing module references separated by namespaces (using
separate dictionaries).  Updates the compile API to return the namespace
-> module map dictionary rather than just a single module map.