### PR TITLE
Resolve regression with ReadyValid.undirected_t

### DIFF
--- a/docs/types_and_values.md
+++ b/docs/types_and_values.md
@@ -153,3 +153,11 @@ Magma provides two subclasses of `ReadyValid` with well defined semantics:
 Magma also provides two aliases:
 * `EnqIO[T]` for `Producer(Decoupled[T])`
 * `DeqIO[T]` for `Consumer(Decoupled[T])`
+
+Beyond `Producer` and `Consumer`, Magma also provides the `Monitor` qualifier
+which takes a ReadyValid type and returns a view of it where all the ports are
+inputs (useful for monitor circuits that want to observe ready valid
+transactions).
+
+`ReadyValid` types provide the standard type property `undirected_t` which
+returns an undirected version of the type.

--- a/docs/types_and_values.md
+++ b/docs/types_and_values.md
@@ -154,10 +154,12 @@ Magma also provides two aliases:
 * `EnqIO[T]` for `Producer(Decoupled[T])`
 * `DeqIO[T]` for `Consumer(Decoupled[T])`
 
-Beyond `Producer` and `Consumer`, Magma also provides the `Monitor` qualifier
-which takes a ReadyValid type and returns a view of it where all the ports are
-inputs (useful for monitor circuits that want to observe ready valid
-transactions).
+Beyond `Producer` and `Consumer`, `ReadyValid` types support the `In` and
+`Monitor` qualifiers which takes a ReadyValid type and returns a view of it
+where all the ports are inputs (useful for monitor circuits that want to
+observe ready valid transactions).
 
 `ReadyValid` types provide the standard type property `undirected_t` which
 returns an undirected version of the type.
+
+`ReadyValid` types do not support the `Out` qualifier.

--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -96,8 +96,7 @@ from magma.primitives import (LUT, Mux, mux, dict_lookup, list_lookup,
                               Memory, set_index, register, Wire)
 
 from magma.types import (BitPattern, Valid, ReadyValid, Consumer, Producer,
-                         Decoupled, EnqIO, DeqIO, Irrevocable)
-from magma.types.ready_valid import Monitor
+                         Decoupled, EnqIO, DeqIO, Irrevocable, Monitor)
 import magma.smart
 from magma.compile_guard import compile_guard
 from magma.set_name import set_name

--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -97,6 +97,7 @@ from magma.primitives import (LUT, Mux, mux, dict_lookup, list_lookup,
 
 from magma.types import (BitPattern, Valid, ReadyValid, Consumer, Producer,
                          Decoupled, EnqIO, DeqIO, Irrevocable)
+from magma.types.ready_valid import Monitor
 import magma.smart
 from magma.compile_guard import compile_guard
 from magma.set_name import set_name

--- a/magma/types/__init__.py
+++ b/magma/types/__init__.py
@@ -1,4 +1,4 @@
 from .bit_pattern import BitPattern
 from .valid import Valid
 from .ready_valid import (ReadyValid, Producer, Consumer, Decoupled, EnqIO,
-                          DeqIO, Irrevocable)
+                          DeqIO, Irrevocable, Monitor)

--- a/magma/types/ready_valid.py
+++ b/magma/types/ready_valid.py
@@ -46,9 +46,11 @@ class ReadyValidKind(ProductKind):
         raise TypeError("Cannot flip an undirected ReadyValid type")
 
     def qualify(cls, direction):
-        if direction is not Direction.In:
-            raise TypeError(f"Cannot qualify ReadyValid with {direction}")
-        return Monitor(cls)
+        if direction is Direction.In:
+            return Monitor(cls)
+        if direction is Direction.Undirected:
+            return Undirected(cls)
+        raise TypeError(f"Cannot qualify ReadyValid with {direction}")
 
     @property
     def undirected_data_t(cls):
@@ -359,6 +361,18 @@ def Monitor(T: ReadyValidKind):
     if issubclass(T, ReadyValid):
         return ReadyValidMonitor[undirected_T]
     raise TypeError(f"Monitor({T}) is unsupported")
+
+
+def Undirected(T: ReadyValidKind):
+    if issubclass(T, ReadyValid):
+        undirected_T = T.undirected_data_t
+    if issubclass(T, Irrevocable):
+        return Irrevocable[undirected_T]
+    if issubclass(T, Decoupled):
+        return Decoupled[undirected_T]
+    if issubclass(T, ReadyValid):
+        return ReadyValid[undirected_T]
+    raise TypeError(f"Undirected({T}) is unsupported")
 
 
 # TODO: QueueIO and Queue

--- a/tests/test_type/test_ready_valid.py
+++ b/tests/test_type/test_ready_valid.py
@@ -204,7 +204,7 @@ def test_ready_valid_none():
     m.compile("build/Foo", Foo)
 
 
-def test_in_ready_valid():
+def test_qualify_ready_valid():
     T = m.Consumer(m.ReadyValid[m.Bits[8]])
     T = m.In(T)
     assert T.ready.is_input()
@@ -214,3 +214,15 @@ def test_in_ready_valid():
     with pytest.raises(TypeError) as e:
         T = T.flip()
     assert str(e.value) == "Cannot flip Monitor"
+
+    T = T.undirected_t
+    assert not T.ready.is_input()
+    assert not T.valid.is_input()
+    assert not T.data.is_input()
+    assert not T.ready.is_output()
+    assert not T.valid.is_output()
+    assert not T.data.is_output()
+    assert not T.ready.is_inout()
+    assert not T.valid.is_inout()
+    assert not T.data.is_inout()
+    assert issubclass(T, m.ReadyValid[m.Bits[8]])

--- a/tests/test_type/test_ready_valid.py
+++ b/tests/test_type/test_ready_valid.py
@@ -215,18 +215,18 @@ def test_qualify_ready_valid(qualifiers, is_valid):
         for q in qualifiers:
             T = q(T)
             assert issubclass(T, m.ReadyValid[m.Bits[8]])
-            if q is m.In:
-                with pytest.raises(TypeError) as e:
-                    T.flip()
-                assert str(e.value) == "Cannot flip Monitor"
-            elif q in (m.Producer, m.Consumer):
+            if q in (m.Producer, m.Consumer):
                 T = T.flip()
                 assert issubclass(T, m.ReadyValid[m.Bits[8]])
             else:
+                if q is m.In:
+                    msg = "Cannot flip Monitor"
+                else:
+                    msg = (
+                        "Cannot flip an undirected ReadyValid type")
                 with pytest.raises(TypeError) as e:
                     T.flip()
-                assert str(e.value) == (
-                    "Cannot flip an undirected ReadyValid type")
+                assert str(e.value) == msg
         return
 
     with pytest.raises(TypeError) as e:


### PR DESCRIPTION
This is used in the product/tuple base class logic (see
https://github.com/leonardt/magma_riscv_mini/runs/3216036083?check_suite_focus=true
for a failure example).  I think it is reasonable to be able to get the
"undirected" version of a ReadyValid and the recent change to the
monitor logic removed this capability.  These changes add back the
capability while preserving the prevention of using the In/Out qualifier.