### PR TITLE
Optimize InstView logic

### DIFF
--- a/magma/placer.py
+++ b/magma/placer.py
@@ -49,9 +49,10 @@ class PlacerBase(ABC):
 
 
 def _setup_view(inst):
+    inst_view = InstView(inst)
     # Setup view now because inline strings might use it during defn
     for sub_inst in getattr(type(inst), "instances", []):
-        setattr(inst, sub_inst.name, InstView(sub_inst, InstView(inst)))
+        setattr(inst, sub_inst.name, InstView(sub_inst, inst_view))
 
 
 class Placer:


### PR DESCRIPTION
This was one source of the memory issues.  The sub instances can share
the same reference to their parent rather than creating a unique one for
each child.  We can improve this further, but this is a simple stop gap.
To improve it, we should make this hierarchical reference logic lazy
(add getattr logic that fetches these sub instances on demand) rather
than building up the references ahead of time (since the common case is
to not use these references).  The problematic circuit had 10,000
instances, causing this to become quite an issue.