### PR TITLE
Fix bug in enumerate children slice index logic

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -772,9 +772,10 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
             slice_T = type(self)[slice_.stop - slice_.start, self.T]
             slice_value = slice_T(name=ArrayRef(self, slice_))
             self._slices[key] = slice_value
-            if not self._resolve_overlapping_indices(slice_, slice_value):
-                self._slices_by_start_index[key[0]] = (slice_, slice_value)
-                self._unresolved_slices[key] = slice_value
+            if self._resolve_overlapping_indices(slice_, slice_value):
+                return slice_value
+            self._slices_by_start_index[key[0]] = (slice_, slice_value)
+            self._unresolved_slices[key] = slice_value
         return slice_value
 
     def _normalize_slice_key(self, key):

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -457,5 +457,4 @@ def test_slice_instref(caplog):
         bar.I @= io.I[2:]
         io.O[2:] @= bar.O
         io.O[:2] @= bar.O
-        assert list(io.O.trace().connection_iter()) == [
-            (bar.O, None), (bar.O, None)]
+        assert io.O.value().driven() is False

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -457,5 +457,5 @@ def test_slice_instref(caplog):
         bar.I @= io.I[2:]
         io.O[2:] @= bar.O
         io.O[:2] @= bar.O
-        assert list(io.O.trace().connection_iter()) == [(bar.O, None), (bar.O,
-                                                                        None)]
+        assert list(io.O.trace().connection_iter()) == [
+            (bar.O, None), (bar.O, None)]

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -444,3 +444,18 @@ def test_mixed_direction_slice(caplog):
     assert not caplog.records, "Should not report an error"
     _check_compile("test_array2_mixed_direction_slice", Foo, False,
                    True)
+
+
+def test_slice_instref(caplog):
+    class Bar(m.Circuit):
+        io = m.IO(I=m.In(m.Array[2, m.Bit]), O=m.Out(m.Array[2, m.Bit]))
+
+    class Foo(m.Circuit):
+        T = m.Array[4, m.Bit]
+        io = m.IO(I=m.In(T), O=m.Out(T))
+        bar = Bar()
+        bar.I @= io.I[2:]
+        io.O[2:] @= bar.O
+        io.O[:2] @= bar.O
+        assert list(io.O.trace().connection_iter()) == [(bar.O, None), (bar.O,
+                                                                        None)]


### PR DESCRIPTION
Before, we assumed the value of the slice was itself a slice object, but
after the changes in https://github.com/phanrahan/magma/pull/1045 this
is no longer true since an Array can be constructed with an
existing value as the slice.

The included shows one such case, where two slices are wired up to
InstRef values, and calling trace() returns an object where the slice
value is an instref.

This updates the logic to store the original slice_ key with the slice_
value in the data structure used for the slice lookup.