### PR TITLE
Ensure unconnected ports raise a compile exception

### DIFF
--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -106,4 +106,4 @@ class DefinitionContext(FinalizableDelegator):
     def finalize(self, defn):
         super().finalize()
         logs = unstage_logger()
-        defn._has_errors_ = any(log[1] is py_logging.ERROR for log in logs)
+        defn._has_errors_ |= any(log[1] is py_logging.ERROR for log in logs)

--- a/tests/test_compile/test_errors.py
+++ b/tests/test_compile/test_errors.py
@@ -1,0 +1,12 @@
+import pytest
+import magma as m
+
+
+def test_undriven():
+    class Foo(m.Circuit):
+        io = m.IO(x=m.Out(m.Bit), y=m.Out(m.Bit))
+        io.x @= 1
+
+    with pytest.raises(m.compile_exception.MagmaCompileException) as e:
+        m.compile("build/Foo", Foo)
+    assert str(e.value) == "Found circuit with errors: Foo"


### PR DESCRIPTION
The unconnected ports logic reported to the error logging, but did not
update the _has_errors_ attribute that was set during definition time
(since this check is done after definition time, the staged logging
logic is not in use).