### PR TITLE
Use reduce logic for tuple.__eq__

### DIFF
--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -1,5 +1,6 @@
 import itertools
-from functools import lru_cache
+from functools import lru_cache, reduce
+import operator
 from collections import OrderedDict
 from hwtypes.adt import (
     TupleMeta,
@@ -232,7 +233,8 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
         if not isinstance(rhs, type(self)):
             return NotImplemented
         else:
-            return self.ts == rhs.ts
+            return reduce(operator.and_,
+                          (x == y for x, y in zip(self, rhs)))
 
     @output_only("Cannot use != on an input")
     def __ne__(self, rhs):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -1,5 +1,6 @@
 import itertools
 from functools import lru_cache
+import functools
 import operator
 from collections import OrderedDict
 from hwtypes.adt import (

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -234,10 +234,10 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
         if not isinstance(rhs, type(self)):
             return NotImplemented
         else:
-            # NOTE: Use functool.reduce so import * doesn't clobber m.reduce
+            # NOTE: Use functools.reduce so import * doesn't clobber m.reduce
             # from bits
-            return functool.reduce(operator.and_,
-                                   (x == y for x, y in zip(self, rhs)))
+            return functools.reduce(operator.and_,
+                                    (x == y for x, y in zip(self, rhs)))
 
     @output_only("Cannot use != on an input")
     def __ne__(self, rhs):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -1,5 +1,5 @@
 import itertools
-from functools import lru_cache, reduce
+from functools import lru_cache
 import operator
 from collections import OrderedDict
 from hwtypes.adt import (
@@ -233,8 +233,10 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
         if not isinstance(rhs, type(self)):
             return NotImplemented
         else:
-            return reduce(operator.and_,
-                          (x == y for x, y in zip(self, rhs)))
+            # NOTE: Use functool.reduce so import * doesn't clobber m.reduce
+            # from bits
+            return functool.reduce(operator.and_,
+                                   (x == y for x, y in zip(self, rhs)))
 
     @output_only("Cannot use != on an input")
     def __ne__(self, rhs):

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -310,3 +310,11 @@ def test_mixed_direction_wrap():
         io.clocks.clk1 @= m.clock(tff(tff.O ^ 1))
 
     m.compile('build/test_mixed_direction_wrap', Main)
+
+
+def test_recursive_eq():
+    class Foo(m.Circuit):
+        io = m.IO(I0=m.In(m.Tuple[m.Bit, m.Bits[4]]),
+                  I1=m.In(m.Tuple[m.Bit, m.Bits[4]]),
+                  O=m.Out(m.Tuple[m.Bit, m.Bits[4]]))
+        io.O @= io.I0 == io.I1


### PR DESCRIPTION
Same as https://github.com/phanrahan/magma/pull/1024 except for Tuple
this time

Avoids this error:
```
tests/test_type/test_tuple.py:320: in Foo
    io.O @= io.I0 == io.I1
magma/operator_utils.py:12: in _wrapped
    return fn(self, *args, **kwargs)
magma/tuple.py:236: in __eq__
    return self.ts == rhs.ts
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = .out

    def __bool__(self) -> bool:
        if not self.const():
>           raise ValueError(
                "Converting non-constant magma bit to boo
l not supported")
E           ValueError: Converting non-constant magma bit
 to bool not supported
```