### PR TITLE
Improve  handling of In(ReadyValid)

### DIFF
--- a/magma/types/ready_valid.py
+++ b/magma/types/ready_valid.py
@@ -96,7 +96,7 @@ class ReadyValidProducerKind(ReadyValidKind):
     def __getitem__(cls, T: Union[Type, MagmaProtocol]):
         fields = {"valid": Out(Bit), "ready": In(Bit)}
         _maybe_add_data(cls, fields, T, Out)
-        t = type(f"{cls}[{T}]", (cls, ), fields)
+        t = type(f"{cls}[{T}]", (cls, cls.__bases__[-1][T],), fields)
         if T is None:
             # Remove deq/no_deq methods if no data.
             t.deq = _deq_error
@@ -172,7 +172,7 @@ class ReadyValidConsumerKind(ReadyValidKind):
     def __getitem__(cls, T: Union[Type, MagmaProtocol]):
         fields = {"valid": In(Bit), "ready": Out(Bit)}
         _maybe_add_data(cls, fields, T, In)
-        t = type(f"{cls}[{T}]", (cls, ), fields)
+        t = type(f"{cls}[{T}]", (cls, cls.__bases__[-1][T],), fields)
         if T is None:
             t.enq = _enq_error
             t.no_enq = _no_enq_error
@@ -246,7 +246,7 @@ class ReadyValidMonitorKind(ReadyValidKind):
     def __getitem__(cls, T: Union[Type, MagmaProtocol]):
         fields = {"valid": In(Bit), "ready": In(Bit)}
         _maybe_add_data(cls, fields, T, In)
-        return type(f"{cls}[{T}]", (cls, ), fields)
+        return type(f"{cls}[{T}]", (cls, ReadyValid[T]), fields)
 
     def flip(cls):
         raise TypeError("Cannot flip Monitor")

--- a/tests/test_type/test_ready_valid.py
+++ b/tests/test_type/test_ready_valid.py
@@ -209,7 +209,6 @@ def test_in_ready_valid():
     assert T.ready.is_input()
     assert T.valid.is_input()
     assert T.data.is_input()
-    T = T.flip()
-    assert T.ready.is_output()
-    assert T.valid.is_output()
-    assert T.data.is_output()
+    with pytest.raises(TypeError) as e:
+        T = T.flip()
+    assert str(e.value) == "Cannot flip Monitor"

--- a/tests/test_type/test_ready_valid.py
+++ b/tests/test_type/test_ready_valid.py
@@ -14,6 +14,7 @@ def test_ready_valid_simple(T):
             fired=m.Out(m.Bit)
         )
         assert isinstance(io.I, T)
+        assert isinstance(io.I, T[m.Bits[5]])
         io.O @= io.I
         io.fired @= io.I.fired() & io.O.fired()
 
@@ -209,6 +210,7 @@ def test_in_ready_valid():
     assert T.ready.is_input()
     assert T.valid.is_input()
     assert T.data.is_input()
+    assert issubclass(T, m.ReadyValid[m.Bits[8]])
     with pytest.raises(TypeError) as e:
         T = T.flip()
     assert str(e.value) == "Cannot flip Monitor"


### PR DESCRIPTION
Fixes #975

Avoids the following inconsistency:
```python
T = m.In(m.ReadyValid)
assert isinstance(T, m.ReadyValid)  # fails!
```

by introducing the concept of ReadyValidMonitor (ala ReadyValid
Producer/Consumer)