### PR TITLE
Add support for verilog prefix in bind

### DIFF
--- a/magma/bind.py
+++ b/magma/bind.py
@@ -100,6 +100,9 @@ Bind monitor interface does not match circuit interface
     if user_namespace is not None:
         cls_name = user_namespace + "_" + cls_name
         monitor_name = user_namespace + "_" + monitor_name
+    if verilog_prefix is not None:
+        cls_name = verilog_prefix + cls_name
+        monitor_name = verilog_prefix + monitor_name
     bind_str = f"bind {cls_name} {monitor_name} {monitor_name}_inst (\n    {ports_str}\n);"  # noqa
     if compile_guard is not None:
         bind_str = f"""
@@ -114,7 +117,7 @@ Bind monitor interface does not match circuit interface
     # Circular dependency, need coreir backend to compile, backend imports
     # circuit (for wrap casts logic, we might be able to factor that out).
     compile_fn(f".magma/{monitor.name}", monitor, inline=True,
-               user_namespace=user_namespace)
+               user_namespace=user_namespace, verilog_prefix=verilog_prefix)
     set_compile_dir(curr_compile_dir)
     with open(f".magma/{monitor.name}.v", "r") as f:
         content = "\n".join((f.read(), bind_str))

--- a/tests/test_verilog/gold/RTLMonitor.sv
+++ b/tests/test_verilog/gold/RTLMonitor.sv
@@ -1,11 +1,11 @@
-module coreir_wrap (
+module bar_coreir_wrap (
     input in,
     output out
 );
   assign out = in;
 endmodule
 
-module coreir_term #(
+module bar_coreir_term #(
     parameter width = 1
 ) (
     input [width-1:0] in
@@ -13,13 +13,13 @@ module coreir_term #(
 
 endmodule
 
-module corebit_term (
+module bar_corebit_term (
     input in
 );
 
 endmodule
 
-module foo_RTLMonitor (
+module bar_foo_RTLMonitor (
     input CLK,
     input handshake_arr_0_ready,
     input handshake_arr_0_valid,
@@ -70,7 +70,7 @@ endmodule
 
 
 `ifdef BIND_ON
-bind foo_RTL foo_RTLMonitor foo_RTLMonitor_inst (
+bind bar_foo_RTL bar_foo_RTLMonitor bar_foo_RTLMonitor_inst (
     .CLK(CLK),
     .in1(in1),
     .in2(in2),

--- a/tests/test_verilog/gold/RTLMonitor_unq1.sv
+++ b/tests/test_verilog/gold/RTLMonitor_unq1.sv
@@ -1,11 +1,11 @@
-module coreir_wrap (
+module bar_coreir_wrap (
     input in,
     output out
 );
   assign out = in;
 endmodule
 
-module coreir_term #(
+module bar_coreir_term #(
     parameter width = 1
 ) (
     input [width-1:0] in
@@ -13,13 +13,13 @@ module coreir_term #(
 
 endmodule
 
-module corebit_term (
+module bar_corebit_term (
     input in
 );
 
 endmodule
 
-module foo_RTLMonitor_unq1 (
+module bar_foo_RTLMonitor_unq1 (
     input CLK,
     input handshake_arr_0_ready,
     input handshake_arr_0_valid,
@@ -70,7 +70,7 @@ endmodule
 
 
 `ifdef BIND_ON
-bind foo_RTL_unq1 foo_RTLMonitor_unq1 foo_RTLMonitor_unq1_inst (
+bind bar_foo_RTL_unq1 bar_foo_RTLMonitor_unq1 bar_foo_RTLMonitor_unq1_inst (
     .CLK(CLK),
     .in1(in1),
     .in2(in2),

--- a/tests/test_verilog/gold/bind_test.v
+++ b/tests/test_verilog/gold/bind_test.v
@@ -8,7 +8,7 @@ endmodule
 module andr_4 (input [3:0] I, output O);
 assign O = &(I);
 endmodule
-module coreir_term #(
+module bar_coreir_term #(
     parameter width = 1
 ) (
     input [width-1:0] in
@@ -16,17 +16,17 @@ module coreir_term #(
 
 endmodule
 
-module foo_SomeCircuit (
+module bar_foo_SomeCircuit (
     input [3:0] I
 );
-coreir_term #(
+bar_coreir_term #(
     .width(4)
 ) term_inst0 (
     .in(I)
 );
 endmodule
 
-module foo_NestedOtherCircuit (
+module bar_foo_NestedOtherCircuit (
     output [19:0] x_y [0:0]
 );
 wire [19:0] _magma_bind_wire_0_0;
@@ -34,20 +34,20 @@ assign _magma_bind_wire_0_0 = x_y[0];
 foo_OtherCircuit other_circ (
     .x_y(x_y)
 );
-coreir_term #(
+bar_coreir_term #(
     .width(20)
 ) term_inst0 (
     .in(_magma_bind_wire_0_0)
 );
 endmodule
 
-module corebit_term (
+module bar_corebit_term (
     input in
 );
 
 endmodule
 
-module foo_RTL (
+module bar_foo_RTL (
     input CLK,
     input handshake_arr_0_ready,
     output handshake_arr_0_valid,
@@ -80,7 +80,7 @@ wire [1:0] self_ndarr_0;
 wire [1:0] self_ndarr_1;
 wire [1:0] self_ndarr_2;
 wire temp3;
-foo_SomeCircuit SomeCircuit_inst0 (
+bar_foo_SomeCircuit SomeCircuit_inst0 (
     .I(magma_Bits_4_xor_inst0_out)
 );
 assign _magma_bind_wire_0 = orr_4_inst0_O;
@@ -95,40 +95,40 @@ andr_4 andr_4_inst0 (
     .I(in1),
     .O(andr_4_inst0_O)
 );
-corebit_term corebit_term_inst0 (
+bar_corebit_term corebit_term_inst0 (
     .in(temp3)
 );
-corebit_term corebit_term_inst1 (
+bar_corebit_term corebit_term_inst1 (
     .in(_magma_bind_wire_0)
 );
-corebit_term corebit_term_inst10 (
+bar_corebit_term corebit_term_inst10 (
     .in(_magma_bind_wire_5_1[1])
 );
-corebit_term corebit_term_inst11 (
+bar_corebit_term corebit_term_inst11 (
     .in(_magma_bind_wire_5_1[2])
 );
-corebit_term corebit_term_inst2 (
+bar_corebit_term corebit_term_inst2 (
     .in(_magma_bind_wire_1)
 );
-corebit_term corebit_term_inst3 (
+bar_corebit_term corebit_term_inst3 (
     .in(_magma_bind_wire_2_0)
 );
-corebit_term corebit_term_inst4 (
+bar_corebit_term corebit_term_inst4 (
     .in(_magma_bind_wire_2_1)
 );
-corebit_term corebit_term_inst5 (
+bar_corebit_term corebit_term_inst5 (
     .in(_magma_bind_wire_4)
 );
-corebit_term corebit_term_inst6 (
+bar_corebit_term corebit_term_inst6 (
     .in(_magma_bind_wire_5_0[0])
 );
-corebit_term corebit_term_inst7 (
+bar_corebit_term corebit_term_inst7 (
     .in(_magma_bind_wire_5_0[1])
 );
-corebit_term corebit_term_inst8 (
+bar_corebit_term corebit_term_inst8 (
     .in(_magma_bind_wire_5_0[2])
 );
-corebit_term corebit_term_inst9 (
+bar_corebit_term corebit_term_inst9 (
     .in(_magma_bind_wire_5_1[0])
 );
 assign intermediate_ndarr_0 = {self_ndarr_2[0],self_ndarr_1[0],self_ndarr_0[0]};
@@ -139,7 +139,7 @@ logical_and logical_and_inst0 (
     .O(out)
 );
 assign magma_Bits_4_xor_inst0_out = in1 ^ in2;
-foo_NestedOtherCircuit nested_other_circ (
+bar_foo_NestedOtherCircuit nested_other_circ (
     .x_y(nested_other_circ_x_y)
 );
 orr_4 orr_4_inst0 (
@@ -152,12 +152,12 @@ assign self_ndarr_2 = ndarr[2];
 assign temp3 = andr_4_inst0_O;
 wire [5:0] term_inst0_in;
 assign term_inst0_in = {self_ndarr_2[1:0],self_ndarr_1[1:0],self_ndarr_0[1:0]};
-coreir_term #(
+bar_coreir_term #(
     .width(6)
 ) term_inst0 (
     .in(term_inst0_in)
 );
-coreir_term #(
+bar_coreir_term #(
     .width(4)
 ) term_inst1 (
     .in(_magma_bind_wire_3)

--- a/tests/test_verilog/test_bind.py
+++ b/tests/test_verilog/test_bind.py
@@ -9,7 +9,8 @@ from subprocess import run
 def test_bind():
     RTL4 = RTL.generate(4)
 
-    m.compile("build/bind_test", RTL4, inline=True, user_namespace="foo")
+    m.compile("build/bind_test", RTL4, inline=True, user_namespace="foo",
+              verilog_prefix="bar_")
     assert m.testing.check_files_equal(__file__,
                                        f"build/bind_test.v",
                                        f"gold/bind_test.v")
@@ -22,7 +23,7 @@ def test_bind():
     if version >= 4.016:
         assert not os.system('cd tests/test_verilog/build && '
                              'verilator --lint-only bind_test.v RTLMonitor.sv '
-                             '--top-module foo_RTL -Wno-MODDUP')
+                             '--top-module bar_foo_RTL -Wno-MODDUP')
     listings_file = "tests/test_verilog/build/bind_test_bind_files.list"
     with open(listings_file, "r") as f:
         assert f.read() == """\


### PR DESCRIPTION
Somehow this got mixed since it seems like we passed the information through to the bind logic, but we simply forgot to use it.