### PR TITLE
Add support for name argument in mux operator

### DIFF
--- a/magma/primitives/mux.py
+++ b/magma/primitives/mux.py
@@ -144,7 +144,7 @@ def mux(I: list, S, **kwargs):
     if isinstance(S, int):
         return I[S]
     T, I = _infer_mux_type(I)
-    inst = Mux(len(I), T, **kwargs)()
+    inst = Mux(len(I), T)(**kwargs)
     if len(I) == 2 and isinstance(S, Bits[1]):
         S = S[0]
     result = inst(*I, S)

--- a/tests/test_primitives/gold/test_mux_operator.v
+++ b/tests/test_primitives/gold/test_mux_operator.v
@@ -49,13 +49,13 @@ module test_mux_operator (
     input S,
     output O
 );
-wire Mux2xBit_inst0_O;
-Mux2xBit Mux2xBit_inst0 (
+wire foo_O;
+Mux2xBit foo (
     .I0(I[0]),
     .I1(I[1]),
     .S(S),
-    .O(Mux2xBit_inst0_O)
+    .O(foo_O)
 );
-assign O = Mux2xBit_inst0_O;
+assign O = foo_O;
 endmodule
 

--- a/tests/test_primitives/test_mux.py
+++ b/tests/test_primitives/test_mux.py
@@ -136,7 +136,7 @@ def test_basic_mux_product():
 def test_mux_operator():
     class test_mux_operator(m.Circuit):
         io = m.IO(I=m.In(m.Bits[2]), S=m.In(m.Bit), O=m.Out(m.Bit))
-        io.O @= m.mux([io.I[0], io.I[1]], io.S)
+        io.O @= m.mux([io.I[0], io.I[1]], io.S, name="foo")
 
     m.compile("build/test_mux_operator", test_mux_operator)
 


### PR DESCRIPTION
Since kwargs isn't being used (only T and height are arguments to the
Mux generator), we swap the logic to passthrough kwargs to the instance
to pass any instance parameters.  In the future we could special case
the name kwarg if we wanted to pass through kwargs to the generator, or
vice versa (special case generator kwargs).