### PR TITLE
Fix always True assertion

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -246,7 +246,7 @@ def _make_array_from_bv(N, T, arg):
 def _check_arg(N, T, arg):
     assert (type(arg) == T or type(arg) == T.flip() or
             issubclass(type(type(arg)), type(T)) or
-            issubclass(type(T), type(type(arg))), (type(arg), T))
+            issubclass(type(T), type(type(arg)))), (type(arg), T)
 
 
 def _make_array_length_one(T, arg):


### PR DESCRIPTION
In a refactor, this assertion got changed into a multiline using
parentheses, but the parens wrap both the condition and error message.
This fixes the assertion to only wrap the condition in the multiline
parentheses to avoid an always True assertion