### PR TITLE
Fixes issue in handling mixed direction arrays

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -611,7 +611,9 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         o = magma_value(o)
         if not self._check_wireable(o, debug_info):
             return
-        if self._has_elaborated_children() or o._has_elaborated_children():
+        if (self._has_elaborated_children() or
+                o._has_elaborated_children() or
+                self.T.is_mixed()):
             # Ensure the children maintain consistency with the bulk wire
             self._wire_children(o)
         else:

--- a/tests/test_type/gold/test_array2_mixed_direction_slice.v
+++ b/tests/test_type/gold/test_array2_mixed_direction_slice.v
@@ -1,0 +1,28 @@
+module Foo (
+    input I_0_x,
+    output I_0_y,
+    input I_1_x,
+    output I_1_y,
+    input I_2_x,
+    output I_2_y,
+    input I_3_x,
+    output I_3_y,
+    output O_0_x,
+    input O_0_y,
+    output O_1_x,
+    input O_1_y,
+    output O_2_x,
+    input O_2_y,
+    output O_3_x,
+    input O_3_y
+);
+assign I_0_y = O_2_y;
+assign I_1_y = O_3_y;
+assign I_2_y = O_0_y;
+assign I_3_y = O_1_y;
+assign O_0_x = I_2_x;
+assign O_1_x = I_3_x;
+assign O_2_x = I_0_x;
+assign O_3_x = I_1_x;
+endmodule
+

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -393,3 +393,16 @@ def test_array2_wire_to_anon():
         for i, driving in enumerate(io.I.driving()):
             assert len(driving) == 1
             assert driving[0] is io.O[i]
+
+
+def test_mixed_direction_slice(caplog):
+    class T(m.Product):
+        x = m.In(m.Bit)
+        y = m.Out(m.Bit)
+
+    class Foo(m.Circuit):
+        io = m.IO(I=m.Array[4, T], O=m.Array[4, m.Flip(T)])
+        io.O[:2] @= io.I[2:]
+        io.O[2:] @= io.I[:2]
+
+    assert not caplog.records

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -405,4 +405,6 @@ def test_mixed_direction_slice(caplog):
         io.O[:2] @= io.I[2:]
         io.O[2:] @= io.I[:2]
 
-    assert not caplog.records
+    assert not caplog.records, "Should not report an error"
+    _check_compile("test_array2_mixed_direction_slice", Foo, False,
+                   True)


### PR DESCRIPTION
If we wire two arrays of mixed direction, we need to recursively wire
the children, since the Wireable logic doesn't support bi-directional
wiring for the bulk connection.