### PR TITLE
Add bind compile_guard

### DIFF
--- a/docs/inline_verilog.md
+++ b/docs/inline_verilog.md
@@ -380,3 +380,16 @@ m.compile("build/bind_test", RTL4, inline=True)
 ```
 
 If you don't want to enable the bind, simply do not import `rtl_monitor`
+
+The `bind` statement also supports an optional `compile_guard=` keyword
+argument that allows the user to wrap the generated bind statement inside a
+verilog `ifdef`.  Here's an example:
+
+```python
+circuit.bind(RTLMonitor, circuit.temp1, circuit.temp2,
+             circuit.intermediate_tuple, compile_guard="BIND_ON")
+# generates
+# `ifdef BIND_ON
+# bind ...
+# endif
+```

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -688,8 +688,8 @@ class DefineCircuitKind(CircuitKind):
         """Place a circuit instance in this definition"""
         cls._context_.placer.place(inst)
 
-    def bind(cls, monitor, *args):
-        cls.bind_modules[monitor] = args
+    def bind(cls, monitor, *args, compile_guard=None):
+        cls.bind_modules[monitor] = (args, compile_guard)
 
 
 @six.add_metaclass(DefineCircuitKind)

--- a/tests/test_verilog/gold/RTLMonitor.sv
+++ b/tests/test_verilog/gold/RTLMonitor.sv
@@ -68,6 +68,8 @@ assign temp5 = intermediate_ndarr[1][1];
 endmodule
 
 
+
+`ifdef BIND_ON
 bind foo_RTL foo_RTLMonitor foo_RTLMonitor_inst (
     .CLK(CLK),
     .in1(in1),
@@ -91,3 +93,4 @@ bind foo_RTL foo_RTLMonitor foo_RTLMonitor_inst (
     .intermediate_ndarr('{_magma_bind_wire_5_1, _magma_bind_wire_5_0}),
     .tuple_arr('{nested_other_circ._magma_bind_wire_0_0})
 );
+`endif

--- a/tests/test_verilog/gold/RTLMonitor_unq1.sv
+++ b/tests/test_verilog/gold/RTLMonitor_unq1.sv
@@ -68,6 +68,8 @@ assign temp5 = intermediate_ndarr[1][1];
 endmodule
 
 
+
+`ifdef BIND_ON
 bind foo_RTL_unq1 foo_RTLMonitor_unq1 foo_RTLMonitor_unq1_inst (
     .CLK(CLK),
     .in1(in1),
@@ -91,3 +93,4 @@ bind foo_RTL_unq1 foo_RTLMonitor_unq1 foo_RTLMonitor_unq1_inst (
     .intermediate_ndarr('{_magma_bind_wire_5_1, _magma_bind_wire_5_0}),
     .tuple_arr('{nested_other_circ._magma_bind_wire_0_0})
 );
+`endif

--- a/tests/test_verilog/rtl_monitor.py
+++ b/tests/test_verilog/rtl_monitor.py
@@ -39,7 +39,8 @@ assign temp5 = {io.intermediate_ndarr[1, 1]};
         circuit.bind(RTLMonitor, circuit.temp1, circuit.temp2,
                      circuit.intermediate_tuple, circuit.some_circ.I,
                      circuit.temp3, circuit.intermediate_ndarr,
-                     circuit.nested_other_circ.other_circ.x.y)
+                     circuit.nested_other_circ.other_circ.x.y,
+                     compile_guard="BIND_ON")
 
 
 RTL.bind(RTLMonitor)

--- a/tests/test_verilog/test_bind.py
+++ b/tests/test_verilog/test_bind.py
@@ -63,7 +63,8 @@ RTLMonitor_unq1.sv\
     if version >= 4.016:
         assert not os.system('cd tests/test_verilog/build && '
                              'verilator --lint-only bind_uniq_test.v '
-                             'RTLMonitor.sv RTLMonitor_unq1.sv -Wno-MODDUP')
+                             'RTLMonitor.sv RTLMonitor_unq1.sv -Wno-MODDUP'
+                             ' --top-module foo_Main')
         # TODO: For now, we ignore duplicate modules since each monitor will
         # regenerate coreir primitives.  # since these have the same definition
         # it's okay, but in general this is a bad flag to have on because if


### PR DESCRIPTION
Eventually we should unify the generic `compile_guard` logic to work with this, but for now we can add an explicit argument to unblock the DV flow. (the compile_guard logic could just inject this argument for the bind flow, or the logic could look it up in the context)