### PR TITLE
Add support for verilog field in coreir backend

### DIFF
--- a/magma/backend/coreir/coreir_transformer.py
+++ b/magma/backend/coreir/coreir_transformer.py
@@ -249,6 +249,10 @@ class DefinitionTransformer(TransformerBase):
             metadata = json.dumps({"verilog_string": self.defn.verilogFile})
             self.coreir_module.add_metadata("verilog", metadata)
             return coreir_defn
+        if hasattr(self.defn, "verilog") and self.defn.verilog:
+            metadata = json.dumps({"verilog_body": self.defn.verilog})
+            self.coreir_module.add_metadata("verilog", metadata)
+            return coreir_defn
         if self.defn.coreir_lib is not None:
             self.backend.include_lib_or_libs(self.defn.coreir_lib)
         for name, port in self.defn.interface.ports.items():

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -629,7 +629,7 @@ class DefineCircuitKind(CircuitKind):
 
         self = CircuitKind.__new__(metacls, name, bases, dct)
 
-        self.verilog = None
+        self.verilog = dct.get("verilog", None)
         self.verilogFile = None
         self.verilogLib = None
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "pyverilog",
         "numpy",
         "graphviz",
-        "coreir>=2.0.125",
+        "coreir>=2.0.131",
         "hwtypes>=1.4.4",
         "ast_tools>=0.0.16",
         "staticfg"

--- a/tests/test_compile/gold/test_verilog_body.v
+++ b/tests/test_compile/gold/test_verilog_body.v
@@ -1,0 +1,14 @@
+module Foo (
+    input I,
+    output O
+);
+
+always @(*) begin
+    O = I;
+    // Note we need to escape the newline here or python treats it as regular
+    // newline
+    $display("%d\n", I);
+end
+
+endmodule
+

--- a/tests/test_compile/test_verilog.py
+++ b/tests/test_compile/test_verilog.py
@@ -1,0 +1,20 @@
+import magma as m
+import magma.testing
+
+
+def test_verilog_body():
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+        verilog = f"""
+always @(*) begin
+    O = I;
+    // Note we need to escape the newline here or python treats it as regular
+    // newline
+    $display("%d\\n", I);
+end
+"""
+
+    m.compile("build/test_verilog_body", Foo)
+    assert m.testing.check_files_equal(
+        __file__, f"build/test_verilog_body.v",
+        f"gold/test_verilog_body.v")


### PR DESCRIPTION
Depends on https://github.com/rdaly525/coreir/pull/987

This was a feature we used to support in magma (see first example
https://github.com/phanrahan/magmathon/blob/master/notebooks/advanced/verilog.ipynb)
that used the verilog backend. This adds support for the same feature in
the coreir backend.

This simply allows the user to define circuit interface in magma,
but the body in verilog. This is slightly different than inline verilog
in that we allow the user to drive signals from the verilog body string.
Otherwise, if we drove a signal from inline_verilog, we'd get an
undriven error in magma/coreir since we aren't aware of the driver from
the string.