### PR TITLE
Share inline wires for undriven clocks

### DIFF
--- a/tests/test_verilog/gold/test_inline_verilog_share_default_clocks.v
+++ b/tests/test_verilog/gold/test_inline_verilog_share_default_clocks.v
@@ -1,0 +1,51 @@
+module coreir_wrap (
+    input in,
+    output out
+);
+  assign out = in;
+endmodule
+
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module WireClock (
+    input I,
+    output O
+);
+wire Wire_inst0;
+wire coreir_wrapInClock_inst0_out;
+assign Wire_inst0 = coreir_wrapInClock_inst0_out;
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(I),
+    .out(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(Wire_inst0),
+    .out(O)
+);
+endmodule
+
+module Foo (
+    input x,
+    input y,
+    input CLK,
+    input RESET
+);
+wire _magma_inline_wire0_O;
+wire _magma_inline_wire1;
+WireClock _magma_inline_wire0 (
+    .I(CLK),
+    .O(_magma_inline_wire0_O)
+);
+assign _magma_inline_wire1 = RESET;
+
+assert property (@(posedge _magma_inline_wire0_O) disable iff (! _magma_inline_wire1) x |-> ##1 y);
+
+
+assert property (@(posedge _magma_inline_wire0_O) disable iff (! _magma_inline_wire1) x |-> ##1 y);
+
+endmodule
+

--- a/tests/test_verilog/test_inline.py
+++ b/tests/test_verilog/test_inline.py
@@ -246,3 +246,23 @@ end
     assert m.testing.check_files_equal(
         __file__, f"build/test_inline_verilog_unique_old_style2.v",
         f"gold/test_inline_verilog_unique_old_style2.v")
+
+
+def test_inline_verilog_share_default_clocks():
+    class Foo(m.Circuit):
+        io = m.IO(x=m.In(m.Bit), y=m.In(m.Bit)) + m.ClockIO(has_reset=True)
+        # Auto-wired
+        clk = m.Clock()
+        rst = m.Reset()
+        m.inline_verilog("""
+assert property (@(posedge {clk}) disable iff (! {rst}) {io.x} |-> ##1 {io.y});
+""")
+        m.inline_verilog("""
+assert property (@(posedge {clk}) disable iff (! {rst}) {io.x} |-> ##1 {io.y});
+""")
+
+    m.compile("build/test_inline_verilog_share_default_clocks", Foo,
+              inline=True)
+    assert m.testing.check_files_equal(
+        __file__, f"build/test_inline_verilog_share_default_clocks.v",
+        f"gold/test_inline_verilog_share_default_clocks.v")


### PR DESCRIPTION
The current pattern for using the default clocks in inline verilog is to
refer to an undriven anonymous clock (e.g. `clk = m.Clock()`).  Then,
the compiler will use the default clock driver logic to wire this up.
This is useful for the pattern where you have a helper function for
generating properties, with an optional clock argument (so the user can
pass a specific clock, or by default it uses the default clock).  Since
this helper function doesn't know the context in which it's being
invoked (i.e. the default clock of the definition it's being used in),
it simply uses an undriven anonymous clock that will be automatically
wired up later.

The current inline_verilog logic will generate multiple wires for each
undriven clock because they're different anonymous values, which is
annoying (since many properties use the default clock, we get many wires
for the default clock, but they are all the same clock).

This changes the logic to handle undriven clocks and share a wire for
each undriven clock type, with the intention that they will all use the
same default driver wired up later.  Note that we don't handle general
(non clock types) since this logic happens during the process inline
verilog pass during the compilation phase.  At this point, we assume
that all values have been wired up, so if there's no driver for a
non-clock value, then it's an error (won't be handled by the automatic)
clock wiring logic, so we only need to consider the case where clock
types are undriven.