### PR TITLE
Fix error with reset cast in python sim flatten

### DIFF
--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -191,7 +191,9 @@ def wire_new_bit(origbit, newbit, cur_scope, primitive_map, bit_map, old_circuit
 
     newsource = get_new_source(source_qual, primitive_map, old_circuit, new_circuit)
     # Convert newsource because it might have been casted in the user code
-    newsource = convertbit(newsource, type(newbit).undirected_t)
+    newbit_T = type(newbit).undirected_t
+    if not isinstance(newsource, newbit_T):
+        newsource = convertbit(newsource, newbit_T)
     wire(newsource, newbit)
 
     for collapsed in collapsed_in_bits:

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -1,6 +1,6 @@
 from collections import namedtuple, OrderedDict
 from .circuit import CopyInstance, Circuit, IO
-from .conversions import convertbit
+from magma.conversions import convertbit
 from .is_definition import isdefinition
 from .is_primitive import isprimitive
 from .digital import Digital

--- a/magma/transforms.py
+++ b/magma/transforms.py
@@ -1,5 +1,6 @@
 from collections import namedtuple, OrderedDict
 from .circuit import CopyInstance, Circuit, IO
+from .conversions import convertbit
 from .is_definition import isdefinition
 from .is_primitive import isprimitive
 from .digital import Digital
@@ -189,6 +190,8 @@ def wire_new_bit(origbit, newbit, cur_scope, primitive_map, bit_map, old_circuit
         collapsed_in_bits.append(intermediate_in)
 
     newsource = get_new_source(source_qual, primitive_map, old_circuit, new_circuit)
+    # Convert newsource because it might have been casted in the user code
+    newsource = convertbit(newsource, type(newbit).undirected_t)
     wire(newsource, newbit)
 
     for collapsed in collapsed_in_bits:

--- a/tests/test_simulator/test_register.py
+++ b/tests/test_simulator/test_register.py
@@ -1,0 +1,16 @@
+import magma as m
+import fault as f
+
+
+def test_register():
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[4]), O=m.Out(m.Bits[4])) 
+        io += m.ClockIO(has_reset=True)
+        io.O @= m.Register(
+            m.Bits[4], reset_type=m.Reset
+        )()(io.I)
+
+    tester = f.PythonTester(Foo, Foo.CLK)
+    tester.circuit.I = 3
+    tester.step(2)
+    tester.circuit.O.expect(3)


### PR DESCRIPTION
Before, we'd get this error:
```
ERROR:magma:Cannot wire Foo_flattened.RESET (Out(Reset)) to coreir_commonlib_mux2x4_inst0.in.sel[0] (In(Bit))
```

This is because inside the register code, we cast a register to bit (as
an input to a mux).

This fix changes the flattening code to cast a new source bit before
wiring it to a sink bit since at this point we can assume the user code
was valid (i.e. they performed a cast).