### PR TITLE
Prototype inline_comb2

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -105,3 +105,4 @@ from magma.circuit_utils import circuit_stub, stubify, CircuitStub
 from magma.compile import MagmaCompileException
 from magma.linking import link_module, link_default_module, clear_link_info
 import magma.math
+from magma.syntax.inline_combinational2 import inline_combinational2

--- a/magma/array.py
+++ b/magma/array.py
@@ -864,7 +864,7 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
             result = arr._get_slice(slice(offset + key.start,
                                           offset + key.stop))
         else:
-            raise NotImplementedError(key, type(key))
+            return super().__getitem__(key)
         self._resolve_bulk_wire()
         return result
 

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -33,6 +33,7 @@ from magma.ref import TempNamedRef
 from magma.t import In
 from magma.view import PortView
 from magma.wire_container import WiringLog
+from magma.syntax.inline_combinational2 import process_inline_comb_fn
 
 
 __all__ = ['AnonymousCircuitType']
@@ -253,6 +254,9 @@ class CircuitKind(type):
 
         cls._syntax_style_ = _SyntaxStyle.NONE
         cls._renamed_ports_ = dct["renamed_ports"]
+        for key, value in dct.items():
+            if getattr(value, "_magma_inline_combinational_", False):
+                process_inline_comb_fn(cls, value)
         try:
             context = _definition_context_stack.pop()
         except IndexError:  # no staged placer

--- a/magma/syntax/inline_combinational2.py
+++ b/magma/syntax/inline_combinational2.py
@@ -5,7 +5,7 @@ import functools
 from magma.ast_utils import get_ast
 
 
-class SelfReferenceCollector(ast.NodeVisitor):
+class ClsReferenceCollector(ast.NodeVisitor):
     def __init__(self):
         self.references = set()
 
@@ -17,12 +17,12 @@ class SelfReferenceCollector(ast.NodeVisitor):
     def _get_attrs(self, node):
         if isinstance(node, ast.Attribute):
             return self._get_attrs(node.value) + (node.attr, )
-        assert isinstance(node, ast.Name) and node.id == "self"
+        assert isinstance(node, ast.Name) and node.id == "cls"
         return tuple()
 
     def visit_Attribute(self, node):
         leaf = self._get_leaf(node.value)
-        if not (isinstance(leaf, ast.Name) and leaf.id == "self"):
+        if not (isinstance(leaf, ast.Name) and leaf.id == "cls"):
             return
         self.references.add(self._get_attrs(node))
 
@@ -34,7 +34,7 @@ def inline_combinational2(fn):
 
 def process_inline_comb_fn(defn, fn):
     tree = get_ast(fn)
-    collector = SelfReferenceCollector()
+    collector = ClsReferenceCollector()
     collector.visit(tree)
     values = []
     for ref in collector.references:

--- a/magma/syntax/inline_combinational2.py
+++ b/magma/syntax/inline_combinational2.py
@@ -37,7 +37,7 @@ def process_inline_comb_fn(defn, fn):
     collector = ClsReferenceCollector()
     collector.visit(tree)
     values = []
-    for ref in collector.references:
+    for ref in sorted(collector.references):
         values.append(functools.reduce(lambda x, y: getattr(x, y), ref, defn))
 
     import magma as m  # TODO(leonardt): Can we avoid this circular ref?

--- a/magma/syntax/inline_combinational2.py
+++ b/magma/syntax/inline_combinational2.py
@@ -1,0 +1,58 @@
+import ast
+import astor
+import functools
+
+from magma.ast_utils import get_ast
+
+
+class SelfReferenceCollector(ast.NodeVisitor):
+    def __init__(self):
+        self.references = set()
+
+    def _get_leaf(self, node):
+        if isinstance(node, ast.Attribute):
+            return self._get_leaf(node.value)
+        return node
+
+    def _get_attrs(self, node):
+        if isinstance(node, ast.Attribute):
+            return self._get_attrs(node.value) + (node.attr, )
+        assert isinstance(node, ast.Name) and node.id == "self"
+        return tuple()
+
+    def visit_Attribute(self, node):
+        leaf = self._get_leaf(node.value)
+        if not (isinstance(leaf, ast.Name) and leaf.id == "self"):
+            return
+        self.references.add(self._get_attrs(node))
+
+
+def inline_combinational2(fn):
+    fn._magma_inline_combinational_ = True
+    return fn
+
+
+def process_inline_comb_fn(defn, fn):
+    tree = get_ast(fn)
+    collector = SelfReferenceCollector()
+    collector.visit(tree)
+    values = []
+    for ref in collector.references:
+        values.append(functools.reduce(lambda x, y: getattr(x, y), ref, defn))
+
+    import magma as m  # TODO(leonardt): Can we avoid this circular ref?
+
+    class InlineCombWrapper(m.Circuit):
+        io = m.IO()
+        for i, value in enumerate(values):
+            io += m.IO(**{f"v{i}": type(value).flip()})
+        for i, value in enumerate(values):
+            if value.is_input():
+                getattr(io, f"v{i}").undriven()
+        _magma_inline_combinational_ast_ = tree
+        m.inline_verilog("// " +
+                         "\n// ".join(astor.to_source(tree).splitlines()))
+
+    inst = InlineCombWrapper()
+    for i, value in enumerate(values):
+        m.wire(getattr(inst, f"v{i}"), value)

--- a/tests/test_syntax/gold/test_inline_comb_basic2.v
+++ b/tests/test_syntax/gold/test_inline_comb_basic2.v
@@ -34,11 +34,11 @@ corebit_undriven corebit_undriven_inst0 (
 );
 assign v0 = corebit_undriven_inst0_out;
 // @m.inline_combinational2
-// def logic(self):
-//     if self.io.I:
-//         self.io.O @= 0
+// def logic(cls):
+//     if cls.io.I:
+//         cls.io.O @= 0
 //     else:
-//         self.io.O @= 1
+//         cls.io.O @= 1
 endmodule
 
 module Foo (

--- a/tests/test_syntax/gold/test_inline_comb_basic2.v
+++ b/tests/test_syntax/gold/test_inline_comb_basic2.v
@@ -19,8 +19,8 @@ module corebit_const #(
 endmodule
 
 module InlineCombWrapper (
-    output v0,
-    input v1
+    input v0,
+    output v1
 );
 wire bit_const_0_None_out;
 wire corebit_undriven_inst0_out;
@@ -32,7 +32,7 @@ corebit_const #(
 corebit_undriven corebit_undriven_inst0 (
     .out(corebit_undriven_inst0_out)
 );
-assign v0 = corebit_undriven_inst0_out;
+assign v1 = corebit_undriven_inst0_out;
 // @m.inline_combinational2
 // def logic(cls):
 //     if cls.io.I:
@@ -45,11 +45,11 @@ module Foo (
     input I,
     output O
 );
-wire InlineCombWrapper_inst0_v0;
+wire InlineCombWrapper_inst0_v1;
 InlineCombWrapper InlineCombWrapper_inst0 (
-    .v0(InlineCombWrapper_inst0_v0),
-    .v1(I)
+    .v0(I),
+    .v1(InlineCombWrapper_inst0_v1)
 );
-assign O = InlineCombWrapper_inst0_v0;
+assign O = InlineCombWrapper_inst0_v1;
 endmodule
 

--- a/tests/test_syntax/gold/test_inline_comb_basic2.v
+++ b/tests/test_syntax/gold/test_inline_comb_basic2.v
@@ -1,0 +1,55 @@
+module corebit_undriven (
+    output out
+);
+
+endmodule
+
+module corebit_term (
+    input in
+);
+
+endmodule
+
+module corebit_const #(
+    parameter value = 1
+) (
+    output out
+);
+  assign out = value;
+endmodule
+
+module InlineCombWrapper (
+    output v0,
+    input v1
+);
+wire bit_const_0_None_out;
+wire corebit_undriven_inst0_out;
+corebit_const #(
+    .value(1'b0)
+) bit_const_0_None (
+    .out(bit_const_0_None_out)
+);
+corebit_undriven corebit_undriven_inst0 (
+    .out(corebit_undriven_inst0_out)
+);
+assign v0 = corebit_undriven_inst0_out;
+// @m.inline_combinational2
+// def logic(self):
+//     if self.io.I:
+//         self.io.O @= 0
+//     else:
+//         self.io.O @= 1
+endmodule
+
+module Foo (
+    input I,
+    output O
+);
+wire InlineCombWrapper_inst0_v0;
+InlineCombWrapper InlineCombWrapper_inst0 (
+    .v0(InlineCombWrapper_inst0_v0),
+    .v1(I)
+);
+assign O = InlineCombWrapper_inst0_v0;
+endmodule
+

--- a/tests/test_syntax/test_inline_comb2.py
+++ b/tests/test_syntax/test_inline_comb2.py
@@ -1,0 +1,18 @@
+import magma as m
+from magma.testing import check_files_equal
+
+
+def test_inline_comb2_basic():
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+
+        @m.inline_combinational2
+        def logic(self):
+            if self.io.I:
+                self.io.O @= 0
+            else:
+                self.io.O @= 1
+
+    m.compile("build/test_inline_comb_basic2", Foo)
+    assert check_files_equal(__file__, "build/test_inline_comb_basic2.v",
+                             "gold/test_inline_comb_basic2.v")

--- a/tests/test_syntax/test_inline_comb2.py
+++ b/tests/test_syntax/test_inline_comb2.py
@@ -6,12 +6,14 @@ def test_inline_comb2_basic():
     class Foo(m.Circuit):
         io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
 
+        # TODO(leonardt): Using classmethod decorator breaks ast inspect
+        # @classmethod
         @m.inline_combinational2
-        def logic(self):
-            if self.io.I:
-                self.io.O @= 0
+        def logic(cls):
+            if cls.io.I:
+                cls.io.O @= 0
             else:
-                self.io.O @= 1
+                cls.io.O @= 1
 
     m.compile("build/test_inline_comb_basic2", Foo)
     assert check_files_equal(__file__, "build/test_inline_comb_basic2.v",


### PR DESCRIPTION
Here's a proposal for how we can architect the frontend for inline comb -> MLIR.

The overall structure is:
* Use a traditional "classmethod" definition syntax to provide a handle to the circuit definition (cls)
  * We choose this over the current inline_combinational semantics since that has some wonky pitfalls with trying to inherit the parent scope for delayed execution semantics.  Instead the user only has access to the scope through the `cls` object which is simple to provide when processing the code
* Use an AST pass to determine references to `cls`, these are used to generate a wrapper circuit/instance that is wired up to the referenced values (useful for maintaining consistency of the representation, e.g. tracing an output driver to the inside of the code)
* "inline" wrapper during MLIR code generation by directly translating the AST to MLIR code and replacing `cls` references to the corresponding MLIR values

Thoughts?