### PR TITLE
Fix make_smart for all directed types

### DIFF
--- a/magma/value_utils.py
+++ b/magma/value_utils.py
@@ -41,6 +41,13 @@ class ValueVisitor(WrappedVisitor):
         return _wrap_value(value)
 
 
+class ValueTransformer(ValueVisitor):
+    def generic_visit(self, value):
+        wrapped = _wrap_value(value)
+        args = (self.visit(child) for child in wrapped.children)
+        return type(value)(*args)
+
+
 @dataclasses.dataclass(frozen=True)
 class Selector:
     child: 'Selector'

--- a/tests/test_smart/test_smart_bits.py
+++ b/tests/test_smart/test_smart_bits.py
@@ -310,6 +310,6 @@ def test_make_smart():
     assert type(smart.y[0])._signed == False
 
     # Value checks.
-    assert smart.x._get_magma_value_().value() is value.x
+    assert smart.x._get_magma_value_() is value.x
     for i in range(10):
-        assert smart.y[i]._get_magma_value_().value() is value.y[i]
+        assert smart.y[i]._get_magma_value_() is value.y[i]


### PR DESCRIPTION
Before make_smart implicitly assumed that all incoming values were
outputs (driveable) (this assumption was baked into using @= to
construct smart values rather than the constructor itself).

This change fixes that to work for all directions of types.