### PR TITLE
Add inverted compile guard support

### DIFF
--- a/docs/compile_guard.md
+++ b/docs/compile_guard.md
@@ -75,5 +75,5 @@ by using the `ASSERT_ON` define.
 Note that logic inside a compile guard cannot be used outside of a compile
 guard (otherwise a signal may not have a driver when the guard is disabled).
 
-To generate an `ifndef` instead of `ifdef`, pass the argument `invert=True` to
-`m.compile_guard`.
+To generate an `ifndef` instead of `ifdef`, pass the argument
+`type="undefined"` to `m.compile_guard` (the default is `type="defined"`).

--- a/docs/compile_guard.md
+++ b/docs/compile_guard.md
@@ -74,3 +74,6 @@ by using the `ASSERT_ON` define.
 
 Note that logic inside a compile guard cannot be used outside of a compile
 guard (otherwise a signal may not have a driver when the guard is disabled).
+
+To generate an `ifndef` instead of `ifdef`, pass the argument `invert=True` to
+`m.compile_guard`.

--- a/magma/compile_guard.py
+++ b/magma/compile_guard.py
@@ -127,8 +127,7 @@ class _CompileGuard:
         if self._defn_name is None:
             self._defn_name = _CompileGuard._new_name()
         if self._state is None:
-            ckt = _CompileGuardBuilder(self._defn_name, self._cond,
-                                       self._type)
+            ckt = _CompileGuardBuilder(self._defn_name, self._cond, self._type)
             if self._inst_name is None:
                 ckt.set_instance_name(self._inst_name)
             ctx_mgr = _DefinitionContextManager(ckt._context)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "pyverilog",
         "numpy",
         "graphviz",
-        "coreir>=2.0.131",
+        "coreir>=2.0.133",
         "hwtypes>=1.4.4",
         "ast_tools>=0.0.16",
         "staticfg"

--- a/tests/gold/test_compile_guard_array.json
+++ b/tests/gold/test_compile_guard_array.json
@@ -45,7 +45,7 @@
         "instances":{
           "COND_compile_guard":{
             "modref":"global.COND_compile_guard",
-            "metadata":{"compile_guard":{"condition_str":"COND","invert":false}}
+            "metadata":{"compile_guard":{"condition_str":"COND","type":"defined"}}
           }
         },
         "connections":[

--- a/tests/gold/test_compile_guard_array.json
+++ b/tests/gold/test_compile_guard_array.json
@@ -45,7 +45,7 @@
         "instances":{
           "COND_compile_guard":{
             "modref":"global.COND_compile_guard",
-            "metadata":{"compile_guard":"COND"}
+            "metadata":{"compile_guard":{"condition_str":"COND","invert":false}}
           }
         },
         "connections":[

--- a/tests/gold/test_compile_guard_assert.json
+++ b/tests/gold/test_compile_guard_assert.json
@@ -157,7 +157,7 @@
         "instances":{
           "ASSERT_ON_compile_guard":{
             "modref":"global.ASSERT_ON_compile_guard",
-            "metadata":{"compile_guard":"ASSERT_ON"}
+            "metadata":{"compile_guard":{"condition_str":"ASSERT_ON","invert":false}}
           },
           "Register_inst0":{
             "modref":"global.Register"

--- a/tests/gold/test_compile_guard_assert.json
+++ b/tests/gold/test_compile_guard_assert.json
@@ -157,7 +157,7 @@
         "instances":{
           "ASSERT_ON_compile_guard":{
             "modref":"global.ASSERT_ON_compile_guard",
-            "metadata":{"compile_guard":{"condition_str":"ASSERT_ON","invert":false}}
+            "metadata":{"compile_guard":{"condition_str":"ASSERT_ON","type":"defined"}}
           },
           "Register_inst0":{
             "modref":"global.Register"

--- a/tests/gold/test_compile_guard_basic.json
+++ b/tests/gold/test_compile_guard_basic.json
@@ -45,7 +45,7 @@
         "instances":{
           "COND_compile_guard":{
             "modref":"global.COND_compile_guard",
-            "metadata":{"compile_guard":{"condition_str":"COND","invert":false}}
+            "metadata":{"compile_guard":{"condition_str":"COND","type":"defined"}}
           }
         },
         "connections":[

--- a/tests/gold/test_compile_guard_basic.json
+++ b/tests/gold/test_compile_guard_basic.json
@@ -45,7 +45,7 @@
         "instances":{
           "COND_compile_guard":{
             "modref":"global.COND_compile_guard",
-            "metadata":{"compile_guard":"COND"}
+            "metadata":{"compile_guard":{"condition_str":"COND","invert":false}}
           }
         },
         "connections":[

--- a/tests/gold/test_compile_guard_basic_invert.json
+++ b/tests/gold/test_compile_guard_basic_invert.json
@@ -1,0 +1,60 @@
+{"top":"global._Top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "COND_compile_guard":{
+        "type":["Record",[
+          ["port_0","BitIn"],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances":{
+          "Register_inst0":{
+            "modref":"global.Register"
+          }
+        },
+        "connections":[
+          ["self.CLK","Register_inst0.CLK"],
+          ["self.port_0","Register_inst0.I"]
+        ]
+      },
+      "Register":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances":{
+          "reg_P_inst0":{
+            "genref":"coreir.reg",
+            "genargs":{"width":["Int",1]},
+            "modargs":{"clk_posedge":["Bool",true], "init":[["BitVector",1],"1'h0"]}
+          }
+        },
+        "connections":[
+          ["self.CLK","reg_P_inst0.clk"],
+          ["self.I","reg_P_inst0.in.0"],
+          ["self.O","reg_P_inst0.out.0"]
+        ]
+      },
+      "_Top":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances":{
+          "COND_compile_guard":{
+            "modref":"global.COND_compile_guard",
+            "metadata":{"compile_guard":{"condition_str":"COND","invert":true}}
+          }
+        },
+        "connections":[
+          ["self.CLK","COND_compile_guard.CLK"],
+          ["self.I","COND_compile_guard.port_0"],
+          ["self.O","self.I"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/gold/test_compile_guard_basic_undefined.json
+++ b/tests/gold/test_compile_guard_basic_undefined.json
@@ -1,0 +1,60 @@
+{"top":"global._Top",
+"namespaces":{
+  "global":{
+    "modules":{
+      "COND_compile_guard":{
+        "type":["Record",[
+          ["port_0","BitIn"],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances":{
+          "Register_inst0":{
+            "modref":"global.Register"
+          }
+        },
+        "connections":[
+          ["self.CLK","Register_inst0.CLK"],
+          ["self.port_0","Register_inst0.I"]
+        ]
+      },
+      "Register":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances":{
+          "reg_P_inst0":{
+            "genref":"coreir.reg",
+            "genargs":{"width":["Int",1]},
+            "modargs":{"clk_posedge":["Bool",true], "init":[["BitVector",1],"1'h0"]}
+          }
+        },
+        "connections":[
+          ["self.CLK","reg_P_inst0.clk"],
+          ["self.I","reg_P_inst0.in.0"],
+          ["self.O","reg_P_inst0.out.0"]
+        ]
+      },
+      "_Top":{
+        "type":["Record",[
+          ["I","BitIn"],
+          ["O","Bit"],
+          ["CLK",["Named","coreir.clkIn"]]
+        ]],
+        "instances":{
+          "COND_compile_guard":{
+            "modref":"global.COND_compile_guard",
+            "metadata":{"compile_guard":{"condition_str":"COND","type":"undefined"}}
+          }
+        },
+        "connections":[
+          ["self.CLK","COND_compile_guard.CLK"],
+          ["self.I","COND_compile_guard.port_0"],
+          ["self.O","self.I"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/gold/test_compile_guard_multiple_array.json
+++ b/tests/gold/test_compile_guard_multiple_array.json
@@ -51,7 +51,7 @@
         "instances":{
           "COND_compile_guard":{
             "modref":"global.COND_compile_guard",
-            "metadata":{"compile_guard":"COND"}
+            "metadata":{"compile_guard":{"condition_str":"COND","invert":false}}
           }
         },
         "connections":[

--- a/tests/gold/test_compile_guard_multiple_array.json
+++ b/tests/gold/test_compile_guard_multiple_array.json
@@ -51,7 +51,7 @@
         "instances":{
           "COND_compile_guard":{
             "modref":"global.COND_compile_guard",
-            "metadata":{"compile_guard":{"condition_str":"COND","invert":false}}
+            "metadata":{"compile_guard":{"condition_str":"COND","type":"defined"}}
           }
         },
         "connections":[

--- a/tests/gold/test_compile_guard_nested_type.json
+++ b/tests/gold/test_compile_guard_nested_type.json
@@ -51,7 +51,7 @@
         "instances":{
           "COND_compile_guard":{
             "modref":"global.COND_compile_guard",
-            "metadata":{"compile_guard":"COND"}
+            "metadata":{"compile_guard":{"condition_str":"COND","invert":false}}
           }
         },
         "connections":[

--- a/tests/gold/test_compile_guard_nested_type.json
+++ b/tests/gold/test_compile_guard_nested_type.json
@@ -51,7 +51,7 @@
         "instances":{
           "COND_compile_guard":{
             "modref":"global.COND_compile_guard",
-            "metadata":{"compile_guard":{"condition_str":"COND","invert":false}}
+            "metadata":{"compile_guard":{"condition_str":"COND","type":"defined"}}
           }
         },
         "connections":[

--- a/tests/test_compile_guard.py
+++ b/tests/test_compile_guard.py
@@ -144,4 +144,4 @@ def test_basic_invert():
     m.compile("build/test_compile_guard_basic_invert", _Top)
     assert m.testing.check_files_equal(
         __file__, f"build/test_compile_guard_basic_invert.json",
-        f"gold/test_compile_guard_basic_invert_invert.json")
+        f"gold/test_compile_guard_basic_invert.json")

--- a/tests/test_compile_guard.py
+++ b/tests/test_compile_guard.py
@@ -130,18 +130,18 @@ def test_basic_oldstyle():
         f"gold/test_compile_guard_basic.json")
 
 
-def test_basic_invert():
+def test_basic_undefined():
 
     class _Top(m.Circuit):
         io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit)) + m.ClockIO()
 
         with m.compile_guard("COND", defn_name="COND_compile_guard",
-                             invert=True):
+                             type='undefined'):
             out = m.Register(m.Bit)()(io.I)
 
         io.O @= io.I
 
-    m.compile("build/test_compile_guard_basic_invert", _Top)
+    m.compile("build/test_compile_guard_basic_undefined", _Top)
     assert m.testing.check_files_equal(
-        __file__, f"build/test_compile_guard_basic_invert.json",
-        f"gold/test_compile_guard_basic_invert.json")
+        __file__, f"build/test_compile_guard_basic_undefined.json",
+        f"gold/test_compile_guard_basic_undefined.json")

--- a/tests/test_compile_guard.py
+++ b/tests/test_compile_guard.py
@@ -128,3 +128,20 @@ def test_basic_oldstyle():
     assert m.testing.check_files_equal(
         __file__, f"build/test_compile_guard_basic.json",
         f"gold/test_compile_guard_basic.json")
+
+
+def test_basic_invert():
+
+    class _Top(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit)) + m.ClockIO()
+
+        with m.compile_guard("COND", defn_name="COND_compile_guard",
+                             invert=True):
+            out = m.Register(m.Bit)()(io.I)
+
+        io.O @= io.I
+
+    m.compile("build/test_compile_guard_basic_invert", _Top)
+    assert m.testing.check_files_equal(
+        __file__, f"build/test_compile_guard_basic_invert.json",
+        f"gold/test_compile_guard_basic_invert_invert.json")


### PR DESCRIPTION
Depends on https://github.com/rdaly525/coreir/pull/988

Support for the `ifndef` pattern has been requested.