### PR TITLE
Fix bug in inline_verilog clock sharing logic

### DIFF
--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -94,7 +94,8 @@ def _insert_temporary_wires(
                     f"{repr(orig_value)}")
 
         key = value
-        is_undriven_clock = isinstance(value, ClockTypes) and value.is_input() and not value.driven()
+        is_undriven_clock = (isinstance(value, ClockTypes) and value.is_input()
+                             and not value.driven())
         if is_undriven_clock:
             # Share wire for undriven clocks so we don't
             # generate a separate wire for the eventual

--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -94,7 +94,8 @@ def _insert_temporary_wires(
                     f"{repr(orig_value)}")
 
         key = value
-        if isinstance(value, ClockTypes) and not value.driven():
+        if (isinstance(value, ClockTypes) and value.is_input()
+                and not value.driven()):
             # Share wire for undriven clocks so we don't
             # generate a separate wire for the eventual
             # driver from the automatic clock wiring logic

--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -94,8 +94,8 @@ def _insert_temporary_wires(
                     f"{repr(orig_value)}")
 
         key = value
-        if (isinstance(value, ClockTypes) and value.is_input()
-                and not value.driven()):
+        is_undriven_clock = isinstance(value, ClockTypes) and value.is_input() and not value.driven()
+        if is_undriven_clock:
             # Share wire for undriven clocks so we don't
             # generate a separate wire for the eventual
             # driver from the automatic clock wiring logic

--- a/tests/test_verilog/gold/test_inline_verilog_clock_output.v
+++ b/tests/test_verilog/gold/test_inline_verilog_clock_output.v
@@ -1,0 +1,49 @@
+module coreir_wrap (
+    input in,
+    output out
+);
+  assign out = in;
+endmodule
+
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module WireClock (
+    input I,
+    output O
+);
+wire Wire_inst0;
+wire coreir_wrapInClock_inst0_out;
+assign Wire_inst0 = coreir_wrapInClock_inst0_out;
+coreir_wrap coreir_wrapInClock_inst0 (
+    .in(I),
+    .out(coreir_wrapInClock_inst0_out)
+);
+coreir_wrap coreir_wrapOutClock_inst0 (
+    .in(Wire_inst0),
+    .out(O)
+);
+endmodule
+
+module Foo (
+    input x,
+    input y
+);
+wire _magma_inline_wire0_O;
+wire _magma_inline_wire1_O;
+WireClock _magma_inline_wire0 (
+    .I(x),
+    .O(_magma_inline_wire0_O)
+);
+WireClock _magma_inline_wire1 (
+    .I(y),
+    .O(_magma_inline_wire1_O)
+);
+
+Foo bar (.x(_magma_inline_wire0_O, .y_magma_inline_wire1_O))
+
+endmodule
+

--- a/tests/test_verilog/test_inline.py
+++ b/tests/test_verilog/test_inline.py
@@ -288,7 +288,7 @@ def test_inline_passthrough_wire():
         T = m.AnonProduct[dict(x=m.Bit, y=m.Bits[4])]
         io = m.IO(I=m.In(T), O=m.Out(T))
         io.O @= io.I
-        
+
         m.inline_verilog("""
     assert {io.I.y[0]} == {io.I.y[1]}
 """)
@@ -299,3 +299,17 @@ def test_inline_passthrough_wire():
     assert m.testing.check_files_equal(
         __file__, f"build/test_inline_passthrough_wire.v",
         f"gold/test_inline_passthrough_wire.v")
+
+
+def test_inline_verilog_clock_output():
+    class Foo(m.Circuit):
+        io = m.IO(x=m.In(m.Clock), y=m.In(m.Clock))
+        m.inline_verilog("""
+Foo bar (.x({io.x}, .y{io.y}))
+""")
+
+    m.compile("build/test_inline_verilog_clock_output", Foo,
+              inline=True)
+    assert m.testing.check_files_equal(
+        __file__, f"build/test_inline_verilog_clock_output.v",
+        f"gold/test_inline_verilog_clock_output.v")


### PR DESCRIPTION
There is logic in inline verilog to share the same wire for default clock that
forgot to check if the clock type was an input.  This caused clock outputs to
be seen as undriven and use the shared wire.  This sharing logic should only be
used for undriven inputs.