### PR TITLE
Protocol mux

### DIFF
--- a/magma/bit.py
+++ b/magma/bit.py
@@ -158,16 +158,10 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
             return f_branch
         if isinstance(t_branch, tuple):
             return tuple(self.ite(t, f) for t, f in zip(t_branch, f_branch))
-        # Note: coreir flips t/f cases
-        # self._mux monkey patched in magma/primitives/mux.py to avoid circular
-        # dependency
-        r = self._mux([f_branch, t_branch], self)
-
-        # cast protocol values back to protocol
-        if type(t_branch) == type(f_branch) and isinstance(t_branch, MagmaProtocol):
-            r = type(t_branch)._from_magma_value_(r)
-
-        return r
+        # NOTE(rsetaluri): CoreIR flips t/f cases.
+        # NOTE(rseatluri): self._mux is monkey patched in
+        # magma/primitives/mux.py to avoid circular dependency.
+        return self._mux([f_branch, t_branch], self)
 
     def __bool__(self) -> bool:
         raise NotImplementedError("Converting magma bit to bool not supported")

--- a/magma/testing/__init__.py
+++ b/magma/testing/__init__.py
@@ -1,1 +1,1 @@
-from .utils import check_files_equal, magma_debug_section
+from .utils import check_files_equal, magma_debug_section, SimpleMagmaProtocol

--- a/magma/testing/utils.py
+++ b/magma/testing/utils.py
@@ -89,8 +89,19 @@ class SimpleMagmaProtocolMeta(MagmaProtocolMeta):
         return cls(val)
 
     def __getitem__(cls, T):
-        return SimpleMagmaProtocolMeta._CACHE.setdefault(
-            T, type(cls)(f"SimpleMagmaProtocol{T}", (cls, ), {"T": T}))
+        try:
+            base = cls.base
+        except AttributeError:
+            base = cls
+        dct = {"T": T, "base": base}
+        derived = type(cls)(f"{base.__name__}[{T}]", (cls,), dct)
+        return SimpleMagmaProtocolMeta._CACHE.setdefault(T, derived)
+
+    def __repr__(cls):
+        return str(cls)
+
+    def __str__(cls):
+        return cls.__name__
 
 
 class SimpleMagmaProtocol(MagmaProtocol, metaclass=SimpleMagmaProtocolMeta):

--- a/magma/testing/utils.py
+++ b/magma/testing/utils.py
@@ -1,11 +1,16 @@
 """
 Infrastructure for writing magma tests
 """
+import difflib
 import filecmp
 import os
 import sys
-import difflib
-from ..config import get_debug_mode, set_debug_mode
+from typing import Optional
+
+from magma.config import get_debug_mode, set_debug_mode
+from magma.conversions import bits
+from magma.protocol_type import MagmaProtocolMeta, MagmaProtocol
+from magma.t import Type, Direction
 
 
 def check_files_equal(callee_file, file1_name, file2_name):
@@ -66,3 +71,38 @@ def has_error(caplog, msg=None):
 
 def has_warning(caplog, msg=None):
     return has_log(caplog, "WARNING", msg)
+
+
+class SimpleMagmaProtocolMeta(MagmaProtocolMeta):
+    _CACHE = {}
+
+    def _to_magma_(cls):
+        return cls.T
+
+    def _qualify_magma_(cls, direction: Direction):
+        return cls[cls.T.qualify(direction)]
+
+    def _flip_magma_(cls):
+        return cls[cls.T.flip()]
+
+    def _from_magma_value_(cls, val: Type):
+        return cls(val)
+
+    def __getitem__(cls, T):
+        return SimpleMagmaProtocolMeta._CACHE.setdefault(
+            T, type(cls)(f"SimpleMagmaProtocol{T}", (cls, ), {"T": T}))
+
+
+class SimpleMagmaProtocol(MagmaProtocol, metaclass=SimpleMagmaProtocolMeta):
+    def __init__(self, val: Optional[Type] = None):
+        if val is None:
+            val = self.T()
+        self._val = val
+
+    def _get_magma_value_(self):
+        return self._val
+
+    def non_standard_operation(self):
+        v0 = self._val << 2
+        v1 = bits(self._val[0], len(self.T)) << 1
+        return SimpleMagmaProtocol(v0 | v1 | bits(self._val[0], len(self.T)))

--- a/tests/test_primitives/test_mux.py
+++ b/tests/test_primitives/test_mux.py
@@ -1,19 +1,16 @@
 import os
 import pytest
-from hwtypes import BitVector
-import hwtypes as ht
-
-import magma as m
-from magma.testing import check_files_equal
-from magma.primitives import Mux
 
 import fault
+import hwtypes as ht
+import magma as m
+from magma.testing import check_files_equal, SimpleMagmaProtocol
 
 
 def test_basic_mux():
     class test_basic_mux(m.Circuit):
         io = m.IO(I=m.In(m.Bits[2]), S=m.In(m.Bit), O=m.Out(m.Bit))
-        io.O @= Mux(2, m.Bit)()(io.I[0], io.I[1], io.S)
+        io.O @= m.Mux(2, m.Bit)()(io.I[0], io.I[1], io.S)
 
     m.compile("build/test_basic_mux", test_basic_mux)
 
@@ -36,7 +33,7 @@ def test_basic_mux():
 def test_basic_mux_bits():
     class test_basic_mux_bits(m.Circuit):
         io = m.IO(I=m.In(m.Array[2, m.Bits[2]]), S=m.In(m.Bit), O=m.Out(m.Bits[2]))
-        io.O @= Mux(2, m.Bits[2])()(io.I[0], io.I[1], io.S)
+        io.O @= m.Mux(2, m.Bits[2])()(io.I[0], io.I[1], io.S)
 
     m.compile("build/test_basic_mux_bits", test_basic_mux_bits)
 
@@ -61,7 +58,7 @@ def test_basic_mux_arr():
 
     class test_basic_mux_arr(m.Circuit):
         io = m.IO(I=m.In(m.Array[2, T]), S=m.In(m.Bit), O=m.Out(T))
-        io.O @= Mux(2, T)()(io.I[0], io.I[1], io.S)
+        io.O @= m.Mux(2, T)()(io.I[0], io.I[1], io.S)
 
     m.compile("build/test_basic_mux_arr", test_basic_mux_arr)
 
@@ -86,7 +83,7 @@ def test_basic_mux_tuple():
 
     class test_basic_mux_tuple(m.Circuit):
         io = m.IO(I=m.In(m.Array[2, T]), S=m.In(m.Bit), O=m.Out(T))
-        io.O @= Mux(2, T)()(io.I[0], io.I[1], io.S)
+        io.O @= m.Mux(2, T)()(io.I[0], io.I[1], io.S)
 
     m.compile("build/test_basic_mux_tuple", test_basic_mux_tuple)
 
@@ -113,7 +110,7 @@ def test_basic_mux_product():
 
     class test_basic_mux_product(m.Circuit):
         io = m.IO(I=m.In(m.Array[2, T]), S=m.In(m.Bit), O=m.Out(T))
-        io.O @= Mux(2, T)()(io.I[0], io.I[1], io.S)
+        io.O @= m.Mux(2, T)()(io.I[0], io.I[1], io.S)
 
     m.compile("build/test_basic_mux_product", test_basic_mux_product)
 
@@ -184,8 +181,8 @@ def test_mux_operator_tuple():
         io = m.IO(S=m.In(m.Bit), O0=m.Out(m.Bit), O1=m.Out(m.Bits[2]),
                   O2=m.Out(m.Bit))
         O0, O1, O2 = m.mux([
-            (True, BitVector[2](3), ht.Bit(0)),
-            (False, BitVector[2](0), ht.Bit(1))
+            (True, ht.BitVector[2](3), ht.Bit(0)),
+            (False, ht.BitVector[2](0), ht.Bit(1))
         ], io.S)
         io.O0 @= O0
         io.O1 @= O1
@@ -210,10 +207,10 @@ def test_mux_operator_tuple():
 
 
 def test_mux_tuple_wire():
-    default = (BitVector.random(3), BitVector.random(5))
+    default = (ht.BitVector.random(3), ht.BitVector.random(5))
     inst_map = {
-        0: (BitVector.random(3), BitVector.random(5)),
-        1: (BitVector.random(3), BitVector.random(5)),
+        0: (ht.BitVector.random(3), ht.BitVector.random(5)),
+        1: (ht.BitVector.random(3), ht.BitVector.random(5)),
     }
 
     class Main(m.Circuit):
@@ -228,11 +225,11 @@ def test_mux_dict_lookup():
         io = m.IO(S=m.In(m.Bits[2]), O=m.Out(m.Bits[5]))
 
         dict_ = {
-            0: BitVector[5](0),
-            2: BitVector[5](2),
-            3: BitVector[5](3)
+            0: ht.BitVector[5](0),
+            2: ht.BitVector[5](2),
+            3: ht.BitVector[5](3)
         }
-        io.O @= m.dict_lookup(dict_, io.S, BitVector[5](1))
+        io.O @= m.dict_lookup(dict_, io.S, ht.BitVector[5](1))
 
     m.compile("build/test_mux_dict_lookup", test_mux_dict_lookup)
 
@@ -251,8 +248,8 @@ def test_mux_list_lookup():
     class test_mux_list_lookup(m.Circuit):
         io = m.IO(S=m.In(m.Bits[2]), O=m.Out(m.Bits[5]))
 
-        list_ = [BitVector[5](0), BitVector[5](1), BitVector[5](2)]
-        io.O @= m.list_lookup(list_, io.S, BitVector[5](3))
+        list_ = [ht.BitVector[5](0), ht.BitVector[5](1), ht.BitVector[5](2)]
+        io.O @= m.list_lookup(list_, io.S, ht.BitVector[5](3))
 
     m.compile("build/test_mux_list_lookup", test_mux_list_lookup)
 
@@ -321,3 +318,18 @@ def test_mux_signed_unsigned():
         assert str(e.value) == (
             "Found incompatible types UInt[16] and SInt[16] in mux inference"
         )
+
+
+def test_mux_protocol():
+    T = SimpleMagmaProtocol[m.Bits[8]]
+
+    class _(m.Circuit):
+        x, y = T(), T()
+        s = m.Bit()
+        out = m.mux([x, y], s)
+        assert isinstance(out, T)
+
+    Mux = m.Mux(2, T)
+    assert isinstance(Mux.I0, m.Out(T))
+    assert isinstance(Mux.I1, m.Out(T))
+    assert isinstance(Mux.O, m.In(T))

--- a/tests/test_syntax/gold/TestSequential2CounterIf.v
+++ b/tests/test_syntax/gold/TestSequential2CounterIf.v
@@ -32,7 +32,7 @@ coreir_reg #(
 );
 endmodule
 
-module Mux2xSInt16 (
+module Mux2x_SequentialRegisterWrapperSInt16 (
     input [15:0] I0,
     input [15:0] I1,
     input S,
@@ -57,7 +57,7 @@ module Test2 (
 );
 wire [15:0] Register_inst0_O;
 wire [15:0] magma_SInt_16_add_inst0_out;
-Mux2xSInt16 Mux2xSInt16_inst0 (
+Mux2x_SequentialRegisterWrapperSInt16 Mux2x_SequentialRegisterWrapperSInt16_inst0 (
     .I0(Register_inst0_O),
     .I1(magma_SInt_16_add_inst0_out),
     .S(sel),

--- a/tests/test_syntax/gold/TestSequential2IteBits.v
+++ b/tests/test_syntax/gold/TestSequential2IteBits.v
@@ -32,6 +32,24 @@ coreir_reg #(
 );
 endmodule
 
+module Mux2x_SequentialRegisterWrapperBits8 (
+    input [7:0] I0,
+    input [7:0] I1,
+    input S,
+    output [7:0] O
+);
+reg [7:0] coreir_commonlib_mux2x8_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x8_inst0_out = I0;
+end else begin
+    coreir_commonlib_mux2x8_inst0_out = I1;
+end
+end
+
+assign O = coreir_commonlib_mux2x8_inst0_out;
+endmodule
+
 module Mux2xTuplea__SequentialRegisterWrapperBits8 (
     input [7:0] I0_a,
     input [7:0] I1_a,
@@ -50,45 +68,27 @@ end
 assign O_a = coreir_commonlib_mux2x8_inst0_out;
 endmodule
 
-module Mux2xBits8 (
-    input [7:0] I0,
-    input [7:0] I1,
-    input S,
-    output [7:0] O
-);
-reg [7:0] coreir_commonlib_mux2x8_inst0_out;
-always @(*) begin
-if (S == 0) begin
-    coreir_commonlib_mux2x8_inst0_out = I0;
-end else begin
-    coreir_commonlib_mux2x8_inst0_out = I1;
-end
-end
-
-assign O = coreir_commonlib_mux2x8_inst0_out;
-endmodule
-
 module Test (
     input CLK,
     output [7:0] O_a,
     input sel
 );
-wire [7:0] Mux2xBits8_inst0_O;
+wire [7:0] Mux2x_SequentialRegisterWrapperBits8_inst0_O;
 wire [7:0] Register_inst0_O;
-Mux2xBits8 Mux2xBits8_inst0 (
-    .I0(Register_inst0_O),
-    .I1(Register_inst0_O),
-    .S(sel),
-    .O(Mux2xBits8_inst0_O)
-);
 Mux2xTuplea__SequentialRegisterWrapperBits8 Mux2xTuplea__SequentialRegisterWrapperBits8_inst0 (
     .I0_a(Register_inst0_O),
     .I1_a(Register_inst0_O),
     .O_a(O_a),
     .S(sel)
 );
+Mux2x_SequentialRegisterWrapperBits8 Mux2x_SequentialRegisterWrapperBits8_inst0 (
+    .I0(Register_inst0_O),
+    .I1(Register_inst0_O),
+    .S(sel),
+    .O(Mux2x_SequentialRegisterWrapperBits8_inst0_O)
+);
 Register Register_inst0 (
-    .I(Mux2xBits8_inst0_O),
+    .I(Mux2x_SequentialRegisterWrapperBits8_inst0_O),
     .O(Register_inst0_O),
     .CLK(CLK)
 );

--- a/tests/test_syntax/gold/TestSequential2IteBits2.v
+++ b/tests/test_syntax/gold/TestSequential2IteBits2.v
@@ -32,6 +32,24 @@ coreir_reg #(
 );
 endmodule
 
+module Mux2x_SequentialRegisterWrapperBits8 (
+    input [7:0] I0,
+    input [7:0] I1,
+    input S,
+    output [7:0] O
+);
+reg [7:0] coreir_commonlib_mux2x8_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x8_inst0_out = I0;
+end else begin
+    coreir_commonlib_mux2x8_inst0_out = I1;
+end
+end
+
+assign O = coreir_commonlib_mux2x8_inst0_out;
+endmodule
+
 module Mux2xTuplea__SequentialRegisterWrapperBits8 (
     input [7:0] I0_a,
     input [7:0] I1_a,
@@ -50,45 +68,27 @@ end
 assign O_a = coreir_commonlib_mux2x8_inst0_out;
 endmodule
 
-module Mux2xBits8 (
-    input [7:0] I0,
-    input [7:0] I1,
-    input S,
-    output [7:0] O
-);
-reg [7:0] coreir_commonlib_mux2x8_inst0_out;
-always @(*) begin
-if (S == 0) begin
-    coreir_commonlib_mux2x8_inst0_out = I0;
-end else begin
-    coreir_commonlib_mux2x8_inst0_out = I1;
-end
-end
-
-assign O = coreir_commonlib_mux2x8_inst0_out;
-endmodule
-
 module Test (
     input CLK,
     output [7:0] O_a,
     input sel
 );
-wire [7:0] Mux2xBits8_inst0_O;
+wire [7:0] Mux2x_SequentialRegisterWrapperBits8_inst0_O;
 wire [7:0] Register_inst0_O;
-Mux2xBits8 Mux2xBits8_inst0 (
-    .I0(Register_inst0_O),
-    .I1(Register_inst0_O),
-    .S(sel),
-    .O(Mux2xBits8_inst0_O)
-);
 Mux2xTuplea__SequentialRegisterWrapperBits8 Mux2xTuplea__SequentialRegisterWrapperBits8_inst0 (
     .I0_a(Register_inst0_O),
     .I1_a(8'h00),
     .O_a(O_a),
     .S(sel)
 );
+Mux2x_SequentialRegisterWrapperBits8 Mux2x_SequentialRegisterWrapperBits8_inst0 (
+    .I0(Register_inst0_O),
+    .I1(Register_inst0_O),
+    .S(sel),
+    .O(Mux2x_SequentialRegisterWrapperBits8_inst0_O)
+);
 Register Register_inst0 (
-    .I(Mux2xBits8_inst0_O),
+    .I(Mux2x_SequentialRegisterWrapperBits8_inst0_O),
     .O(Register_inst0_O),
     .CLK(CLK)
 );

--- a/tests/test_syntax/gold/TestSequential2IteBits3.v
+++ b/tests/test_syntax/gold/TestSequential2IteBits3.v
@@ -34,6 +34,24 @@ coreir_reg #(
 assign O = reg_P1_inst0_out[0];
 endmodule
 
+module Mux2x_SequentialRegisterWrapperBit (
+    input I0,
+    input I1,
+    input S,
+    output O
+);
+reg [0:0] coreir_commonlib_mux2x1_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x1_inst0_out = I0;
+end else begin
+    coreir_commonlib_mux2x1_inst0_out = I1;
+end
+end
+
+assign O = coreir_commonlib_mux2x1_inst0_out[0];
+endmodule
+
 module Mux2xTuplea_Bits8 (
     input [7:0] I0_a,
     input [7:0] I1_a,
@@ -52,37 +70,13 @@ end
 assign O_a = coreir_commonlib_mux2x8_inst0_out;
 endmodule
 
-module Mux2xBit (
-    input I0,
-    input I1,
-    input S,
-    output O
-);
-reg [0:0] coreir_commonlib_mux2x1_inst0_out;
-always @(*) begin
-if (S == 0) begin
-    coreir_commonlib_mux2x1_inst0_out = I0;
-end else begin
-    coreir_commonlib_mux2x1_inst0_out = I1;
-end
-end
-
-assign O = coreir_commonlib_mux2x1_inst0_out[0];
-endmodule
-
 module Test (
     input CLK,
     output [7:0] O_a,
     input sel
 );
-wire Mux2xBit_inst0_O;
+wire Mux2x_SequentialRegisterWrapperBit_inst0_O;
 wire Register_inst0_O;
-Mux2xBit Mux2xBit_inst0 (
-    .I0(Register_inst0_O),
-    .I1(Register_inst0_O),
-    .S(sel),
-    .O(Mux2xBit_inst0_O)
-);
 wire [7:0] Mux2xTuplea_Bits8_inst0_I0_a;
 assign Mux2xTuplea_Bits8_inst0_I0_a = {1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,1'b0,Register_inst0_O};
 wire [7:0] Mux2xTuplea_Bits8_inst0_I1_a;
@@ -93,8 +87,14 @@ Mux2xTuplea_Bits8 Mux2xTuplea_Bits8_inst0 (
     .O_a(O_a),
     .S(sel)
 );
+Mux2x_SequentialRegisterWrapperBit Mux2x_SequentialRegisterWrapperBit_inst0 (
+    .I0(Register_inst0_O),
+    .I1(Register_inst0_O),
+    .S(sel),
+    .O(Mux2x_SequentialRegisterWrapperBit_inst0_O)
+);
 Register Register_inst0 (
-    .I(Mux2xBit_inst0_O),
+    .I(Mux2x_SequentialRegisterWrapperBit_inst0_O),
     .O(Register_inst0_O),
     .CLK(CLK)
 );

--- a/tests/test_syntax/gold/TestSequential2IteComplex.v
+++ b/tests/test_syntax/gold/TestSequential2IteComplex.v
@@ -50,6 +50,42 @@ coreir_reg #(
 assign O = reg_P1_inst0_out[0];
 endmodule
 
+module Mux2x_SequentialRegisterWrapperBits2 (
+    input [1:0] I0,
+    input [1:0] I1,
+    input S,
+    output [1:0] O
+);
+reg [1:0] coreir_commonlib_mux2x2_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x2_inst0_out = I0;
+end else begin
+    coreir_commonlib_mux2x2_inst0_out = I1;
+end
+end
+
+assign O = coreir_commonlib_mux2x2_inst0_out;
+endmodule
+
+module Mux2x_SequentialRegisterWrapperBit (
+    input I0,
+    input I1,
+    input S,
+    output O
+);
+reg [0:0] coreir_commonlib_mux2x1_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x1_inst0_out = I0;
+end else begin
+    coreir_commonlib_mux2x1_inst0_out = I1;
+end
+end
+
+assign O = coreir_commonlib_mux2x1_inst0_out[0];
+endmodule
+
 module Mux2xTuplea_TupleArray2__SequentialRegisterWrapperBit_b_Array2_Bit (
     input [1:0] I0_a__0,
     input [1:0] I0_b,
@@ -72,64 +108,16 @@ assign O_a__0 = coreir_commonlib_mux2x4_inst0_out_unq1[1:0];
 assign O_b = coreir_commonlib_mux2x4_inst0_out_unq1[3:2];
 endmodule
 
-module Mux2xBits2 (
-    input [1:0] I0,
-    input [1:0] I1,
-    input S,
-    output [1:0] O
-);
-reg [1:0] coreir_commonlib_mux2x2_inst0_out;
-always @(*) begin
-if (S == 0) begin
-    coreir_commonlib_mux2x2_inst0_out = I0;
-end else begin
-    coreir_commonlib_mux2x2_inst0_out = I1;
-end
-end
-
-assign O = coreir_commonlib_mux2x2_inst0_out;
-endmodule
-
-module Mux2xBit (
-    input I0,
-    input I1,
-    input S,
-    output O
-);
-reg [0:0] coreir_commonlib_mux2x1_inst0_out;
-always @(*) begin
-if (S == 0) begin
-    coreir_commonlib_mux2x1_inst0_out = I0;
-end else begin
-    coreir_commonlib_mux2x1_inst0_out = I1;
-end
-end
-
-assign O = coreir_commonlib_mux2x1_inst0_out[0];
-endmodule
-
 module Test (
     input CLK,
     output [1:0] O_a__0,
     output [1:0] O_b,
     input sel
 );
-wire Mux2xBit_inst0_O;
-wire [1:0] Mux2xBits2_inst0_O;
+wire Mux2x_SequentialRegisterWrapperBit_inst0_O;
+wire [1:0] Mux2x_SequentialRegisterWrapperBits2_inst0_O;
 wire Register_inst0_O;
 wire [1:0] Register_inst1_O;
-Mux2xBit Mux2xBit_inst0 (
-    .I0(Register_inst0_O),
-    .I1(Register_inst0_O),
-    .S(sel),
-    .O(Mux2xBit_inst0_O)
-);
-Mux2xBits2 Mux2xBits2_inst0 (
-    .I0(Register_inst1_O),
-    .I1(Register_inst1_O),
-    .S(sel),
-    .O(Mux2xBits2_inst0_O)
-);
 wire [1:0] Mux2xTuplea_TupleArray2__SequentialRegisterWrapperBit_b_Array2_Bit_inst0_I0_a__0;
 assign Mux2xTuplea_TupleArray2__SequentialRegisterWrapperBit_b_Array2_Bit_inst0_I0_a__0 = {Register_inst0_O,Register_inst0_O};
 wire [1:0] Mux2xTuplea_TupleArray2__SequentialRegisterWrapperBit_b_Array2_Bit_inst0_I1_b;
@@ -143,13 +131,25 @@ Mux2xTuplea_TupleArray2__SequentialRegisterWrapperBit_b_Array2_Bit Mux2xTuplea_T
     .O_b(O_b),
     .S(sel)
 );
+Mux2x_SequentialRegisterWrapperBit Mux2x_SequentialRegisterWrapperBit_inst0 (
+    .I0(Register_inst0_O),
+    .I1(Register_inst0_O),
+    .S(sel),
+    .O(Mux2x_SequentialRegisterWrapperBit_inst0_O)
+);
+Mux2x_SequentialRegisterWrapperBits2 Mux2x_SequentialRegisterWrapperBits2_inst0 (
+    .I0(Register_inst1_O),
+    .I1(Register_inst1_O),
+    .S(sel),
+    .O(Mux2x_SequentialRegisterWrapperBits2_inst0_O)
+);
 Register Register_inst0 (
-    .I(Mux2xBit_inst0_O),
+    .I(Mux2x_SequentialRegisterWrapperBit_inst0_O),
     .O(Register_inst0_O),
     .CLK(CLK)
 );
 Register_unq1 Register_inst1 (
-    .I(Mux2xBits2_inst0_O),
+    .I(Mux2x_SequentialRegisterWrapperBits2_inst0_O),
     .O(Register_inst1_O),
     .CLK(CLK)
 );

--- a/tests/test_syntax/gold/TestSequential2IteComplexRegister.v
+++ b/tests/test_syntax/gold/TestSequential2IteComplexRegister.v
@@ -39,7 +39,7 @@ assign O_a[0] = reg_P4_inst0_out[1:0];
 assign O_b__0_c = reg_P4_inst0_out[3:2];
 endmodule
 
-module Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit (
+module Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit (
     input [1:0] I0_a [0:0],
     input [1:0] I0_b__0_c,
     input [1:0] I1_a [0:0],
@@ -67,46 +67,46 @@ module Test (
     output [1:0] O_b__0_c,
     input sel
 );
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a [0:0];
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c;
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a [0:0];
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a [0:0];
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c;
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a [0:0];
 wire [1:0] Register_inst0_O_a [0:0];
 wire [1:0] Register_inst0_O_b__0_c;
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a [0:0];
-assign Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a[0] = Register_inst0_O_a[0];
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a [0:0];
-assign Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a[0] = Register_inst0_O_a[0];
-Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0 (
-    .I0_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a),
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a [0:0];
+assign Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a[0] = Register_inst0_O_a[0];
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a [0:0];
+assign Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a[0] = Register_inst0_O_a[0];
+Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0 (
+    .I0_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a),
     .I0_b__0_c(Register_inst0_O_b__0_c),
-    .I1_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a),
+    .I1_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a),
     .I1_b__0_c(Register_inst0_O_b__0_c),
-    .O_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a),
-    .O_b__0_c(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c),
+    .O_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a),
+    .O_b__0_c(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c),
     .S(sel)
 );
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a [0:0];
-assign Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a[0] = Register_inst0_O_a[0];
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a [0:0];
-assign Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a[0] = Register_inst0_O_a[0];
-Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1 (
-    .I0_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a),
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a [0:0];
+assign Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a[0] = Register_inst0_O_a[0];
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a [0:0];
+assign Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a[0] = Register_inst0_O_a[0];
+Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1 (
+    .I0_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a),
     .I0_b__0_c(Register_inst0_O_b__0_c),
-    .I1_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a),
+    .I1_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a),
     .I1_b__0_c(Register_inst0_O_b__0_c),
-    .O_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a),
+    .O_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a),
     .O_b__0_c(O_b__0_c),
     .S(sel)
 );
 wire [1:0] Register_inst0_I_a [0:0];
-assign Register_inst0_I_a[0] = Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a[0];
+assign Register_inst0_I_a[0] = Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a[0];
 Register Register_inst0 (
     .CLK(CLK),
     .I_a(Register_inst0_I_a),
-    .I_b__0_c(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c),
+    .I_b__0_c(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c),
     .O_a(Register_inst0_O_a),
     .O_b__0_c(Register_inst0_O_b__0_c)
 );
-assign O_a[0] = Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a[0];
+assign O_a[0] = Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a[0];
 endmodule
 

--- a/tests/test_syntax/gold/TestSequential2IteComplexRegister2.v
+++ b/tests/test_syntax/gold/TestSequential2IteComplexRegister2.v
@@ -39,7 +39,7 @@ assign O_a[0] = reg_P4_inst0_out[1:0];
 assign O_b__0_c = reg_P4_inst0_out[3:2];
 endmodule
 
-module Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit (
+module Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit (
     input [1:0] I0_a [0:0],
     input [1:0] I0_b__0_c,
     input [1:0] I1_a [0:0],
@@ -67,48 +67,48 @@ module Test (
     output [1:0] O_b__0_c,
     input sel
 );
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a [0:0];
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c;
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a [0:0];
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a [0:0];
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c;
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a [0:0];
 wire [1:0] Register_inst0_O_a [0:0];
 wire [1:0] Register_inst0_O_b__0_c;
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a [0:0];
-assign Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a[0] = Register_inst0_O_a[0];
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a [0:0];
-assign Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a[0] = Register_inst0_O_a[0];
-Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0 (
-    .I0_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a),
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a [0:0];
+assign Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a[0] = Register_inst0_O_a[0];
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a [0:0];
+assign Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a[0] = Register_inst0_O_a[0];
+Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0 (
+    .I0_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I0_a),
     .I0_b__0_c(Register_inst0_O_b__0_c),
-    .I1_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a),
+    .I1_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_I1_a),
     .I1_b__0_c(Register_inst0_O_b__0_c),
-    .O_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a),
-    .O_b__0_c(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c),
+    .O_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a),
+    .O_b__0_c(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c),
     .S(sel)
 );
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a [0:0];
-assign Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a[0] = Register_inst0_O_a[0];
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a [0:0];
-assign Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a[0] = Register_inst0_O_b__0_c;
-wire [1:0] Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_b__0_c;
-assign Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_b__0_c = {Register_inst0_O_a[0][1],1'b0};
-Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1 (
-    .I0_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a),
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a [0:0];
+assign Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a[0] = Register_inst0_O_a[0];
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a [0:0];
+assign Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a[0] = Register_inst0_O_b__0_c;
+wire [1:0] Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_b__0_c;
+assign Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_b__0_c = {Register_inst0_O_a[0][1],1'b0};
+Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1 (
+    .I0_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I0_a),
     .I0_b__0_c(Register_inst0_O_b__0_c),
-    .I1_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a),
-    .I1_b__0_c(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_b__0_c),
-    .O_a(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a),
+    .I1_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_a),
+    .I1_b__0_c(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_I1_b__0_c),
+    .O_a(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a),
     .O_b__0_c(O_b__0_c),
     .S(sel)
 );
 wire [1:0] Register_inst0_I_a [0:0];
-assign Register_inst0_I_a[0] = Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a[0];
+assign Register_inst0_I_a[0] = Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_a[0];
 Register Register_inst0 (
     .CLK(CLK),
     .I_a(Register_inst0_I_a),
-    .I_b__0_c(Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c),
+    .I_b__0_c(Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst0_O_b__0_c),
     .O_a(Register_inst0_O_a),
     .O_b__0_c(Register_inst0_O_b__0_c)
 );
-assign O_a[0] = Mux2xTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a[0];
+assign O_a[0] = Mux2x_SequentialRegisterWrapperTuplea_Array1_Bits2_b_TupleTuplec_Array2_Bit_inst1_O_a[0];
 endmodule
 

--- a/tests/test_syntax/gold/TestSequential2ReturnTuple.v
+++ b/tests/test_syntax/gold/TestSequential2ReturnTuple.v
@@ -32,6 +32,24 @@ coreir_reg #(
 );
 endmodule
 
+module Mux2x_SequentialRegisterWrapperBits4 (
+    input [3:0] I0,
+    input [3:0] I1,
+    input S,
+    output [3:0] O
+);
+reg [3:0] coreir_commonlib_mux2x4_inst0_out;
+always @(*) begin
+if (S == 0) begin
+    coreir_commonlib_mux2x4_inst0_out = I0;
+end else begin
+    coreir_commonlib_mux2x4_inst0_out = I1;
+end
+end
+
+assign O = coreir_commonlib_mux2x4_inst0_out;
+endmodule
+
 module Mux2xBits4 (
     input [3:0] I0,
     input [3:0] I1,
@@ -58,40 +76,40 @@ module Basic (
     input CLK
 );
 wire [3:0] Mux2xBits4_inst0_O;
-wire [3:0] Mux2xBits4_inst1_O;
+wire [3:0] Mux2x_SequentialRegisterWrapperBits4_inst0_O;
 wire [3:0] Register_inst0_O;
 wire [3:0] Register_inst1_O;
 Mux2xBits4 Mux2xBits4_inst0 (
-    .I0(Register_inst0_O),
-    .I1(Register_inst0_O),
+    .I0(I),
+    .I1(I),
     .S(S),
     .O(Mux2xBits4_inst0_O)
 );
 Mux2xBits4 Mux2xBits4_inst1 (
     .I0(I),
-    .I1(I),
+    .I1(Register_inst0_O),
     .S(S),
-    .O(Mux2xBits4_inst1_O)
+    .O(O1)
 );
-Mux2xBits4 Mux2xBits4_inst2 (
+Mux2x_SequentialRegisterWrapperBits4 Mux2x_SequentialRegisterWrapperBits4_inst0 (
+    .I0(Register_inst0_O),
+    .I1(Register_inst0_O),
+    .S(S),
+    .O(Mux2x_SequentialRegisterWrapperBits4_inst0_O)
+);
+Mux2x_SequentialRegisterWrapperBits4 Mux2x_SequentialRegisterWrapperBits4_inst1 (
     .I0(Register_inst0_O),
     .I1(I),
     .S(S),
     .O(O0)
 );
-Mux2xBits4 Mux2xBits4_inst3 (
-    .I0(I),
-    .I1(Register_inst0_O),
-    .S(S),
-    .O(O1)
-);
 Register Register_inst0 (
-    .I(Mux2xBits4_inst1_O),
+    .I(Mux2xBits4_inst0_O),
     .O(Register_inst0_O),
     .CLK(CLK)
 );
 Register Register_inst1 (
-    .I(Mux2xBits4_inst0_O),
+    .I(Mux2x_SequentialRegisterWrapperBits4_inst0_O),
     .O(Register_inst1_O),
     .CLK(CLK)
 );

--- a/tests/test_type/test_magma_protocol.py
+++ b/tests/test_type/test_magma_protocol.py
@@ -1,49 +1,12 @@
-from typing import Optional
-import magma as m
-from magma.testing import check_files_equal
-
-import sys
 import os
+import sys
+from typing import Optional
 
-_CACHE = {}
-class FooMeta(m.MagmaProtocolMeta):
-    def _to_magma_(cls):
-        # Need way to retrieve underlying magma type
-        return cls.T
+import magma as m
+from magma.testing import check_files_equal, SimpleMagmaProtocol
 
-    def _qualify_magma_(cls, direction: m.Direction):
-        # Need way to create a new version (e.g. give me a Foo with the
-        # underlying type qualified to be an input)
-        return cls[cls.T.qualify(direction)]
 
-    def _flip_magma_(cls):
-        # Need way to create a new version (e.g. give me a Foo with the
-        # underlying type qualified to be an input)
-        return cls[cls.T.flip()]
-
-    def _from_magma_value_(cls, val: m.Type):
-        # Need a way to create an instance of Foo from a value, this just
-        # dispatches to the __init__ logic, but you could define any
-        # custom behavior here
-        return cls(val)
-
-    def __getitem__(cls, T):
-        return _CACHE.setdefault(T, type(cls)(f"Foo{T}", (cls, ), {"T": T}))
-
-class Foo(m.MagmaProtocol, metaclass=FooMeta):
-    def __init__(self, val: Optional[m.Type] = None):
-        if val is None:
-            val = self.T()
-        self._val = val
-
-    def _get_magma_value_(self):
-        # Need way to access underlying magma value
-        return self._val
-
-    def non_standard_operation(self):
-        v0 = self._val << 2
-        v1 = m.bits(self._val[0], len(self.T)) << 1
-        return Foo(v0 | v1 | m.bits(self._val[0], len(self.T)))
+T = SimpleMagmaProtocol[m.Bits[8]]
 
 
 def test_foo_type_magma_protocol():
@@ -52,7 +15,7 @@ def test_foo_type_magma_protocol():
         def __init__(self):
             self.reg = m.Register(m.Bits[1])()
 
-        def __call__(self, foo: Foo[m.Bits[8]]) -> Foo[m.Bits[8]]:
+        def __call__(self, foo: T) -> T:
             self.reg = self.reg
             return foo.non_standard_operation()
 
@@ -62,9 +25,10 @@ def test_foo_type_magma_protocol():
 
 
 def test_ite():
+
     @m.sequential2()
     class Bar:
-        def __call__(self, cond: m.Bit, i0: Foo[m.Bits[8]], i1: Foo[m.Bits[8]]) -> Foo[m.Bits[8]]:
+        def __call__(self, cond: m.Bit, i0: T, i1: T) -> T:
             if cond:
                 foo = i0
             else:


### PR DESCRIPTION
Moves protocol conversion from ite to mux, so that it is uniform for all usages for mux. See discussion at https://github.com/phanrahan/magma/pull/980#discussion_r670811208.

Also includes some adjacent cleanup and refactoring (not core to this change).