### PR TITLE
Add wire in sequential test

### DIFF
--- a/tests/test_syntax/gold/TestSequential2Wiring.v
+++ b/tests/test_syntax/gold/TestSequential2Wiring.v
@@ -1,0 +1,177 @@
+module coreir_xorr #(
+    parameter width = 1
+) (
+    input [width-1:0] in,
+    output out
+);
+  assign out = ^in;
+endmodule
+
+module coreir_reg #(
+    parameter width = 1,
+    parameter clk_posedge = 1,
+    parameter init = 1
+) (
+    input clk,
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  reg [width-1:0] outReg=init;
+  wire real_clk;
+  assign real_clk = clk_posedge ? clk : ~clk;
+  always @(posedge real_clk) begin
+    outReg <= in;
+  end
+  assign out = outReg;
+endmodule
+
+module coreir_orr #(
+    parameter width = 1
+) (
+    input [width-1:0] in,
+    output out
+);
+  assign out = |in;
+endmodule
+
+module coreir_mux #(
+    parameter width = 1
+) (
+    input [width-1:0] in0,
+    input [width-1:0] in1,
+    input sel,
+    output [width-1:0] out
+);
+  assign out = sel ? in1 : in0;
+endmodule
+
+module corebit_const #(
+    parameter value = 1
+) (
+    output out
+);
+  assign out = value;
+endmodule
+
+module commonlib_muxn__N2__width1 (
+    input [0:0] in_data [1:0],
+    input [0:0] in_sel,
+    output [0:0] out
+);
+wire [0:0] _join_out;
+coreir_mux #(
+    .width(1)
+) _join (
+    .in0(in_data[0]),
+    .in1(in_data[1]),
+    .sel(in_sel[0]),
+    .out(_join_out)
+);
+assign out = _join_out;
+endmodule
+
+module Register (
+    input [3:0] I,
+    output [3:0] O,
+    input CLK
+);
+wire [3:0] reg_P4_inst0_out;
+coreir_reg #(
+    .clk_posedge(1'b1),
+    .init(4'h0),
+    .width(4)
+) reg_P4_inst0 (
+    .clk(CLK),
+    .in(I),
+    .out(reg_P4_inst0_out)
+);
+assign O = reg_P4_inst0_out;
+endmodule
+
+module Mux2xBit (
+    input I0,
+    input I1,
+    input S,
+    output O
+);
+wire [0:0] coreir_commonlib_mux2x1_inst0_out;
+wire [0:0] coreir_commonlib_mux2x1_inst0_in_data [1:0];
+assign coreir_commonlib_mux2x1_inst0_in_data[1] = I1;
+assign coreir_commonlib_mux2x1_inst0_in_data[0] = I0;
+commonlib_muxn__N2__width1 coreir_commonlib_mux2x1_inst0 (
+    .in_data(coreir_commonlib_mux2x1_inst0_in_data),
+    .in_sel(S),
+    .out(coreir_commonlib_mux2x1_inst0_out)
+);
+assign O = coreir_commonlib_mux2x1_inst0_out[0];
+endmodule
+
+module Foo (
+    input [3:0] I,
+    output [3:0] O,
+    input CLK
+);
+wire [3:0] Register_inst0_O;
+wire [3:0] Register_inst1_O;
+Register Register_inst0 (
+    .I(I),
+    .O(Register_inst0_O),
+    .CLK(CLK)
+);
+Register Register_inst1 (
+    .I(Register_inst0_O),
+    .O(Register_inst1_O),
+    .CLK(CLK)
+);
+assign O = Register_inst1_O;
+endmodule
+
+module Bar (
+    input [3:0] I,
+    output [3:0] O,
+    input CLK
+);
+wire [3:0] Foo_inst0_O;
+wire [3:0] Foo_inst1_O;
+wire Mux2xBit_inst0_O;
+wire bit_const_0_None_out;
+wire coreir_orr_3_inst0_out;
+wire coreir_xorr_3_inst0_out;
+Foo Foo_inst0 (
+    .I(Foo_inst1_O),
+    .O(Foo_inst0_O),
+    .CLK(CLK)
+);
+wire [3:0] Foo_inst1_I;
+assign Foo_inst1_I = {bit_const_0_None_out,bit_const_0_None_out,bit_const_0_None_out,Mux2xBit_inst0_O};
+Foo Foo_inst1 (
+    .I(Foo_inst1_I),
+    .O(Foo_inst1_O),
+    .CLK(CLK)
+);
+Mux2xBit Mux2xBit_inst0 (
+    .I0(coreir_xorr_3_inst0_out),
+    .I1(coreir_orr_3_inst0_out),
+    .S(I[0]),
+    .O(Mux2xBit_inst0_O)
+);
+corebit_const #(
+    .value(1'b0)
+) bit_const_0_None (
+    .out(bit_const_0_None_out)
+);
+coreir_orr #(
+    .width(3)
+) coreir_orr_3_inst0 (
+    .in(I[3:1]),
+    .out(coreir_orr_3_inst0_out)
+);
+coreir_xorr #(
+    .width(3)
+) coreir_xorr_3_inst0 (
+    .in(I[3:1]),
+    .out(coreir_xorr_3_inst0_out)
+);
+assign O = Foo_inst1_O;
+endmodule
+


### PR DESCRIPTION
So this works given a simple patch to ast_tools:
```diff
diff --git a/ast_tools/passes/ssa.py b/ast_tools/passes/ssa.py
index 01d90fa..c8dc92e 100644
--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -653,7 +653,7 @@ class ssa(Pass):
         names_to_attr = {}
         seen = set()
 
-        for written_attr in writter_attr_visitor.written_attrs:
+        for written_attr in {}:
             d_attr = DeepNode(written_attr)
             if d_attr in seen:
                 continue
```

Basically, the expression context provider used in the written attrs visitor treats augassign as a write, so it tries to rewrite these wiring statements.  There's a few options here:
(1) patch the code to ignore wiring (don't treat it like asssign), this probably means either extending the expressioncontextprovider to only treat assign as store, or writing our own provider that does the same.
(2) patch the code to support augassign.  This requires as few changes, basically there's places where the attr logic assumes names, but here we have nested attributes (e.g. `self.x.I`), so we need to support nesting for port references.  We also need to adapt the logic to handle the lack of default values (i.e. there's not necessarily a `self.x.O` that corresponds to the default value of `self.x.I`, like we assume now for attrs (since they're implicit registers).
(3) patch the code to only support wiring with augassign (i.e. drop support for current attrs), the code should look similar with just the default value logic removed.  The idea here we had is to have the implicit register syntax handled as a pre-pass that rewrites it into this wiring style with the default value.

Option (1) maintains backwards compatibility, but doesn't allow support for wiring inside if statements (since they are ignored in the ssa logic).
Option (2) maintains backwards compatibility and adds support for wiring inside if statements
Option (3) breaks backwards compatibility (we need to add the register pre-pass), but adds support for wiring inside if statements and avoids having to handle/maintain two different cases in the code.

I think based on discussion on Slack, we want to go with Option (3), while Option (1) would present a simple way forward if we don't need to support wiring inside if statements yet