### PR TITLE
Get inst verilog

### DIFF
--- a/tests/test_verilog/foo.py
+++ b/tests/test_verilog/foo.py
@@ -13,12 +13,12 @@ class Baz(m.Circuit):
 
 class Bar(m.Circuit):
     io = m.IO(I=m.In(T), O=m.Out(T))
-    io.O @= Baz()(io.I)
+    io.O @= Baz(name="baz")(io.I)
 
 
 class Foo(m.Circuit):
     io = m.IO(I=m.In(T), O=m.Out(T))
-    io.O @= Bar()(io.I)
+    io.O @= Bar(name="bar")(io.I)
 
 
 m.compile("build/Foo", Foo)

--- a/tests/test_verilog/foo.py
+++ b/tests/test_verilog/foo.py
@@ -1,0 +1,24 @@
+import magma as m
+
+
+class T(m.Product):
+    x = m.Bit
+    y = m.Bits[2]
+
+
+class Baz(m.Circuit):
+    io = m.IO(I=m.In(T), O=m.Out(T))
+    io.O @= io.I
+
+
+class Bar(m.Circuit):
+    io = m.IO(I=m.In(T), O=m.Out(T))
+    io.O @= Baz()(io.I)
+
+
+class Foo(m.Circuit):
+    io = m.IO(I=m.In(T), O=m.Out(T))
+    io.O @= Bar()(io.I)
+
+
+m.compile("build/Foo", Foo)

--- a/tests/test_verilog/test_get_inst_verilog.py
+++ b/tests/test_verilog/test_get_inst_verilog.py
@@ -16,6 +16,17 @@ def test_get_inst_verilog():
 
     class Main(m.Circuit):
         io = m.IO(I=m.In(T), O=m.Out(T))
-        io.O @= T(*Foo()(io.I.x, io.I.y))
+        foo = Foo()
+        # TODO: If we can reconstruct the original tuple for foo, we can just
+        # pass the packed tuple rather than x, y individually
+        io.O @= T(*foo(io.I.x, io.I.y))
+        # TODO: Need API to refer to instance nested inside a verilog imported
+        # module (resolved using the symbol table)
+        # Proposed API is to pass a name for instances, hierarchical reference
+        # using a variable number of string arguments
+        # Then the instance reference provides attributes for magma's standard
+        # type syntax (e.g. dot notation tuples, subscript for arrays)
+        ref = foo.get_instance("bar", "baz").O.x[1]
+        m.inline_verilog('assert ({A} == 1) else $error("ERROR");', A=ref)
 
     m.compile("build/Main", Main)

--- a/tests/test_verilog/test_get_inst_verilog.py
+++ b/tests/test_verilog/test_get_inst_verilog.py
@@ -1,0 +1,21 @@
+import os
+import magma as m
+
+
+class T(m.Product):
+    x = m.Bit
+    y = m.Bits[2]
+
+
+def test_get_inst_verilog():
+    dirname = os.path.abspath(os.path.dirname(__file__))
+    os.system(f"cd {dirname} && python foo.py")
+    # TODO: Need API to load with a symbol table
+    # Also, would be nice to derive a wrapper (e.g. reconstruct the tuples)
+    Foo = m.define_from_verilog_file(f"{dirname}/build/Foo.v")[0]
+
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(T), O=m.Out(T))
+        io.O @= T(*Foo()(io.I.x, io.I.y))
+
+    m.compile("build/Main", Main)


### PR DESCRIPTION
Here's a minimum example test setup for using the symbol table to refer to magma symbols from an imported magma generated verilog definition.

Here's a sketch of how we could support this:
1. Add API/logic to define_from_verilog using a symbol table.  We can use the symbol table to reconstruct the original magma types (this would deprecate the old type_map interface, but also improve it because we could automatically add a wrapper to handle "repacking" tuples/arrays that have been flattened).
2. Add API to reference instances (possibly hierarchically) using string names.  This could work for non-verilog circuits too, which would be nice for making things standard.  For verilog imported circuits that have a symbol table, we can resolve the references and provide a "view" of the nested instance that should have the original magma types.
3. Update inline_verilog to support code generation using these "views" (can use verilog's cross module reference syntax)