### PR TITLE
Use reduce logic for Array equality

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -1,5 +1,6 @@
 import weakref
 from functools import reduce, lru_cache
+import operator
 from abc import ABCMeta
 from hwtypes import BitVector
 from .common import deprecated
@@ -406,7 +407,8 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
     def __eq__(self, rhs):
         if not isinstance(rhs, ArrayType):
             return False
-        return self.ts == rhs.ts
+        return reduce(operator.and_,
+                      (x == y for x, y in zip(self, rhs)))
 
     @output_only("Cannot use != on an input")
     def __ne__(self, rhs):

--- a/tests/test_type/test_array.py
+++ b/tests/test_type/test_array.py
@@ -212,3 +212,9 @@ def test_array_bv_index():
         io = m.IO(I=m.In(m.Bits[4]), O=m.Out(m.Bit))
         io.O @= io.I[BitVector[2](3)]
         assert io.O.value() is io.I[3]
+
+
+def test_array_equality():
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Array[4, m.Bits[4]]), O=m.Out(m.Array[4, m.Bits[4]]))
+        io.O @= io.I


### PR DESCRIPTION
Using equality of lists (since .ts returns a list of children) will recursively
call equals on the members, but then do a reduction to determine if they're all
equal.  This is problematic in magma since this will call `__bool__` on the
output of the equal operator on the children.  Instead we want to explicitly
perform an and reduction.

This is an example of the error we get with the current logic:
```
tests/test_type/test_array.py:222: in Foo
    io.O @= io.I0 == io.I1
magma/operator_utils.py:12: in _wrapped
    return fn(self, *args, **kwargs)
magma/array.py:410: in __eq__
    return self.ts == rhs.ts
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = .out

    def __bool__(self) -> bool:
        if not self.const():
>           raise ValueError(
                "Converting non-constant magma bit to bool not supported")
E           ValueError: Converting non-constant magma bit to bool not supported

magma/digital.py:234: ValueError
```