### PR TITLE
Error when using undriven input in inline verilog

### DIFF
--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -67,9 +67,8 @@ def _insert_temporary_wires(cls, value, inline_wire_prefix):
             value = value.value()
             if value is None:
                 raise InlineVerilogError(
-                    f"Found reference to undriven input port:"
-                    f" {orig_value.debug_name}"
-                )
+                    f"Found reference to undriven input port: "
+                    f"{orig_value.debug_name}")
 
         if not isinstance(_get_top_level_ref(value.name), DefnRef):
             key = value

--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -52,6 +52,10 @@ def _make_temporary(defn, value, num, inline_wire_prefix, parent=None):
     return temp.O
 
 
+class InlineVerilogError(RuntimeError):
+    pass
+
+
 def _insert_temporary_wires(cls, value, inline_wire_prefix):
     """
     For non DefnRef, insert a temporary Wire instance so the signal isn't
@@ -59,7 +63,13 @@ def _insert_temporary_wires(cls, value, inline_wire_prefix):
     """
     if isinstance(value, Type):
         if value.is_input():
+            orig_value = value
             value = value.value()
+            if value is None:
+                raise InlineVerilogError(
+                    f"Found reference to undriven input port:"
+                    f" {orig_value.debug_name}"
+                )
 
         if not isinstance(_get_top_level_ref(value.name), DefnRef):
             key = value


### PR DESCRIPTION
Adds a more useful error message when trying to reference an undriven
input port in the inline verilog flow.  Before, it would give an error
related to NoneType (because value is None) without telling the user
which signal is problematic.