### PR TITLE
Fix issue in flip then qualify of ready valid

### DIFF
--- a/magma/types/ready_valid.py
+++ b/magma/types/ready_valid.py
@@ -47,9 +47,11 @@ class ReadyValidKind(ProductKind):
 
     def qualify(cls, direction):
         T = cls.undirected_data_t
-        fields = {"valid": Bit.qualify(direction),
-                  "ready": Bit.qualify(direction),
-                  "data": T.qualify(direction)}
+        fields = {
+            "valid": Bit.qualify(direction),
+            "ready": Bit.qualify(direction),
+            "data": T.qualify(direction)
+        }
         return AnonProduct[fields]
 
     @property

--- a/magma/types/ready_valid.py
+++ b/magma/types/ready_valid.py
@@ -4,7 +4,7 @@ from magma.logging import root_logger
 from magma.primitives.mux import mux
 from magma.t import Type, In, Out
 from magma.protocol_type import MagmaProtocol
-from magma.tuple import Product, ProductKind
+from magma.tuple import Product, ProductKind, AnonProduct
 
 
 _logger = root_logger()
@@ -44,6 +44,13 @@ class ReadyValidKind(ProductKind):
 
     def flip(cls):
         raise TypeError("Cannot flip an undirected ReadyValid type")
+
+    def qualify(cls, direction):
+        T = cls.undirected_data_t
+        fields = {"valid": Bit.qualify(direction),
+                  "ready": Bit.qualify(direction),
+                  "data": T.qualify(direction)}
+        return AnonProduct[fields]
 
     @property
     def undirected_data_t(cls):

--- a/tests/test_type/test_ready_valid.py
+++ b/tests/test_type/test_ready_valid.py
@@ -201,3 +201,15 @@ def test_ready_valid_none():
         with pytest.raises(Exception):
             io.consumer_handshake.no_deq(1)
     m.compile("build/Foo", Foo)
+
+
+def test_in_ready_valid():
+    T = m.Consumer(m.ReadyValid[m.Bits[8]])
+    T = m.In(T)
+    assert T.ready.is_input()
+    assert T.valid.is_input()
+    assert T.data.is_input()
+    T = T.flip()
+    assert T.ready.is_output()
+    assert T.valid.is_output()
+    assert T.data.is_output()


### PR DESCRIPTION
Currently, calling qualify on a ready valid type (e.g. `In(T)`) will
behave correctly in that it will return a type that has all the
subfields (ready, valid, data) as inputs.  However, calling flip on the
qualified type will actually return the Flip of the original type.  This
is because producer/consumer ready valid types define flip to return the
corresponding dual.  The problem here is that when we call qualify using
the default Type.qualify, it returns a Producer/Consumer type with the
correct field types, but doesn't change the flip behavior.

The proposed change is that when you call qualify on a readyvalid type,
you get an AnonProduct back with the qualified fields that behaves like
a normal tuple.  This seems desirable since once you change a readyvalid
type to be qualified as all In or Out, it no longer really behaves like
a standard ReadyValid type and therefor doesn't obey the interfaces
(e.g. enq/deq, however there might be some use case for calling fired on
it but that could be defined as as helper function).

The use case for this pattern is inside the bind/monitor flow which
takes a generic circuit and converts all the ports to inputs (so the
monitor can read the IO).  Calling In on a ReadyValid type works fine,
but calling Flip on it (inside the Circuit interface flow) produces the
wrong behaviors (returns a Producer or Consumer, instead of something
with all inputs/outputs)