### PR TITLE
Fix return type for Array wireable functions

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -877,7 +877,7 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         if all(t.const() for t in ts):
             return type(self).flip()(ts)
 
-        return Array[self.N, self.T.flip()](ts)
+        return type(self)[self.N, self.T.flip()](ts)
 
     def _has_elaborated_children(self):
         return bool(self._ts) or bool(self._slices)

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -393,3 +393,16 @@ def test_array2_wire_to_anon():
         for i, driving in enumerate(io.I.driving()):
             assert len(driving) == 1
             assert driving[0] is io.O[i]
+
+
+def test_array2_value_return_type():
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[2]))
+
+    class Bar(m.Circuit):
+        io = m.IO(I=m.In(m.Bit))
+        foo = Foo()
+        foo.I[0] @= io.I
+        foo.I[1] @= io.I
+
+        assert isinstance(foo.I.value(), m.Bits)

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -393,16 +393,3 @@ def test_array2_wire_to_anon():
         for i, driving in enumerate(io.I.driving()):
             assert len(driving) == 1
             assert driving[0] is io.O[i]
-
-
-def test_array2_value_return_type():
-    class Foo(m.Circuit):
-        io = m.IO(I=m.In(m.Bits[2]))
-
-    class Bar(m.Circuit):
-        io = m.IO(I=m.In(m.Bit))
-        foo = Foo()
-        foo.I[0] @= io.I
-        foo.I[1] @= io.I
-
-        assert isinstance(foo.I.value(), m.Bits)

--- a/tests/test_wire/test_introspection.py
+++ b/tests/test_wire/test_introspection.py
@@ -1,0 +1,12 @@
+import magma as m
+import pytest
+
+
+@pytest.mark.parametrize("T", (m.Bits,))
+def test_value_arr_type(T):
+    class Foo(m.Circuit):
+        x = m.Out(T[5])(name="x")
+        y = m.In(T[5])(name="y")
+        for i in range(5):
+            y[i] @= x[4-i]
+        assert isinstance(y.value(), T)


### PR DESCRIPTION
Before, the wireable functions like `value` always returned `Array[N,
T.flip()]`, however in the case of a subclass it's preferable (and
expected by previous behavior) to return the subclass type rather than
the base class `Array` type (i.e. `value` on a `Bits` should return a
`Bits` not an array)