### PR TITLE
Use stack for nested staged logging

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,3 +10,6 @@ def magma_test():
     clear_cachedFunctions()
     magma.frontend.coreir_.ResetCoreIR()
     magma.generator.reset_generator_cache()
+    # Need to clear the log stack in case there's an error thrown in the middle
+    # and the unstage logic is not reached
+    magma.logging._staged_log_stack.clear()

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,4 @@ def magma_test():
     clear_cachedFunctions()
     magma.frontend.coreir_.ResetCoreIR()
     magma.generator.reset_generator_cache()
-    # Need to clear the log stack in case there's an error thrown in the middle
-    # and the unstage logic is not reached
-    magma.logging._staged_log_stack.clear()
+    magma.logging.flush_all()  # flush all staged logs

--- a/magma/common.py
+++ b/magma/common.py
@@ -22,6 +22,9 @@ class Stack:
     def peek(self):
         return self._stack[-1]
 
+    def __bool__(self) -> bool:
+        return bool(self._stack)
+
 
 class _Ref(object):
     def __init__(self, value):

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -110,3 +110,4 @@ class DefinitionContext(FinalizableDelegator):
         if self._is_staged:
             logs = unstage_logger()
             defn._has_errors_ = any(log[1] is py_logging.ERROR for log in logs)
+            self._is_staged = False

--- a/magma/logging.py
+++ b/magma/logging.py
@@ -1,11 +1,14 @@
 import colorlog
+import contextlib
 import inspect
 import io
 import logging
 import sys
 import traceback
-from .backend.util import make_relative
-from .config import config, EnvConfig
+
+from magma.backend.util import make_relative
+from magma.common import Stack
+from magma.config import config, EnvConfig
 
 
 config._register(
@@ -16,7 +19,7 @@ config._register(
 )
 
 
-_staged_log_stack = []
+_staged_logs_stack = Stack()
 
 
 def _make_bold(string):
@@ -70,6 +73,11 @@ def _get_additional_kwarg(kwargs, key):
         return None
 
 
+def get_staged_logs_stack() -> Stack:
+    global _staged_logs_stack
+    return _staged_logs_stack
+
+
 class _MagmaLogger(logging.Logger):
     """
     Derivative of logging.Logger class, with two additional keyword args:
@@ -78,8 +86,42 @@ class _MagmaLogger(logging.Logger):
     * 'include_traceback': If True, a traceback is printed along with the
        message.
     """
-    @staticmethod
-    def __with_preamble(fn, msg, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._raw = False
+
+    @property
+    def raw(self) -> bool:
+        return self._raw
+
+    @raw.setter
+    def raw(self, raw: bool):
+        self._raw = raw
+
+    @contextlib.contextmanager
+    def as_raw(self):
+        prev_raw = self.raw
+        self.raw = True
+        try:
+            yield self
+        finally:
+            self.raw = prev_raw
+
+    def _log(self, level, msg, args, **kwargs):
+        if not self.raw and self._staged_log(level, msg, args, **kwargs):
+            return
+        self._raw_log(level, msg, args, **kwargs)
+
+    def _staged_log(self, level, msg, args, **kwargs) -> bool:
+        staged_logs_stack = get_staged_logs_stack()
+        try:
+            staged_logs = staged_logs_stack.peek()
+        except IndexError:
+            return False
+        staged_logs.append((self, level, msg, args, kwargs))
+        return True
+
+    def _raw_log(self, level, msg, args, **kwargs):
         debug_info = _get_additional_kwarg(kwargs, "debug_info")
         if debug_info:
             msg = _attach_debug_info(msg, debug_info)
@@ -87,44 +129,7 @@ class _MagmaLogger(logging.Logger):
         if include_traceback or config.include_traceback:
             msg = _attach_traceback(
                 msg, _frame_selector, config.traceback_limit)
-        fn(msg, *args, **kwargs)
-
-    def log(self, level, msg, *args, **kwargs):
-        key = logging.getLevelName(level).lower()
-        fn = getattr(_MagmaLogger, key)
-        fn(self, msg, *args, **kwargs)
-
-    def debug(self, msg, *args, **kwargs):
-        global _staged_log_stack
-        if _staged_log_stack:
-            _staged_log_stack[-1].append((self, logging.DEBUG, msg, args,
-                                          kwargs))
-            return
-        _MagmaLogger.__with_preamble(super().debug, msg, *args, **kwargs)
-
-    def info(self, msg, *args, **kwargs):
-        global _staged_log_stack
-        if _staged_log_stack:
-            _staged_log_stack[-1].append((self, logging.INFO, msg, args,
-                                          kwargs))
-            return
-        _MagmaLogger.__with_preamble(super().info, msg, *args, **kwargs)
-
-    def warning(self, msg, *args, **kwargs):
-        global _staged_log_stack
-        if _staged_log_stack:
-            _staged_log_stack[-1].append((self, logging.WARNING, msg, args,
-                                          kwargs))
-            return
-        _MagmaLogger.__with_preamble(super().warning, msg, *args, **kwargs)
-
-    def error(self, msg, *args, **kwargs):
-        global _staged_log_stack
-        if _staged_log_stack:
-            _staged_log_stack[-1].append((self, logging.ERROR, msg, args,
-                                          kwargs))
-            return
-        _MagmaLogger.__with_preamble(super().error, msg, *args, **kwargs)
+        super()._log(level, msg, args, **kwargs)
 
 
 # Set logging class to _MagmaLogger to override logging behavior. Also, setup
@@ -139,22 +144,32 @@ _root_logger.addHandler(_handler)
 _root_logger.setLevel(config.log_level)
 
 
-def flush():
-    global _staged_log_stack
-    curr_logs = _staged_log_stack.pop()
-    for logger, level, obj, args, kwargs in curr_logs:
-        logger.log(level, obj, *args, **kwargs)
-    return curr_logs
-
-
 def root_logger():
     return logging.getLogger("magma")
 
 
 def stage_logger():
-    global _staged_log_stack
-    _staged_log_stack.append([])
+    get_staged_logs_stack().push([])
+
+
+def _flush(staged_logs):
+    for logger, level, obj, args, kwargs in staged_logs:
+        with logger.as_raw():
+            logger.log(level, obj, *args, **kwargs)
+
+
+def flush():
+    staged_logs = get_staged_logs_stack().pop()
+    _flush(staged_logs)
+    return staged_logs
 
 
 def unstage_logger():
     return flush()
+
+
+def flush_all():
+    staged_logs_stack = get_staged_logs_stack()
+    while staged_logs_stack:
+        staged_logs = staged_logs_stack.pop()
+        _flush(staged_logs)

--- a/magma/placer.py
+++ b/magma/placer.py
@@ -47,6 +47,10 @@ class PlacerBase(ABC):
     def instances(self):
         raise NotImplementedError()
 
+    @abstractmethod
+    def is_staged(self) -> bool:
+        raise NotImplementedError()
+
 
 def _setup_view(inst):
     inst_view = InstView(inst)
@@ -135,6 +139,9 @@ class Placer:
             inst.stack = inspect.stack()
         _setup_view(inst)
 
+    def is_staged(self) -> bool:
+        return False
+
     def finalize(self, defn):
         if self._finalized:
             raise Exception("Can only call finalize on a placer once")
@@ -160,6 +167,9 @@ class StagedPlacer(ABC):
         self._instances.append(inst)
         inst.defn = LazyCircuit
         _setup_view(inst)
+
+    def is_staged(self) -> bool:
+        return True
 
     def finalize(self, defn):
         if self._finalized:

--- a/tests/test_generator2.py
+++ b/tests/test_generator2.py
@@ -8,7 +8,7 @@ class _MyMux(m.Generator2):
     def __init__(self, width, height):
         self.width = width
         self.height = height
-        sel_bits = m.math.log2_ceil(height)
+        sel_bits = m.bitutils.clog2(height)
         self.name = f"MyMux{width}x{height}"
         args = {f"I{i}": m.In(m.Bits[width]) for i in range(height)}
         args["O"] = m.Out(m.Bits[width])
@@ -92,3 +92,24 @@ def test_no_cache():
     my_gen_other = _MyGen()
     assert my_gen is not my_gen_other
     assert repr(my_gen) == repr(my_gen_other)
+
+
+def test_nested_generator_wiring_log(caplog):
+    class Bar(m.Generator2):
+        def __init__(self):
+            self.io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+            self.io.O @= self.io.I
+
+    class Foo(m.Generator2):
+        def __init__(self):
+            self.io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+            Bar()
+            self.io.O @= self.io.I
+            self.io.O @= self.io.I
+
+    Foo()
+
+    expected = """\
+Wiring multiple outputs to same wire, using last connection. Input: Foo.O, Old Output: Foo.I, New Output: Foo.I\
+"""
+    assert caplog.records[0].message == expected

--- a/tests/test_generator2.py
+++ b/tests/test_generator2.py
@@ -92,24 +92,3 @@ def test_no_cache():
     my_gen_other = _MyGen()
     assert my_gen is not my_gen_other
     assert repr(my_gen) == repr(my_gen_other)
-
-
-def test_nested_generator_wiring_log(caplog):
-    class Bar(m.Generator2):
-        def __init__(self):
-            self.io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
-            self.io.O @= self.io.I
-
-    class Foo(m.Generator2):
-        def __init__(self):
-            self.io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
-            Bar()
-            self.io.O @= self.io.I
-            self.io.O @= self.io.I
-
-    Foo()
-
-    expected = """\
-Wiring multiple outputs to same wire, using last connection. Input: Foo.O, Old Output: Foo.I, New Output: Foo.I\
-"""
-    assert caplog.records[0].message == expected

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,52 @@
+import magma as m
+
+from magma.logging import root_logger, stage_logger, unstage_logger
+from magma.testing.utils import has_info
+
+
+class _NamedObject:
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self):
+        return self.name
+
+
+def test_basic_staging(caplog):
+    msg = _NamedObject("foo")
+    logger = root_logger()
+
+    # First do a sanity check that staged logging without any modifications to
+    # the staged object logs as expected.
+    stage_logger()
+    logger.info(msg)
+    unstage_logger()
+    assert caplog.records[-1].message == "foo"
+
+    # Next check that modifying the object *after* staging & logging, but
+    # *before* unstaging, logs the modified obejct.
+    stage_logger()
+    logger.info(msg)
+    msg.name = "bar"
+    unstage_logger()
+    assert caplog.records[-1].message == "bar"
+
+
+def test_nested_staging(caplog):
+    msg = _NamedObject("foo")
+    logger = root_logger()
+
+    # Check that interleaving logging within unstaging works as expected. After
+    # the first logger is unstaged, the log should be flushed to console, but
+    # the outer logger should remain staged. Therefore, we should see one log
+    # with "foo" right after the first unstage, and one log with "bar" after the
+    # next unstage.
+    stage_logger()
+    stage_logger()
+    logger.info(msg)
+    unstage_logger()
+    assert caplog.records[-1].message == "foo"
+    logger.info(msg)
+    msg.name = "bar"
+    unstage_logger()
+    assert caplog.records[-1].message == "bar"


### PR DESCRIPTION
Before, if we used a staged logger inside an active staged logger, the
unstage logic would clear the parent logger.  This updates the code to
use a stack approach to support nested staged loggers.