### PR TITLE
Raise exception when trying to compile empty defn

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -100,3 +100,4 @@ import magma.smart
 from magma.compile_guard import compile_guard
 from magma.set_name import set_name
 from magma.circuit_utils import circuit_stub, stubify, CircuitStub
+from magma.compile import MagmaCompileException

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -42,7 +42,15 @@ def _get_basename(basename):
     return basename
 
 
+class MagmaCompileException(Exception):
+    pass
+
+
 def compile(basename, main, output="coreir-verilog", **kwargs):
+    if not getattr(main, "is_definition", False):
+        raise MagmaCompileException(
+            f"Trying to compile empty definition {main}"
+        )
     if hasattr(main, "circuit_definition"):
         main = main.circuit_definition
     basename = _get_basename(basename)

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -47,10 +47,9 @@ class MagmaCompileException(Exception):
 
 
 def compile(basename, main, output="coreir-verilog", **kwargs):
-    if not getattr(main, "is_definition", False):
+    if not isdefinition(main):
         raise MagmaCompileException(
-            f"Trying to compile empty definition {main}"
-        )
+            f"Trying to compile empty definition {main}")
     if hasattr(main, "circuit_definition"):
         main = main.circuit_definition
     basename = _get_basename(basename)

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -7,6 +7,7 @@ from magma.bind import BindPass
 from magma.compiler import Compiler
 from magma.config import get_compile_dir
 from magma.inline_verilog import ProcessInlineVerilogPass
+from magma.is_definition import isdefinition
 from magma.passes.clock import WireClockPass
 from magma.passes.drive_undriven import DriveUndrivenPass
 from magma.passes.terminate_unused import TerminateUnusedPass

--- a/tests/test_compile/test_empty_top.py
+++ b/tests/test_compile/test_empty_top.py
@@ -1,0 +1,10 @@
+import pytest
+import magma as m
+
+
+def test_compile_empty_top():
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+
+    with pytest.raises(m.MagmaCompileException):
+        m.compile("build/Main", Main)

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -198,8 +198,10 @@ def test_wire_tuple_to_clock():
         b = m.In(m.Clock)
 
     class Foo(m.Circuit):
-        io = m.IO(I=In(T), O=m.Out(m.Clock))
+        io = m.IO(I=In(T), O=m.Out(m.Clock), x=m.Out(m.Bit))
         m.wire(io.I, io.O)
+        # Wire a dummy output so we don't have an empty defn
+        io.x @= 1
 
     # Imported here to avoid changing line numbers for above tests
     import pytest


### PR DESCRIPTION
This came up with an old-style class definition that had a typo in the
`definition` method (spelled it `definiiton`).  This resulted in a
segfault in coreir since it was trying to compile an empty top.  We
should improve the coreir error handling, but I think at this level it's
fine to raise an Exception when the user tries to do this, because
there's not really any reasonable use case for trying to compile an
empty circuit without a definition (we could just generate a verilog
declaration? but seems like an odd use case for magma that we don't need
to support)