### PR TITLE
Fix bug in inline_verilog reference of tuple slice

### DIFF
--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -50,10 +50,10 @@ class InlineVerilogError(RuntimeError):
 
 def _insert_temporary_wires(cls, value, inline_wire_prefix):
     """
-    Insert a temporary Wire instance so the signal isn't inlined out
+    Insert a temporary Wire instance so the signal isn't inlined out.
 
     We have to do this for DefnRef because the coreir inline.cpp logic
-    sometimes inserts temporary wires for DefnRef that eventually get inlined
+    sometimes inserts temporary wires for DefnRef that eventually get inlined.
     """
     if isinstance(value, Type):
         if value.is_input():

--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -15,14 +15,6 @@ from magma.wire import wire
 from magma.ref import DefnRef, InstRef, ArrayRef, TupleRef
 
 
-def _get_top_level_ref(ref):
-    if isinstance(ref, ArrayRef):
-        return _get_top_level_ref(ref.array.name)
-    if isinstance(ref, TupleRef):
-        return _get_top_level_ref(ref.tuple.name)
-    return ref
-
-
 def _get_view_inst_parent(view):
     while not isinstance(view, InstView):
         assert isinstance(view, PortView), type(view)
@@ -58,8 +50,10 @@ class InlineVerilogError(RuntimeError):
 
 def _insert_temporary_wires(cls, value, inline_wire_prefix):
     """
-    For non DefnRef, insert a temporary Wire instance so the signal isn't
-    inlined out
+    Insert a temporary Wire instance so the signal isn't inlined out
+
+    We have to do this for DefnRef because the coreir inline.cpp logic
+    sometimes inserts temporary wires for DefnRef that eventually get inlined
     """
     if isinstance(value, Type):
         if value.is_input():
@@ -70,19 +64,18 @@ def _insert_temporary_wires(cls, value, inline_wire_prefix):
                     f"Found reference to undriven input port: "
                     f"{orig_value.debug_name}")
 
-        if not isinstance(_get_top_level_ref(value.name), DefnRef):
-            key = value
-            if isinstance(value, ClockTypes) and not value.driven():
-                # Share wire for undriven clocks so we don't
-                # generate a separate wire for the eventual
-                # driver from the automatic clock wiring logic
-                key = type(value)
-            if key not in cls.inline_verilog_wire_map:
-                temp = _make_temporary(cls, value,
-                                       len(cls.inline_verilog_wire_map),
-                                       inline_wire_prefix)
-                cls.inline_verilog_wire_map[key] = temp
-            value = cls.inline_verilog_wire_map[key]
+        key = value
+        if isinstance(value, ClockTypes) and not value.driven():
+            # Share wire for undriven clocks so we don't
+            # generate a separate wire for the eventual
+            # driver from the automatic clock wiring logic
+            key = type(value)
+        if key not in cls.inline_verilog_wire_map:
+            temp = _make_temporary(cls, value,
+                                   len(cls.inline_verilog_wire_map),
+                                   inline_wire_prefix)
+            cls.inline_verilog_wire_map[key] = temp
+        value = cls.inline_verilog_wire_map[key]
     else:
         assert isinstance(value, PortView)
         if value.port.is_input():

--- a/tests/gold/test_compile_guard_assert.json
+++ b/tests/gold/test_compile_guard_assert.json
@@ -15,7 +15,7 @@
           "Register_inst0":{
             "modref":"global.Register_unq1"
           },
-          "_magma_inline_wire0":{
+          "_FAULT_ASSERT_WIRE_0":{
             "modref":"corebit.wire"
           },
           "const_1_2":{
@@ -53,13 +53,13 @@
           }
         },
         "connections":[
-          ["_magma_inline_wire0.out","ASSERT_ON_compile_guard_inline_verilog_inst_0.__magma_inline_value_0"],
+          ["_FAULT_ASSERT_WIRE_0.out","ASSERT_ON_compile_guard_inline_verilog_inst_0.__magma_inline_value_0"],
           ["self.port_0","Register_inst0.CE"],
           ["self.CLK","Register_inst0.CLK"],
           ["magma_UInt_2_add_inst0.out","Register_inst0.I"],
           ["magma_UInt_2_add_inst0.in0","Register_inst0.O"],
           ["magma_UInt_2_eq_inst0.in0","Register_inst0.O"],
-          ["magma_Bit_or_inst0.out","_magma_inline_wire0.in"],
+          ["magma_Bit_or_inst0.out","_FAULT_ASSERT_WIRE_0.in"],
           ["magma_UInt_2_add_inst0.in1","const_1_2.out"],
           ["magma_UInt_2_eq_inst0.in1","const_3_2.out"],
           ["magma_Bits_4_eq_inst0.in1","const_3_4.out"],

--- a/tests/test_verilog/gold/RTLMonitor.sv
+++ b/tests/test_verilog/gold/RTLMonitor.sv
@@ -13,6 +13,23 @@ module bar_coreir_term #(
 
 endmodule
 
+module bar_foo_WireClock (
+    input I,
+    output O
+);
+wire Wire_inst0;
+wire coreir_wrapInClock_inst0_out;
+assign Wire_inst0 = coreir_wrapInClock_inst0_out;
+bar_coreir_wrap coreir_wrapInClock_inst0 (
+    .in(I),
+    .out(coreir_wrapInClock_inst0_out)
+);
+bar_coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(Wire_inst0),
+    .out(O)
+);
+endmodule
+
 module bar_corebit_term (
     input in
 );
@@ -42,28 +59,47 @@ module bar_foo_RTLMonitor (
     input out,
     input [19:0] tuple_arr [0:0]
 );
-wire _magma_inline_wire0;
-wire [3:0] _magma_inline_wire1;
-wire [3:0] _magma_inline_wire2;
+wire [3:0] _magma_inline_wire0;
+wire _magma_inline_wire1;
+wire _magma_inline_wire10;
+wire _magma_inline_wire2;
+wire _magma_inline_wire3_O;
+wire _magma_inline_wire4;
+wire [3:0] _magma_inline_wire5;
+wire [3:0] _magma_inline_wire6;
+wire [3:0] _magma_inline_wire7;
+wire _magma_inline_wire8;
+wire _magma_inline_wire9;
 wire [3:0] arr_2d_0;
 wire [3:0] arr_2d_1;
-assign _magma_inline_wire0 = arr_2d_0[1];
-assign _magma_inline_wire1 = arr_2d_1;
-assign _magma_inline_wire2 = arr_2d_0;
+assign _magma_inline_wire0 = in1;
+assign _magma_inline_wire1 = intermediate_tuple__0;
+assign _magma_inline_wire10 = handshake_valid;
+assign _magma_inline_wire2 = arr_2d_0[1];
+bar_foo_WireClock _magma_inline_wire3 (
+    .I(CLK),
+    .O(_magma_inline_wire3_O)
+);
+assign _magma_inline_wire4 = out;
+assign _magma_inline_wire5 = arr_2d_1;
+assign _magma_inline_wire6 = arr_2d_0;
+assign _magma_inline_wire7 = inst_input;
+assign _magma_inline_wire8 = mon_temp3;
+assign _magma_inline_wire9 = intermediate_ndarr[1][1];
 assign arr_2d_0 = in1;
 assign arr_2d_1 = in2;
 
 logic temp1, temp2;
 logic temp3;
-assign temp1 = |(in1);
-assign temp2 = &(in1) & intermediate_tuple__0;
-assign temp3 = temp1 ^ temp2 & _magma_inline_wire0;
-assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
+assign temp1 = |(_magma_inline_wire0);
+assign temp2 = &(_magma_inline_wire0) & _magma_inline_wire1;
+assign temp3 = temp1 ^ temp2 & _magma_inline_wire2;
+assert property (@(posedge _magma_inline_wire3_O) _magma_inline_wire10 -> _magma_inline_wire4 === temp1 && temp2);
 logic [3:0] temp4 [1:0];
-assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
-always @(*) $display("%x", inst_input & {4{mon_temp3}});
+assign temp4 = '{_magma_inline_wire5, _magma_inline_wire6};
+always @(*) $display("%x", _magma_inline_wire7 & {4{_magma_inline_wire8}});
 logic temp5;
-assign temp5 = intermediate_ndarr[1][1];
+assign temp5 = _magma_inline_wire9;
                                    
 endmodule
 

--- a/tests/test_verilog/gold/RTLMonitor_unq1.sv
+++ b/tests/test_verilog/gold/RTLMonitor_unq1.sv
@@ -13,6 +13,23 @@ module bar_coreir_term #(
 
 endmodule
 
+module bar_foo_WireClock (
+    input I,
+    output O
+);
+wire Wire_inst0;
+wire coreir_wrapInClock_inst0_out;
+assign Wire_inst0 = coreir_wrapInClock_inst0_out;
+bar_coreir_wrap coreir_wrapInClock_inst0 (
+    .in(I),
+    .out(coreir_wrapInClock_inst0_out)
+);
+bar_coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(Wire_inst0),
+    .out(O)
+);
+endmodule
+
 module bar_corebit_term (
     input in
 );
@@ -42,28 +59,47 @@ module bar_foo_RTLMonitor_unq1 (
     input out,
     input [19:0] tuple_arr [0:0]
 );
-wire _magma_inline_wire0;
-wire [4:0] _magma_inline_wire1;
-wire [4:0] _magma_inline_wire2;
+wire [4:0] _magma_inline_wire0;
+wire _magma_inline_wire1;
+wire _magma_inline_wire10;
+wire _magma_inline_wire2;
+wire _magma_inline_wire3_O;
+wire _magma_inline_wire4;
+wire [4:0] _magma_inline_wire5;
+wire [4:0] _magma_inline_wire6;
+wire [4:0] _magma_inline_wire7;
+wire _magma_inline_wire8;
+wire _magma_inline_wire9;
 wire [4:0] arr_2d_0;
 wire [4:0] arr_2d_1;
-assign _magma_inline_wire0 = arr_2d_0[1];
-assign _magma_inline_wire1 = arr_2d_1;
-assign _magma_inline_wire2 = arr_2d_0;
+assign _magma_inline_wire0 = in1;
+assign _magma_inline_wire1 = intermediate_tuple__0;
+assign _magma_inline_wire10 = handshake_valid;
+assign _magma_inline_wire2 = arr_2d_0[1];
+bar_foo_WireClock _magma_inline_wire3 (
+    .I(CLK),
+    .O(_magma_inline_wire3_O)
+);
+assign _magma_inline_wire4 = out;
+assign _magma_inline_wire5 = arr_2d_1;
+assign _magma_inline_wire6 = arr_2d_0;
+assign _magma_inline_wire7 = inst_input;
+assign _magma_inline_wire8 = mon_temp3;
+assign _magma_inline_wire9 = intermediate_ndarr[1][1];
 assign arr_2d_0 = in1;
 assign arr_2d_1 = in2;
 
 logic temp1, temp2;
 logic temp3;
-assign temp1 = |(in1);
-assign temp2 = &(in1) & intermediate_tuple__0;
-assign temp3 = temp1 ^ temp2 & _magma_inline_wire0;
-assert property (@(posedge CLK) handshake_valid -> out === temp1 && temp2);
+assign temp1 = |(_magma_inline_wire0);
+assign temp2 = &(_magma_inline_wire0) & _magma_inline_wire1;
+assign temp3 = temp1 ^ temp2 & _magma_inline_wire2;
+assert property (@(posedge _magma_inline_wire3_O) _magma_inline_wire10 -> _magma_inline_wire4 === temp1 && temp2);
 logic [4:0] temp4 [1:0];
-assign temp4 = '{_magma_inline_wire1, _magma_inline_wire2};
-always @(*) $display("%x", inst_input & {5{mon_temp3}});
+assign temp4 = '{_magma_inline_wire5, _magma_inline_wire6};
+always @(*) $display("%x", _magma_inline_wire7 & {5{_magma_inline_wire8}});
 logic temp5;
-assign temp5 = intermediate_ndarr[1][1];
+assign temp5 = _magma_inline_wire9;
                                    
 endmodule
 

--- a/tests/test_verilog/gold/TestDisplay.v
+++ b/tests/test_verilog/gold/TestDisplay.v
@@ -11,6 +11,23 @@ module corebit_term (
 
 endmodule
 
+module WireClock (
+    input I,
+    output O
+);
+wire Wire_inst0;
+wire coreir_wrapInClock_inst0_out;
+assign Wire_inst0 = coreir_wrapInClock_inst0_out;
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(I),
+    .out(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(Wire_inst0),
+    .out(O)
+);
+endmodule
+
 module FF(input I, output reg O, input CLK, input CE);
 always @(posedge CLK) begin
   if (CE) O <= I;
@@ -23,6 +40,9 @@ module TestDisplay (
     input CE
 );
 wire _magma_inline_wire0;
+wire _magma_inline_wire1;
+wire _magma_inline_wire2_O;
+wire _magma_inline_wire3;
 FF FF_inst0 (
     .I(I),
     .O(O),
@@ -30,8 +50,14 @@ FF FF_inst0 (
     .CE(CE)
 );
 assign _magma_inline_wire0 = O;
-always @(posedge CLK) begin
-    if (CE) $display("%0t: ff.O=%d, ff.I=%d", $time, _magma_inline_wire0, I);
+assign _magma_inline_wire1 = I;
+WireClock _magma_inline_wire2 (
+    .I(CLK),
+    .O(_magma_inline_wire2_O)
+);
+assign _magma_inline_wire3 = CE;
+always @(posedge _magma_inline_wire2_O) begin
+    if (_magma_inline_wire3) $display("%0t: ff.O=%d, ff.I=%d", $time, _magma_inline_wire0, _magma_inline_wire1);
 end
 
 endmodule

--- a/tests/test_verilog/gold/TestFDisplay.v
+++ b/tests/test_verilog/gold/TestFDisplay.v
@@ -11,6 +11,23 @@ module corebit_term (
 
 endmodule
 
+module WireClock (
+    input I,
+    output O
+);
+wire Wire_inst0;
+wire coreir_wrapInClock_inst0_out;
+assign Wire_inst0 = coreir_wrapInClock_inst0_out;
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(I),
+    .out(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(Wire_inst0),
+    .out(O)
+);
+endmodule
+
 module FF(input I, output reg O, input CLK, input CE);
 always @(posedge CLK) begin
   if (CE) O <= I;
@@ -23,6 +40,9 @@ module TestFDisplay (
     input CE
 );
 wire _magma_inline_wire0;
+wire _magma_inline_wire1;
+wire _magma_inline_wire2_O;
+wire _magma_inline_wire3;
 FF FF_inst0 (
     .I(I),
     .O(O),
@@ -30,12 +50,18 @@ FF FF_inst0 (
     .CE(CE)
 );
 assign _magma_inline_wire0 = O;
+assign _magma_inline_wire1 = I;
+WireClock _magma_inline_wire2 (
+    .I(CLK),
+    .O(_magma_inline_wire2_O)
+);
+assign _magma_inline_wire3 = CE;
 
 integer \_file_test_fdisplay.log ;
 initial \_file_test_fdisplay.log = $fopen("test_fdisplay.log", "a");
 
-always @(posedge CLK) begin
-    if (CE) $fdisplay(\_file_test_fdisplay.log , "ff.O=%d, ff.I=%d", _magma_inline_wire0, I);
+always @(posedge _magma_inline_wire2_O) begin
+    if (_magma_inline_wire3) $fdisplay(\_file_test_fdisplay.log , "ff.O=%d, ff.I=%d", _magma_inline_wire0, _magma_inline_wire1);
 end
 
 

--- a/tests/test_verilog/gold/TestFLog.v
+++ b/tests/test_verilog/gold/TestFLog.v
@@ -11,6 +11,23 @@ module corebit_term (
 
 endmodule
 
+module WireClock (
+    input I,
+    output O
+);
+wire Wire_inst0;
+wire coreir_wrapInClock_inst0_out;
+assign Wire_inst0 = coreir_wrapInClock_inst0_out;
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(I),
+    .out(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(Wire_inst0),
+    .out(O)
+);
+endmodule
+
 module FF(input I, output reg O, input CLK, input CE);
 always @(posedge CLK) begin
   if (CE) O <= I;
@@ -23,6 +40,9 @@ module TestFLog (
     input CE
 );
 wire _magma_inline_wire0;
+wire _magma_inline_wire1;
+wire _magma_inline_wire2_O;
+wire _magma_inline_wire3;
 FF FF_inst0 (
     .I(I),
     .O(O),
@@ -30,6 +50,12 @@ FF FF_inst0 (
     .CE(CE)
 );
 assign _magma_inline_wire0 = O;
+assign _magma_inline_wire1 = I;
+WireClock _magma_inline_wire2 (
+    .I(CLK),
+    .O(_magma_inline_wire2_O)
+);
+assign _magma_inline_wire3 = CE;
 
 `ifndef MAGMA_LOG_LEVEL
     `define MAGMA_LOG_LEVEL 1
@@ -38,20 +64,20 @@ assign _magma_inline_wire0 = O;
 integer \_file_test_flog.log ;
 initial \_file_test_flog.log = $fopen("test_flog.log", "a");
 
-always @(posedge CLK) begin
-    if ((`MAGMA_LOG_LEVEL <= 0) && (CE)) $fdisplay(\_file_test_flog.log , "[DEBUG] ff.O=%d, ff.I=%d", _magma_inline_wire0, I);
+always @(posedge _magma_inline_wire2_O) begin
+    if ((`MAGMA_LOG_LEVEL <= 0) && (_magma_inline_wire3)) $fdisplay(\_file_test_flog.log , "[DEBUG] ff.O=%d, ff.I=%d", _magma_inline_wire0, _magma_inline_wire1);
 end
 
-always @(posedge CLK) begin
-    if ((`MAGMA_LOG_LEVEL <= 1) && (CE)) $fdisplay(\_file_test_flog.log , "[INFO] ff.O=%d, ff.I=%d", _magma_inline_wire0, I);
+always @(posedge _magma_inline_wire2_O) begin
+    if ((`MAGMA_LOG_LEVEL <= 1) && (_magma_inline_wire3)) $fdisplay(\_file_test_flog.log , "[INFO] ff.O=%d, ff.I=%d", _magma_inline_wire0, _magma_inline_wire1);
 end
 
-always @(posedge CLK) begin
-    if ((`MAGMA_LOG_LEVEL <= 2) && (CE)) $fdisplay(\_file_test_flog.log , "[WARNING] ff.O=%d, ff.I=%d", _magma_inline_wire0, I);
+always @(posedge _magma_inline_wire2_O) begin
+    if ((`MAGMA_LOG_LEVEL <= 2) && (_magma_inline_wire3)) $fdisplay(\_file_test_flog.log , "[WARNING] ff.O=%d, ff.I=%d", _magma_inline_wire0, _magma_inline_wire1);
 end
 
-always @(posedge CLK) begin
-    if ((`MAGMA_LOG_LEVEL <= 3) && (CE)) $fdisplay(\_file_test_flog.log , "[ERROR] ff.O=%d, ff.I=%d", _magma_inline_wire0, I);
+always @(posedge _magma_inline_wire2_O) begin
+    if ((`MAGMA_LOG_LEVEL <= 3) && (_magma_inline_wire3)) $fdisplay(\_file_test_flog.log , "[ERROR] ff.O=%d, ff.I=%d", _magma_inline_wire0, _magma_inline_wire1);
 end
 
 

--- a/tests/test_verilog/gold/TestLog.v
+++ b/tests/test_verilog/gold/TestLog.v
@@ -11,6 +11,23 @@ module corebit_term (
 
 endmodule
 
+module WireClock (
+    input I,
+    output O
+);
+wire Wire_inst0;
+wire coreir_wrapInClock_inst0_out;
+assign Wire_inst0 = coreir_wrapInClock_inst0_out;
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(I),
+    .out(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(Wire_inst0),
+    .out(O)
+);
+endmodule
+
 module FF(input I, output reg O, input CLK, input CE);
 always @(posedge CLK) begin
   if (CE) O <= I;
@@ -23,6 +40,9 @@ module TestLog (
     input CE
 );
 wire _magma_inline_wire0;
+wire _magma_inline_wire1;
+wire _magma_inline_wire2_O;
+wire _magma_inline_wire3;
 FF FF_inst0 (
     .I(I),
     .O(O),
@@ -30,24 +50,30 @@ FF FF_inst0 (
     .CE(CE)
 );
 assign _magma_inline_wire0 = O;
+assign _magma_inline_wire1 = I;
+WireClock _magma_inline_wire2 (
+    .I(CLK),
+    .O(_magma_inline_wire2_O)
+);
+assign _magma_inline_wire3 = CE;
 
 `ifndef MAGMA_LOG_LEVEL
     `define MAGMA_LOG_LEVEL 1
 `endif
-always @(posedge CLK) begin
-    if ((`MAGMA_LOG_LEVEL <= 0) && (CE)) $display("[DEBUG] ff.O=%d, ff.I=%d", _magma_inline_wire0, I);
+always @(posedge _magma_inline_wire2_O) begin
+    if ((`MAGMA_LOG_LEVEL <= 0) && (_magma_inline_wire3)) $display("[DEBUG] ff.O=%d, ff.I=%d", _magma_inline_wire0, _magma_inline_wire1);
 end
 
-always @(posedge CLK) begin
-    if ((`MAGMA_LOG_LEVEL <= 1) && (CE)) $display("[INFO] ff.O=%d, ff.I=%d", _magma_inline_wire0, I);
+always @(posedge _magma_inline_wire2_O) begin
+    if ((`MAGMA_LOG_LEVEL <= 1) && (_magma_inline_wire3)) $display("[INFO] ff.O=%d, ff.I=%d", _magma_inline_wire0, _magma_inline_wire1);
 end
 
-always @(posedge CLK) begin
-    if ((`MAGMA_LOG_LEVEL <= 2) && (CE)) $display("[WARNING] ff.O=%d, ff.I=%d", _magma_inline_wire0, I);
+always @(posedge _magma_inline_wire2_O) begin
+    if ((`MAGMA_LOG_LEVEL <= 2) && (_magma_inline_wire3)) $display("[WARNING] ff.O=%d, ff.I=%d", _magma_inline_wire0, _magma_inline_wire1);
 end
 
-always @(posedge CLK) begin
-    if ((`MAGMA_LOG_LEVEL <= 3) && (CE)) $display("[ERROR] ff.O=%d, ff.I=%d", _magma_inline_wire0, I);
+always @(posedge _magma_inline_wire2_O) begin
+    if ((`MAGMA_LOG_LEVEL <= 3) && (_magma_inline_wire3)) $display("[ERROR] ff.O=%d, ff.I=%d", _magma_inline_wire0, _magma_inline_wire1);
 end
 
 endmodule

--- a/tests/test_verilog/gold/test_inline_2d_array_interface.v
+++ b/tests/test_verilog/gold/test_inline_2d_array_interface.v
@@ -1,3 +1,12 @@
+module coreir_wire #(
+    parameter width = 1
+) (
+    input [width-1:0] in,
+    output [width-1:0] out
+);
+  assign out = in;
+endmodule
+
 module coreir_term #(
     parameter width = 1
 ) (
@@ -9,8 +18,456 @@ endmodule
 module MonitorWrapper (
     input [7:0] arr [63:0]
 );
+wire [7:0] _magma_inline_wire0_out;
+wire [7:0] _magma_inline_wire1_out;
+wire [7:0] _magma_inline_wire10_out;
+wire [7:0] _magma_inline_wire11_out;
+wire [7:0] _magma_inline_wire12_out;
+wire [7:0] _magma_inline_wire13_out;
+wire [7:0] _magma_inline_wire14_out;
+wire [7:0] _magma_inline_wire15_out;
+wire [7:0] _magma_inline_wire16_out;
+wire [7:0] _magma_inline_wire17_out;
+wire [7:0] _magma_inline_wire18_out;
+wire [7:0] _magma_inline_wire19_out;
+wire [7:0] _magma_inline_wire2_out;
+wire [7:0] _magma_inline_wire20_out;
+wire [7:0] _magma_inline_wire21_out;
+wire [7:0] _magma_inline_wire22_out;
+wire [7:0] _magma_inline_wire23_out;
+wire [7:0] _magma_inline_wire24_out;
+wire [7:0] _magma_inline_wire25_out;
+wire [7:0] _magma_inline_wire26_out;
+wire [7:0] _magma_inline_wire27_out;
+wire [7:0] _magma_inline_wire28_out;
+wire [7:0] _magma_inline_wire29_out;
+wire [7:0] _magma_inline_wire3_out;
+wire [7:0] _magma_inline_wire30_out;
+wire [7:0] _magma_inline_wire31_out;
+wire [7:0] _magma_inline_wire32_out;
+wire [7:0] _magma_inline_wire33_out;
+wire [7:0] _magma_inline_wire34_out;
+wire [7:0] _magma_inline_wire35_out;
+wire [7:0] _magma_inline_wire36_out;
+wire [7:0] _magma_inline_wire37_out;
+wire [7:0] _magma_inline_wire38_out;
+wire [7:0] _magma_inline_wire39_out;
+wire [7:0] _magma_inline_wire4_out;
+wire [7:0] _magma_inline_wire40_out;
+wire [7:0] _magma_inline_wire41_out;
+wire [7:0] _magma_inline_wire42_out;
+wire [7:0] _magma_inline_wire43_out;
+wire [7:0] _magma_inline_wire44_out;
+wire [7:0] _magma_inline_wire45_out;
+wire [7:0] _magma_inline_wire46_out;
+wire [7:0] _magma_inline_wire47_out;
+wire [7:0] _magma_inline_wire48_out;
+wire [7:0] _magma_inline_wire49_out;
+wire [7:0] _magma_inline_wire5_out;
+wire [7:0] _magma_inline_wire50_out;
+wire [7:0] _magma_inline_wire51_out;
+wire [7:0] _magma_inline_wire52_out;
+wire [7:0] _magma_inline_wire53_out;
+wire [7:0] _magma_inline_wire54_out;
+wire [7:0] _magma_inline_wire55_out;
+wire [7:0] _magma_inline_wire56_out;
+wire [7:0] _magma_inline_wire57_out;
+wire [7:0] _magma_inline_wire58_out;
+wire [7:0] _magma_inline_wire59_out;
+wire [7:0] _magma_inline_wire6_out;
+wire [7:0] _magma_inline_wire60_out;
+wire [7:0] _magma_inline_wire61_out;
+wire [7:0] _magma_inline_wire62_out;
+wire [7:0] _magma_inline_wire63_out;
+wire [7:0] _magma_inline_wire7_out;
+wire [7:0] _magma_inline_wire8_out;
+wire [7:0] _magma_inline_wire9_out;
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire0 (
+    .in(arr[63]),
+    .out(_magma_inline_wire0_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire1 (
+    .in(arr[62]),
+    .out(_magma_inline_wire1_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire10 (
+    .in(arr[53]),
+    .out(_magma_inline_wire10_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire11 (
+    .in(arr[52]),
+    .out(_magma_inline_wire11_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire12 (
+    .in(arr[51]),
+    .out(_magma_inline_wire12_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire13 (
+    .in(arr[50]),
+    .out(_magma_inline_wire13_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire14 (
+    .in(arr[49]),
+    .out(_magma_inline_wire14_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire15 (
+    .in(arr[48]),
+    .out(_magma_inline_wire15_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire16 (
+    .in(arr[47]),
+    .out(_magma_inline_wire16_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire17 (
+    .in(arr[46]),
+    .out(_magma_inline_wire17_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire18 (
+    .in(arr[45]),
+    .out(_magma_inline_wire18_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire19 (
+    .in(arr[44]),
+    .out(_magma_inline_wire19_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire2 (
+    .in(arr[61]),
+    .out(_magma_inline_wire2_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire20 (
+    .in(arr[43]),
+    .out(_magma_inline_wire20_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire21 (
+    .in(arr[42]),
+    .out(_magma_inline_wire21_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire22 (
+    .in(arr[41]),
+    .out(_magma_inline_wire22_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire23 (
+    .in(arr[40]),
+    .out(_magma_inline_wire23_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire24 (
+    .in(arr[39]),
+    .out(_magma_inline_wire24_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire25 (
+    .in(arr[38]),
+    .out(_magma_inline_wire25_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire26 (
+    .in(arr[37]),
+    .out(_magma_inline_wire26_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire27 (
+    .in(arr[36]),
+    .out(_magma_inline_wire27_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire28 (
+    .in(arr[35]),
+    .out(_magma_inline_wire28_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire29 (
+    .in(arr[34]),
+    .out(_magma_inline_wire29_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire3 (
+    .in(arr[60]),
+    .out(_magma_inline_wire3_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire30 (
+    .in(arr[33]),
+    .out(_magma_inline_wire30_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire31 (
+    .in(arr[32]),
+    .out(_magma_inline_wire31_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire32 (
+    .in(arr[31]),
+    .out(_magma_inline_wire32_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire33 (
+    .in(arr[30]),
+    .out(_magma_inline_wire33_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire34 (
+    .in(arr[29]),
+    .out(_magma_inline_wire34_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire35 (
+    .in(arr[28]),
+    .out(_magma_inline_wire35_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire36 (
+    .in(arr[27]),
+    .out(_magma_inline_wire36_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire37 (
+    .in(arr[26]),
+    .out(_magma_inline_wire37_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire38 (
+    .in(arr[25]),
+    .out(_magma_inline_wire38_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire39 (
+    .in(arr[24]),
+    .out(_magma_inline_wire39_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire4 (
+    .in(arr[59]),
+    .out(_magma_inline_wire4_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire40 (
+    .in(arr[23]),
+    .out(_magma_inline_wire40_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire41 (
+    .in(arr[22]),
+    .out(_magma_inline_wire41_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire42 (
+    .in(arr[21]),
+    .out(_magma_inline_wire42_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire43 (
+    .in(arr[20]),
+    .out(_magma_inline_wire43_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire44 (
+    .in(arr[19]),
+    .out(_magma_inline_wire44_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire45 (
+    .in(arr[18]),
+    .out(_magma_inline_wire45_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire46 (
+    .in(arr[17]),
+    .out(_magma_inline_wire46_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire47 (
+    .in(arr[16]),
+    .out(_magma_inline_wire47_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire48 (
+    .in(arr[15]),
+    .out(_magma_inline_wire48_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire49 (
+    .in(arr[14]),
+    .out(_magma_inline_wire49_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire5 (
+    .in(arr[58]),
+    .out(_magma_inline_wire5_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire50 (
+    .in(arr[13]),
+    .out(_magma_inline_wire50_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire51 (
+    .in(arr[12]),
+    .out(_magma_inline_wire51_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire52 (
+    .in(arr[11]),
+    .out(_magma_inline_wire52_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire53 (
+    .in(arr[10]),
+    .out(_magma_inline_wire53_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire54 (
+    .in(arr[9]),
+    .out(_magma_inline_wire54_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire55 (
+    .in(arr[8]),
+    .out(_magma_inline_wire55_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire56 (
+    .in(arr[7]),
+    .out(_magma_inline_wire56_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire57 (
+    .in(arr[6]),
+    .out(_magma_inline_wire57_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire58 (
+    .in(arr[5]),
+    .out(_magma_inline_wire58_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire59 (
+    .in(arr[4]),
+    .out(_magma_inline_wire59_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire6 (
+    .in(arr[57]),
+    .out(_magma_inline_wire6_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire60 (
+    .in(arr[3]),
+    .out(_magma_inline_wire60_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire61 (
+    .in(arr[2]),
+    .out(_magma_inline_wire61_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire62 (
+    .in(arr[1]),
+    .out(_magma_inline_wire62_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire63 (
+    .in(arr[0]),
+    .out(_magma_inline_wire63_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire7 (
+    .in(arr[56]),
+    .out(_magma_inline_wire7_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire8 (
+    .in(arr[55]),
+    .out(_magma_inline_wire8_out)
+);
+coreir_wire #(
+    .width(8)
+) _magma_inline_wire9 (
+    .in(arr[54]),
+    .out(_magma_inline_wire9_out)
+);
 
-monitor #(.WIDTH(8), .DEPTH(64)) monitor_inst(.arr('{arr[63], arr[62], arr[61], arr[60], arr[59], arr[58], arr[57], arr[56], arr[55], arr[54], arr[53], arr[52], arr[51], arr[50], arr[49], arr[48], arr[47], arr[46], arr[45], arr[44], arr[43], arr[42], arr[41], arr[40], arr[39], arr[38], arr[37], arr[36], arr[35], arr[34], arr[33], arr[32], arr[31], arr[30], arr[29], arr[28], arr[27], arr[26], arr[25], arr[24], arr[23], arr[22], arr[21], arr[20], arr[19], arr[18], arr[17], arr[16], arr[15], arr[14], arr[13], arr[12], arr[11], arr[10], arr[9], arr[8], arr[7], arr[6], arr[5], arr[4], arr[3], arr[2], arr[1], arr[0]}));
+monitor #(.WIDTH(8), .DEPTH(64)) monitor_inst(.arr('{_magma_inline_wire0_out, _magma_inline_wire1_out, _magma_inline_wire2_out, _magma_inline_wire3_out, _magma_inline_wire4_out, _magma_inline_wire5_out, _magma_inline_wire6_out, _magma_inline_wire7_out, _magma_inline_wire8_out, _magma_inline_wire9_out, _magma_inline_wire10_out, _magma_inline_wire11_out, _magma_inline_wire12_out, _magma_inline_wire13_out, _magma_inline_wire14_out, _magma_inline_wire15_out, _magma_inline_wire16_out, _magma_inline_wire17_out, _magma_inline_wire18_out, _magma_inline_wire19_out, _magma_inline_wire20_out, _magma_inline_wire21_out, _magma_inline_wire22_out, _magma_inline_wire23_out, _magma_inline_wire24_out, _magma_inline_wire25_out, _magma_inline_wire26_out, _magma_inline_wire27_out, _magma_inline_wire28_out, _magma_inline_wire29_out, _magma_inline_wire30_out, _magma_inline_wire31_out, _magma_inline_wire32_out, _magma_inline_wire33_out, _magma_inline_wire34_out, _magma_inline_wire35_out, _magma_inline_wire36_out, _magma_inline_wire37_out, _magma_inline_wire38_out, _magma_inline_wire39_out, _magma_inline_wire40_out, _magma_inline_wire41_out, _magma_inline_wire42_out, _magma_inline_wire43_out, _magma_inline_wire44_out, _magma_inline_wire45_out, _magma_inline_wire46_out, _magma_inline_wire47_out, _magma_inline_wire48_out, _magma_inline_wire49_out, _magma_inline_wire50_out, _magma_inline_wire51_out, _magma_inline_wire52_out, _magma_inline_wire53_out, _magma_inline_wire54_out, _magma_inline_wire55_out, _magma_inline_wire56_out, _magma_inline_wire57_out, _magma_inline_wire58_out, _magma_inline_wire59_out, _magma_inline_wire60_out, _magma_inline_wire61_out, _magma_inline_wire62_out, _magma_inline_wire63_out}));
                     
 endmodule
 

--- a/tests/test_verilog/gold/test_inline_passthrough_wire.v
+++ b/tests/test_verilog/gold/test_inline_passthrough_wire.v
@@ -1,0 +1,38 @@
+module coreir_term #(
+    parameter width = 1
+) (
+    input [width-1:0] in
+);
+
+endmodule
+
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module Foo (
+    input I_x,
+    input [3:0] I_y,
+    output O_x,
+    output [3:0] O_y
+);
+wire _magma_inline_wire0;
+wire _magma_inline_wire1;
+wire [1:0] _magma_inline_wire2;
+wire [1:0] _magma_inline_wire3;
+assign _magma_inline_wire0 = I_y[0];
+assign _magma_inline_wire1 = I_y[1];
+assign _magma_inline_wire2 = I_y[2:1];
+assign _magma_inline_wire3 = I_y[3:2];
+assign O_x = I_x;
+assign O_y = I_y;
+
+    assert _magma_inline_wire0 == _magma_inline_wire1
+
+
+    assert _magma_inline_wire2 == _magma_inline_wire3
+
+endmodule
+

--- a/tests/test_verilog/gold/test_inline_simple.sv
+++ b/tests/test_verilog/gold/test_inline_simple.sv
@@ -16,17 +16,23 @@ module Main (
     input CLK
 );
 wire _foo_prefix_0;
+wire _foo_prefix_1;
+wire _magma_inline_wire2;
+wire _magma_inline_wire3;
 FF FF_inst0 (
     .I(I),
     .O(O),
     .CLK(CLK)
 );
 assign _foo_prefix_0 = O;
+assign _foo_prefix_1 = I;
+assign _magma_inline_wire2 = arr[0];
+assign _magma_inline_wire3 = arr[1];
 
-assert property (@(posedge CLK) I |-> ##1 _foo_prefix_0);
+assert property (@(posedge CLK) _foo_prefix_1 |-> ##1 _foo_prefix_0);
 
 
-assert property (@(posedge CLK) arr[0] |-> ##1 arr[1]);
+assert property (@(posedge CLK) _magma_inline_wire2 |-> ##1 _magma_inline_wire3);
 
 endmodule
 

--- a/tests/test_verilog/gold/test_inline_tuple.sv
+++ b/tests/test_verilog/gold/test_inline_tuple.sv
@@ -20,10 +20,10 @@ module InnerDelayUnit (
     input OUTPUT_1_ready,
     output OUTPUT_1_valid
 );
-wire _magma_inline_wire4;
-wire _magma_inline_wire5;
-assign _magma_inline_wire4 = OUTPUT_1_valid;
-assign _magma_inline_wire5 = INPUT_0_ready;
+wire _magma_inline_wire6;
+wire _magma_inline_wire7;
+assign _magma_inline_wire6 = OUTPUT_1_valid;
+assign _magma_inline_wire7 = INPUT_0_ready;
 InnerInnerDelayUnit inner_inner_delay (
     .INPUT_0_data(INPUT_1_data),
     .INPUT_0_ready(INPUT_1_ready),
@@ -55,10 +55,10 @@ module DelayUnit (
     input OUTPUT_1_ready,
     output OUTPUT_1_valid
 );
-wire _magma_inline_wire2;
-wire _magma_inline_wire3;
-assign _magma_inline_wire2 = OUTPUT_1_valid;
-assign _magma_inline_wire3 = INPUT_0_ready;
+wire _magma_inline_wire4;
+wire _magma_inline_wire5;
+assign _magma_inline_wire4 = OUTPUT_1_valid;
+assign _magma_inline_wire5 = INPUT_0_ready;
 InnerDelayUnit inner_delay (
     .CLK(CLK),
     .INPUT_0_data(INPUT_1_data),
@@ -93,6 +93,8 @@ module Main (
 );
 wire _magma_inline_wire0;
 wire _magma_inline_wire1;
+wire _magma_inline_wire2;
+wire _magma_inline_wire3;
 DelayUnit DelayUnit_inst0 (
     .CLK(CLK),
     .INPUT_0_data(I_1_data),
@@ -108,11 +110,13 @@ DelayUnit DelayUnit_inst0 (
     .OUTPUT_1_ready(O_0_ready),
     .OUTPUT_1_valid(O_0_valid)
 );
-assign _magma_inline_wire0 = O_0_valid;
-assign _magma_inline_wire1 = I_1_ready;
-assert property (@(posedge CLK) I_0_valid |-> ##3 O_1_ready);
+assign _magma_inline_wire0 = I_0_valid;
+assign _magma_inline_wire1 = O_1_ready;
+assign _magma_inline_wire2 = O_0_valid;
+assign _magma_inline_wire3 = I_1_ready;
 assert property (@(posedge CLK) _magma_inline_wire0 |-> ##3 _magma_inline_wire1);
-assert property (@(posedge CLK) DelayUnit_inst0._magma_inline_wire2.out |-> ##3 DelayUnit_inst0._magma_inline_wire3.out);
-assert property (@(posedge CLK) DelayUnit_inst0.inner_delay._magma_inline_wire4.out |-> ##3 DelayUnit_inst0.inner_delay._magma_inline_wire5.out);
+assert property (@(posedge CLK) _magma_inline_wire2 |-> ##3 _magma_inline_wire3);
+assert property (@(posedge CLK) DelayUnit_inst0._magma_inline_wire4.out |-> ##3 DelayUnit_inst0._magma_inline_wire5.out);
+assert property (@(posedge CLK) DelayUnit_inst0.inner_delay._magma_inline_wire6.out |-> ##3 DelayUnit_inst0.inner_delay._magma_inline_wire7.out);
 endmodule
 

--- a/tests/test_verilog/gold/test_inline_verilog_share_default_clocks.v
+++ b/tests/test_verilog/gold/test_inline_verilog_share_default_clocks.v
@@ -36,16 +36,20 @@ module Foo (
 );
 wire _magma_inline_wire0_O;
 wire _magma_inline_wire1;
+wire _magma_inline_wire2;
+wire _magma_inline_wire3;
 WireClock _magma_inline_wire0 (
     .I(CLK),
     .O(_magma_inline_wire0_O)
 );
 assign _magma_inline_wire1 = RESET;
+assign _magma_inline_wire2 = x;
+assign _magma_inline_wire3 = y;
 
-assert property (@(posedge _magma_inline_wire0_O) disable iff (! _magma_inline_wire1) x |-> ##1 y);
+assert property (@(posedge _magma_inline_wire0_O) disable iff (! _magma_inline_wire1) _magma_inline_wire2 |-> ##1 _magma_inline_wire3);
 
 
-assert property (@(posedge _magma_inline_wire0_O) disable iff (! _magma_inline_wire1) x |-> ##1 y);
+assert property (@(posedge _magma_inline_wire0_O) disable iff (! _magma_inline_wire1) _magma_inline_wire2 |-> ##1 _magma_inline_wire3);
 
 endmodule
 

--- a/tests/test_verilog/gold/test_inline_verilog_unique.v
+++ b/tests/test_verilog/gold/test_inline_verilog_unique.v
@@ -1,3 +1,10 @@
+module corebit_wire (
+    input in,
+    output out
+);
+  assign out = in;
+endmodule
+
 module corebit_term (
     input in
 );
@@ -7,13 +14,23 @@ endmodule
 module Foo_unq1 (
     input I
 );
-always @(*) $display("%x\n", I);
+wire _magma_inline_wire0_out;
+corebit_wire _magma_inline_wire0 (
+    .in(I),
+    .out(_magma_inline_wire0_out)
+);
+always @(*) $display("%x\n", _magma_inline_wire0_out);
 endmodule
 
 module Foo (
     input I
 );
-always @(*) $display("%d\n", I);
+wire _magma_inline_wire0_out;
+corebit_wire _magma_inline_wire0 (
+    .in(I),
+    .out(_magma_inline_wire0_out)
+);
+always @(*) $display("%d\n", _magma_inline_wire0_out);
 endmodule
 
 module Top (


### PR DESCRIPTION
Before this change, magma assumes that a DefnRef will not be inlined
(since ports aren't inlined), so skips emitting a blacklisted temporary
wire.  The problem is that CoreIR's inline passthrough logic sometimes
inserts temporary wires that do get inlined.  Then, in the compiler, the
inline verilog code generation emits a reference to the temporary wire,
which is then inlined without updating the inline verilog code since
it's not part of the AST.

This change avoids the issue by always inserting a blacklisted temporary
wire regardless of what kind of reference there is.  This is actually
seems like a reasonable choice becuase we cannot assume what might
happen downstream in the compiler (i.e. compiler passes should be free
to insert temporary wires where needed, that are then inlined out).
With this change, magma is impervious to these transformations by always
requiring the reference in the inline verilog to be preserved.

Most of these changes are gold files that requried updating with the
introduction of the new inline wires.