### PR TITLE
Add support for verilog_name metadata

### DIFF
--- a/magma/backend/coreir/coreir_transformer.py
+++ b/magma/backend/coreir/coreir_transformer.py
@@ -414,4 +414,7 @@ class DeclarationTransformer(LeafTransformer):
             attach_debug_info(coreir_module, self.decl.debug_info)
         for key, value in self.decl.coreir_metadata.items():
             coreir_module.add_metadata(key, json.dumps(value))
+        if hasattr(self.decl, "verilog_name"):
+            coreir_module.add_metadata(
+                "verilog_name", json.dumps(self.decl.verilog_name))
         return coreir_module

--- a/tests/test_compile/gold/test_verilog_name.v
+++ b/tests/test_compile/gold/test_verilog_name.v
@@ -1,0 +1,13 @@
+// Module `Foo` defined externally
+module baz_Bar (
+    input I,
+    output O
+);
+wire Foo_inst0_O;
+Foo Foo_inst0 (
+    .I(I),
+    .O(Foo_inst0_O)
+);
+assign O = Foo_inst0_O;
+endmodule
+

--- a/tests/test_compile/test_verilog.py
+++ b/tests/test_compile/test_verilog.py
@@ -18,3 +18,18 @@ end
     assert m.testing.check_files_equal(
         __file__, f"build/test_verilog_body.v",
         f"gold/test_verilog_body.v")
+
+
+def test_verilog_name():
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+        verilog_name = "Foo"
+
+    class Bar(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+        io.O @= Foo()(io.I)
+
+    m.compile("build/test_verilog_name", Bar, verilog_prefix="baz_")
+    assert m.testing.check_files_equal(
+        __file__, f"build/test_verilog_name.v",
+        f"gold/test_verilog_name.v")


### PR DESCRIPTION
CoreIR has a metadata field "verilog_name" that allows a module to
explicitly set a desired verilog name.  It's used for the ice40
primitives, which are defined in the ice40 namespace.  Normally, you'd
get something like ice40_<MODULE_NAME> given the namespace to verilog
name logic, but the verilog_name metadata overrides this logic and fixes
a specific string.  This metadata also overrides the verilog_prefix
logic, which gives the user the ability to mark certain modules to be
ignored by the verilog_prefix.  This is useful when you want most of
your design to use the verilog_prefix, except a select few modules that
you don't control the name of (e.g.  standard cells).