### PR TITLE
Add support for ReadyValid output

### DIFF
--- a/tests/test_type/test_ready_valid.py
+++ b/tests/test_type/test_ready_valid.py
@@ -222,11 +222,8 @@ def test_qualify_ready_valid(qualifiers):
             T = T.flip()
             assert issubclass(T, m.ReadyValid[m.Bits[8]])
         else:
-            if q is m.In:
-                msg = "Cannot flip Monitor"
-            else:
-                msg = (
-                    "Cannot flip an undirected ReadyValid type")
+            msg = (
+                "Cannot flip an undirected ReadyValid type")
             with pytest.raises(TypeError) as e:
                 T.flip()
             assert str(e.value) == msg

--- a/tests/test_type/test_ready_valid.py
+++ b/tests/test_type/test_ready_valid.py
@@ -209,32 +209,24 @@ def test_ready_valid_none():
     m.compile("build/Foo", Foo)
 
 
-@pytest.mark.parametrize("qualifiers,is_valid", [
-    ((m.Consumer, m.Producer, m.In, lambda x: x.undirected_t), True),
-    ((m.Out,), False),
+@pytest.mark.parametrize("qualifiers", [
+    (m.Consumer, m.Producer, m.In, lambda x: x.undirected_t, m.Out)
 ])
-def test_qualify_ready_valid(qualifiers, is_valid):
+def test_qualify_ready_valid(qualifiers):
     T = m.ReadyValid[m.Bits[8]]
 
-    if is_valid:
-        for q in qualifiers:
-            T = q(T)
+    for q in qualifiers:
+        T = q(T)
+        assert issubclass(T, m.ReadyValid[m.Bits[8]])
+        if q in (m.Producer, m.Consumer, m.In, m.Out):
+            T = T.flip()
             assert issubclass(T, m.ReadyValid[m.Bits[8]])
-            if q in (m.Producer, m.Consumer):
-                T = T.flip()
-                assert issubclass(T, m.ReadyValid[m.Bits[8]])
+        else:
+            if q is m.In:
+                msg = "Cannot flip Monitor"
             else:
-                if q is m.In:
-                    msg = "Cannot flip Monitor"
-                else:
-                    msg = (
-                        "Cannot flip an undirected ReadyValid type")
-                with pytest.raises(TypeError) as e:
-                    T.flip()
-                assert str(e.value) == msg
-        return
-
-    with pytest.raises(TypeError) as e:
-        assert len(qualifiers) == 1, "assume one invalid qualifier"
-        qualifiers[0](T)
-    assert str(e.value) == "Cannot qualify ReadyValid with Direction.Out"
+                msg = (
+                    "Cannot flip an undirected ReadyValid type")
+            with pytest.raises(TypeError) as e:
+                T.flip()
+            assert str(e.value) == msg


### PR DESCRIPTION
Turns out we need this for Monitor(ReadyValid), because if we have a
Monitor interface, inside the definition it's actually interpreted as a
"driver" (since the monitor ports are outputs when wiring to internal
logic).