### PR TITLE
Add clog2safe function

### DIFF
--- a/magma/bitutils.py
+++ b/magma/bitutils.py
@@ -7,6 +7,7 @@ from .compatibility import StringTypes
 
 __all__  = ['seq2int', 'int2seq', 'ints2seq', 'fun2seq', 'lutinit']
 __all__ += ['int2uint', 'clz', 'pow2', 'log2', 'clog2', 'rol', 'ror']
+__all__ += ['clog2safe']
 
 #
 # seq to int
@@ -109,6 +110,13 @@ def clog2(x):
     if x > (1 << y):
         y = y + 1
     return y
+
+
+def clog2safe(x):
+    if x == 1:
+        return 1
+    return clog2(x)
+
 
 def pow2(n):
     return 1 << n


### PR DESCRIPTION
Requested by George, here's a reference example implementation: https://github.com/KastnerRG/riffa/blob/master/fpga/riffa_hdl/functions.vh#L59

The idea is that the 1 parameter comes up often in highly parametrized designs, so sometimes it's useful to have a clog2safe function where you get a minimum size of 1 (e.g. instead of Bits[0] or having to call max(..., 1))