### PR TITLE
Fix bug in overlapping slice resolution

### DIFF
--- a/tests/test_backend/test_mlir/golds/simple_aggregates_array.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_aggregates_array.mlir
@@ -16,8 +16,6 @@ hw.module @simple_aggregates_array(%a: !hw.array<8xi16>) -> (y: !hw.array<8xi16>
     %15 = hw.constant 3 : i3
     %14 = hw.array_get %a[%15] : !hw.array<8xi16>
     %16 = hw.array_create %14, %12, %10, %8, %6, %4, %2, %0 : i16
-    %17 = hw.array_create %14, %12, %10, %8, %6, %4, %2, %0 : i16
-    %18 = hw.array_get %17[%1] : !hw.array<8xi16>
-    %19 = hw.array_create %14, %12, %10, %18 : i16
-    hw.output %16, %19 : !hw.array<8xi16>, !hw.array<4xi16>
+    %17 = hw.array_create %14, %12, %10, %8 : i16
+    hw.output %16, %17 : !hw.array<8xi16>, !hw.array<4xi16>
 }

--- a/tests/test_backend/test_mlir/golds/simple_aggregates_bits.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_aggregates_bits.mlir
@@ -16,8 +16,6 @@ hw.module @simple_aggregates_bits(%a: i16) -> (y: i16, z: i8) {
     %14 = comb.extract %a from 6 : (i16) -> i1
     %15 = comb.extract %a from 7 : (i16) -> i1
     %16 = comb.concat %15, %14, %13, %12, %11, %10, %9, %8, %7, %6, %5, %4, %3, %2, %1, %0 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
-    %17 = comb.concat %15, %14, %13, %12, %11, %10, %9, %8, %7, %6, %5, %4, %3, %2, %1, %0 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
-    %18 = comb.extract %17 from 8 : (i16) -> i1
-    %19 = comb.concat %15, %14, %13, %12, %11, %10, %9, %18 : i1, i1, i1, i1, i1, i1, i1, i1
-    hw.output %16, %19 : i16, i8
+    %17 = comb.concat %15, %14, %13, %12, %11, %10, %9, %8 : i1, i1, i1, i1, i1, i1, i1, i1
+    hw.output %16, %17 : i16, i8
 }

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -458,3 +458,8 @@ def test_slice_instref(caplog):
         io.O[2:] @= bar.O
         io.O[:2] @= bar.O
         assert io.O.value().driven() is False
+        for i, elem in enumerate(io.O.value()):
+            assert isinstance(elem.name, m.ref.ArrayRef)
+            assert elem.name.index == i % 2
+            assert isinstance(elem.name.array.name, m.ref.InstRef)
+            assert elem.name.array.name.inst is bar


### PR DESCRIPTION
Follow up to https://github.com/phanrahan/magma/pull/1045 and
https://github.com/phanrahan/magma/pull/1048

Because the collect_children logic now creates Arrays where the slice children
could be from other values, we need the slice resolution logic to decide
whether the slice value is from the current array (e.g. resolving x[0:2] for x)
or from another value (e.g. resolving y for [0:2] of an anon value).

This hotfixes the build issue on master for FB, but will need to add a unit
test to cover this case.