### PR TITLE
Improve unconnected error check for nested clocks

### DIFF
--- a/tests/test_circuit/test_new_style_syntax.py
+++ b/tests/test_circuit/test_new_style_syntax.py
@@ -72,7 +72,7 @@ def test_new_style_unconnected(caplog):
         io.x @= 0
 
     assert m.isdefinition(_Foo)
-    assert has_error(caplog, "Interface output port _Foo.O not driven")
+    assert has_error(caplog, "_Foo.O not driven")
 
 
 def test_new_style_with_definition_method(caplog):
@@ -122,8 +122,8 @@ def test_inst_wiring_error(caplog):
     assert has_error(
         caplog,
         "Cannot wire _Foo._Bar_inst0.O (Out(Bits[1])) to _Foo.O (In(Bit))")
-    assert has_error(caplog, "Interface output port _Foo.O not driven")
-    assert has_error(caplog, "Instance input port _Bar_inst0.I not driven")
+    assert has_error(caplog, "_Foo.O not driven")
+    assert has_error(caplog, "_Foo._Bar_inst0.I not driven")
 
 
 def test_nested_definition():

--- a/tests/test_circuit/test_unconnected.py
+++ b/tests/test_circuit/test_unconnected.py
@@ -50,7 +50,7 @@ def _make_unconnected_autowired(typ):
 def test_unconnected_io(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_io()
-        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:8\x1b[0m: Interface output port _Circuit.O not driven
+        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:8\x1b[0m: _Circuit.O not driven
 >>     class _Circuit(m.Circuit):"""
         assert has_error(caplog, expected)
 
@@ -58,7 +58,7 @@ def test_unconnected_io(caplog):
 def test_unconnected_instance(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_instance()
-        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:27\x1b[0m: Instance input port buf.I not driven
+        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:27\x1b[0m: _Circuit.buf.I not driven
 >>         buf = _Buffer()"""
         assert has_error(caplog, expected)
 
@@ -67,4 +67,5 @@ def test_unconnected_instance(caplog):
 def test_unconnected_autowired(typ, caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_autowired(typ)
-        assert not any("not driven" in log.msg for log in caplog.records)
+        msg = "_Circuit.buf.X not driven, will attempt to automatically wire"
+        assert any(msg in log.msg for log in caplog.records)

--- a/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
+++ b/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
@@ -59,7 +59,7 @@ def _make_unconnected_autowired(typ):
 def test_unconnected_io(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_io()
-        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:8\x1b[0m: Interface output port _Circuit.O not driven
+        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:8\x1b[0m: _Circuit.O not driven
 >>     class _Circuit(m.Circuit):"""
         assert has_error(caplog, expected)
 
@@ -67,7 +67,7 @@ def test_unconnected_io(caplog):
 def test_unconnected_instance(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_instance()
-        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:32\x1b[0m: Instance input port buf.I not driven
+        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:32\x1b[0m: _Circuit.buf.I not driven
 >>             buf = _Buffer()"""
         assert has_error(caplog, expected)
 
@@ -76,4 +76,5 @@ def test_unconnected_instance(caplog):
 def test_unconnected_autowired(typ, caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_autowired(typ)
-        assert not any("not driven" in log.msg for log in caplog.records)
+        msg = "_Circuit.buf.X not driven, will attempt to automatically wire"
+        assert any(msg in log.msg for log in caplog.records)

--- a/tests/test_errors/test_tuple_errors.py
+++ b/tests/test_errors/test_tuple_errors.py
@@ -125,7 +125,7 @@ Cannot wire Bits[1](1) (Out(Bits[1])) to Foo.A.x (In(Bits[2]))\
 Cannot wire Bits[3](2) (Out(Bits[3])) to Foo.A.y (In(Bits[4]))\
 """
     assert caplog.messages[2] == """\
-Interface output port Foo.A not driven\
+Foo.A not driven\
 """
 
 
@@ -146,3 +146,23 @@ def test_product_width_mismatch2(caplog):
     assert caplog.messages[0] == """\
 Cannot wire Foo.A.x (Out(Bits[4])) to Foo.A.y (In(Bits[2]))\
 """
+
+
+def test_unwired_mixed(caplog):
+    class T(m.Product):
+        x = m.Out(m.Bit)
+        y = m.In(m.Bit)
+
+    class Foo(m.Circuit):
+        io = m.IO(z=T, I=m.In(m.Bit))
+
+    class Bar(m.Circuit):
+        io = m.IO(z=T, I=m.In(m.Bit), O=m.Out(m.Bit))
+
+        foo = Foo()
+        foo.I @= io.I
+        io.O @= foo.z.x
+
+
+    assert caplog.messages[0] == "Bar.z.x not driven"
+    assert caplog.messages[1] == "Foo_inst0.z.y not driven"

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -189,7 +189,7 @@ def test_hanging_anon_error(caplog):
             assert str(e) == "Found unconnected port: _Foo.O\n_Foo.O: Unconnected"
 
         msg = """\
-\033[1mtests/test_wire/test_errors.py:180\033[0m: Interface output port _Foo.O not driven
+\033[1mtests/test_wire/test_errors.py:180\033[0m: _Foo.O not driven
 >>         class _Foo(m.Circuit):"""
         assert caplog.records[0].msg == msg
         assert has_error(caplog, msg)


### PR DESCRIPTION
Avoids false positive error log for unconnected clock inside a tuple.

Handles mixed direction types in the unconnected check (recurse and
check input children only, rather than seeing top level is unconnected).

Checks children if a recursive type has a nested clock (could be
unconnected at top level but connected for all non-clock children)