### PR TITLE
Rewrite error logging

### DIFF
--- a/magma/backend/coreir/coreir_compiler.py
+++ b/magma/backend/coreir/coreir_compiler.py
@@ -8,7 +8,7 @@ from magma.frontend import coreir_ as coreir_frontend
 from magma.is_definition import isdefinition
 from magma.logging import root_logger
 from magma.passes import InstanceGraphPass
-from magma.passes.find_errors import find_errors_pass
+from magma.passes.raise_logs_as_exceptions import raise_logs_as_exceptions_pass
 from magma.symbol_table import SymbolTable
 from magma.symbol_table_utils import MasterSymbolTable
 
@@ -83,7 +83,7 @@ class CoreIRCompiler(Compiler):
         result["symbol_table"] = symbol_table = SymbolTable()
         insert_coreir_wires(self.main)
         insert_wrap_casts(self.main)
-        find_errors_pass(self.main)
+        raise_logs_as_exceptions_pass(self.main)
         backend = self.backend
         opts = _make_opts(backend, self.opts)
         opts["symbol_table"] = symbol_table

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -10,7 +10,7 @@ from magma.circuit import DefineCircuitKind
 from magma.common import slice_opts
 from magma.compiler import Compiler
 from magma.passes.clock import wire_clocks
-from magma.passes.find_errors import find_errors_pass
+from magma.passes.raise_logs_as_exceptions import raise_logs_as_exceptions_pass
 
 
 class MlirCompiler(Compiler):
@@ -32,7 +32,7 @@ class MlirCompiler(Compiler):
         insert_coreir_wires(self.main)
         insert_wrap_casts(self.main)
         wire_clocks(self.main)
-        find_errors_pass(self.main)
+        raise_logs_as_exceptions_pass(self.main)
 
     def compile(self):
         self._run_passes()

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -11,7 +11,7 @@ import os
 
 import six
 from . import cache_definition
-from .common import deprecated, setattrs, Stack, OrderedIdentitySet
+from .common import deprecated, setattrs, OrderedIdentitySet
 from .interface import *
 from .wire import *
 from .config import get_debug_mode, set_debug_mode
@@ -27,9 +27,15 @@ except ImportError:
     pass
 
 from magma.clock import is_clock_or_nested_clock, Clock, ClockTypes
-from magma.definition_context import DefinitionContext
+from magma.definition_context import (
+    DefinitionContext,
+    definition_context_manager,
+    push_definition_context,
+    pop_definition_context,
+    get_definition_context,
+)
 from magma.find_unconnected_ports import check_unconnected
-from magma.logging import root_logger
+from magma.logging import root_logger, capture_logs
 from magma.ref import TempNamedRef
 from magma.t import In
 from magma.view import PortView
@@ -55,31 +61,15 @@ circuit_type_method = namedtuple('circuit_type_method', ['name', 'definition'])
 _logger = root_logger()
 
 
+# TODO(rsetaluri): Remove these aliases.
+peek_definition_context_stack = get_definition_context
+DefinitionContextManager = lambda ctx: definition_context_manager(ctx)
+
+
 class _SyntaxStyle(enum.Enum):
     NONE = enum.auto()
     OLD = enum.auto()
     NEW = enum.auto()
-
-
-_definition_context_stack = Stack()
-
-
-def peek_definition_context_stack() -> DefinitionContext:
-    return _definition_context_stack.peek()
-
-
-class _DefinitionContextManager:
-    def __init__(self, context: DefinitionContext):
-        self._context = context
-
-    def __enter__(self):
-        _definition_context_stack.push(self._context)
-
-    def __exit__(self, typ, value, traceback):
-        _definition_context_stack.pop()
-
-
-DefinitionContextManager = _DefinitionContextManager
 
 
 def _has_definition(cls, port=None):
@@ -217,8 +207,8 @@ def _get_intermediate_values(value):
 
 class CircuitKind(type):
     def __prepare__(name, bases, **kwargs):
-        context = DefinitionContext(StagedPlacer(name))
-        _definition_context_stack.push(context)
+        ctx = DefinitionContext(StagedPlacer(name))
+        push_definition_context(ctx, use_staged_logger=True)
         return type.__prepare__(name, bases, **kwargs)
 
     """Metaclass for creating circuits."""
@@ -255,8 +245,12 @@ class CircuitKind(type):
 
         cls._syntax_style_ = _SyntaxStyle.NONE
         cls._renamed_ports_ = dct["renamed_ports"]
+        # NOTE(rsetaluri): We first peek the definition context
+        # (get_definition_context()) so that we can finalize it before popping
+        # it. This is necessary because we want the unstaging of the logger to
+        # happen (inside of pop) after finalization.
         try:
-            context = _definition_context_stack.pop()
+            context = get_definition_context()
         except IndexError:  # no staged placer
             cls._context_ = DefinitionContext(Placer(cls))
         else:
@@ -267,6 +261,7 @@ class CircuitKind(type):
             cls._context_.place_instances(cls)
             _setup_interface(cls)
             cls._context_.finalize(cls)
+            pop_definition_context(use_staged_logger=True)
 
         return cls
 
@@ -364,7 +359,7 @@ class CircuitKind(type):
     def inline_verilog(cls, inline_str, **kwargs):
         # NOTE(rsetaluri): This is a hack to avoid a circular import.
         from magma.inline_verilog import inline_verilog as m_inline_verilog
-        with _DefinitionContextManager(cls._context_):
+        with definition_context_manager(cls._context_):
             m_inline_verilog(inline_str, **kwargs)
 
 
@@ -532,7 +527,7 @@ class AnonymousCircuitType(object):
 
     @classmethod
     def open(cls):
-        return _DefinitionContextManager(cls._context_)
+        return definition_context_manager(cls._context_)
 
 
 def AnonymousCircuit(*decl):
@@ -551,7 +546,7 @@ class CircuitType(AnonymousCircuitType):
     def __init__(self, *largs, **kwargs):
         super(CircuitType, self).__init__(*largs, **kwargs)
         try:
-            context = _definition_context_stack.peek()
+            context = get_definition_context()
             context.placer.place(self)
         except IndexError:  # instances must happen inside a definition context
             raise Exception("Can not instance a circuit outside a definition")
@@ -658,7 +653,7 @@ class DefineCircuitKind(CircuitKind):
                 # instances because old style IO syntax doesn't support the
                 # automatic clock lifting anyways
                 _setup_interface(self)
-                with _DefinitionContextManager(self._context_):
+                with definition_context_manager(self._context_):
                     self.definition()
                 self._context_.place_instances(self)
                 self._context_.finalize(self)
@@ -673,7 +668,8 @@ class DefineCircuitKind(CircuitKind):
         run_unconnected_check = run_unconnected_check and not \
             dct.get("_ignore_undriven_", False)
         if run_unconnected_check:
-            check_unconnected(self)
+            with capture_logs(self._context_):
+                check_unconnected(self)
 
         return self
 
@@ -723,13 +719,16 @@ def DefineCircuit(name, *decl, **args):
                     renamed_ports=args.get('renamed_ports', {}),
                     kratos=args.get("kratos", None)))
     defn = metacls(name, bases, dct)
-    _definition_context_stack.push(defn._context_)
+    push_definition_context(defn._context_)
     return defn
 
 
 def EndDefine():
+    # NOTE(rsetaluri): We first peek the definition context
+    # (get_definition_context()) so that we avoid pushing on a log capturer for
+    # the check_unconnected() call.
     try:
-        context = _definition_context_stack.pop()
+        context = get_definition_context()
     except IndexError:
         raise Exception("EndDefine not matched to DefineCircuit")
     placer = context.placer
@@ -737,6 +736,7 @@ def EndDefine():
     debug_info = get_callee_frame_info()
     placer._defn.end_circuit_filename = debug_info[0]
     placer._defn.end_circuit_lineno = debug_info[1]
+    pop_definition_context()
 
 
 EndCircuit = EndDefine
@@ -806,7 +806,7 @@ def builder_method(func):
 
     @wraps(func)
     def _wrapped(this, *args, **kwargs):
-        with _DefinitionContextManager(this.context):
+        with definition_context_manager(this.context):
             result = func(this, *args, **kwargs)
         return result
 
@@ -822,7 +822,7 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
         # builder will not be automatically finalized, and (b) instantation
         # might fail.
         try:
-            context = _definition_context_stack.peek()
+            context = get_definition_context()
         except IndexError:
             pass
         else:
@@ -859,7 +859,7 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
         self._inst_attrs[key] = value
 
     def _open(self):
-        return _DefinitionContextManager(self._context)
+        return definition_context_manager(self._context)
 
     def _finalize(self):
         pass
@@ -911,12 +911,12 @@ class DebugDefineCircuitKind(DefineCircuitKind):
         #   TypeError: super(type, obj): obj must be an instance or subtype of
         #   type
         cls = DefineCircuitKind.__prepare__(name, bases, **kwargs)
-        ctx = peek_definition_context_stack()
+        ctx = get_definition_context()
         ctx.set_metadata("prev_debug_mode", prev_debug_mode)
         return cls
 
     def __new__(metacls, name, bases, dct):
-        ctx = peek_definition_context_stack()
+        ctx = get_definition_context()
         set_debug_mode(ctx.get_metadata("prev_debug_mode"))
         return DefineCircuitKind.__new__(metacls, name, bases, dct)
 

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -61,11 +61,6 @@ circuit_type_method = namedtuple('circuit_type_method', ['name', 'definition'])
 _logger = root_logger()
 
 
-# TODO(rsetaluri): Remove these aliases.
-peek_definition_context_stack = get_definition_context
-DefinitionContextManager = lambda ctx: definition_context_manager(ctx)
-
-
 class _SyntaxStyle(enum.Enum):
     NONE = enum.auto()
     OLD = enum.auto()

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -226,7 +226,6 @@ class CircuitKind(type):
         dct["inline_verilog_generated"] = False
         dct["bind_modules"] = {}
         dct["compiled_bind_modules"] = {}
-        dct.setdefault("_has_errors_", False)
 
         # If in debug_mode is active and debug_info is not supplied, attach
         # callee stack info.
@@ -680,6 +679,10 @@ class DefineCircuitKind(CircuitKind):
     @property
     def instances(self):
         return self._context_.placer.instances()
+
+    @property
+    def logs(self):
+        return self._context_.logs
 
     def place(cls, inst):
         """Place a circuit instance in this definition"""

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -34,7 +34,7 @@ from magma.definition_context import (
     pop_definition_context,
     get_definition_context,
 )
-from magma.find_unconnected_ports import check_unconnected
+from magma.find_unconnected_ports import find_and_log_unconnected_ports
 from magma.logging import root_logger, capture_logs
 from magma.ref import TempNamedRef
 from magma.t import In
@@ -668,7 +668,7 @@ class DefineCircuitKind(CircuitKind):
             dct.get("_ignore_undriven_", False)
         if run_unconnected_check:
             with capture_logs(self._context_):
-                check_unconnected(self)
+                find_and_log_unconnected_ports(self)
 
         return self
 
@@ -729,13 +729,13 @@ def DefineCircuit(name, *decl, **args):
 def EndDefine():
     # NOTE(rsetaluri): We first peek the definition context
     # (get_definition_context()) so that we avoid pushing on a log capturer for
-    # the check_unconnected() call.
+    # the find_and_log_unconnected_ports() call.
     try:
         context = get_definition_context()
     except IndexError:
         raise Exception("EndDefine not matched to DefineCircuit")
     placer = context.placer
-    check_unconnected(placer._defn)
+    find_and_log_unconnected_ports(placer._defn)
     debug_info = get_callee_frame_info()
     placer._defn.end_circuit_filename = debug_info[0]
     placer._defn.end_circuit_lineno = debug_info[1]

--- a/magma/common.py
+++ b/magma/common.py
@@ -234,3 +234,17 @@ def slice_opts(dct: Dict, cls: type):
 
 def filter_by_key(function: Callable[[Any], bool], dct: Dict):
     return {k: v for k, v in dct.items() if function(k)}
+
+
+def wrap_with_context_manager(ctx_mgr):
+
+    def decorator(fn):
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            with ctx_mgr:
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/magma/compile_exception.py
+++ b/magma/compile_exception.py
@@ -2,14 +2,16 @@ from magma.array import Array
 from magma.tuple import Tuple
 
 
-def _make_unconnected_error_str(port):
-    error_str = port.debug_name
+def make_unconnected_error_str(port):
+    format_args = [port]
+    error_str = "{}"
     if port.trace() is not None:
         error_str += ": Connected"
     elif isinstance(port, (Tuple, Array)):
         child_str = ""
         for child in port:
-            child = _make_unconnected_error_str(child)
+            child, child_args = make_unconnected_error_str(child)
+            format_args.extend(child_args)
             child = "\n    ".join(child.splitlines())
             child_str += f"\n    {child}"
         if "Connected" not in child_str:
@@ -19,7 +21,7 @@ def _make_unconnected_error_str(port):
             error_str += child_str
     elif port.trace() is None:
         error_str += ": Unconnected"
-    return error_str
+    return error_str, format_args
 
 
 class MagmaCompileException(Exception):
@@ -29,5 +31,6 @@ class MagmaCompileException(Exception):
 class UnconnectedPortException(MagmaCompileException):
     def __init__(self, port):
         msg = f"Found unconnected port: {port.debug_name}\n"
-        msg += _make_unconnected_error_str(port)
+        error_str, format_args = make_unconnected_error_str(port)
+        msg += error_str.format(*(arg.debug_name for arg in format_args))
         super().__init__(msg)

--- a/magma/compile_guard.py
+++ b/magma/compile_guard.py
@@ -1,10 +1,12 @@
+import contextlib
 import dataclasses
 from typing import Optional, Tuple
 
 from magma.bits import BitsMeta
 from magma.clock import Clock
-from magma.circuit import Circuit, CircuitBuilder, DefinitionContextManager
+from magma.circuit import Circuit, CircuitBuilder
 from magma.conversions import as_bits
+from magma.definition_context import definition_context_manager
 from magma.digital import DigitalMeta
 from magma.generator import Generator2
 from magma.inline_verilog import inline_verilog
@@ -29,7 +31,7 @@ def _get_top_ref(ref):
 @dataclasses.dataclass(frozen=True)
 class _CompileGuardState:
     ckt: CircuitBuilder
-    ctx_mgr: DefinitionContextManager
+    ctx_mgr: contextlib.AbstractContextManager
 
 
 class _CompileGuardBuilder(CircuitBuilder):
@@ -169,7 +171,7 @@ class _CompileGuard:
             ckt = _CompileGuardBuilder(self._defn_name, self._cond, self._type)
             if self._inst_name is None:
                 ckt.set_instance_name(self._inst_name)
-            ctx_mgr = DefinitionContextManager(ckt._context)
+            ctx_mgr = definition_context_manager(ckt._context)
             self._state = _CompileGuardState(ckt, ctx_mgr)
         self._state.ctx_mgr.__enter__()
 

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging as py_logging
-from typing import Any, Mapping
+from typing import Any, List, Mapping
 import weakref
 
 from magma.common import Stack, Finalizable, FinalizableDelegator
@@ -101,6 +101,10 @@ class DefinitionContext(FinalizableDelegator):
 
     def add_builder(self, builder):
         self._builders.append(builder)
+
+    @property
+    def logs(self) -> List:
+        return self._logs.copy()
 
     def add_log(self, log):
         self._logs.append(log)

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -35,9 +35,8 @@ def _inline_verilog(
         symbol_table: Mapping,
         inline_wire_prefix: str = "_magma_inline_wire"):
     # NOTE(rsetaluri): These are hacks to avoid a circular dependency.
-    from magma.circuit import DefinitionContextManager
     from magma.inline_verilog import inline_verilog_impl
-    with DefinitionContextManager(context):
+    with definition_context_manager(context):
         inline_verilog_impl(
             format_str, format_args, symbol_table, inline_wire_prefix)
 

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -1,9 +1,15 @@
+import contextlib
 import logging as py_logging
 from typing import Any, Mapping
 import weakref
 
-from magma.common import Finalizable, FinalizableDelegator
-from magma.logging import stage_logger, unstage_logger
+from magma.common import Stack, Finalizable, FinalizableDelegator
+from magma.logging import (
+    stage_logger,
+    unstage_logger,
+    push_log_capturer,
+    pop_log_capturer,
+)
 from magma.placer import PlacerBase
 
 
@@ -72,16 +78,22 @@ class VerilogDisplayManager(Finalizable):
             _inline_verilog(self.context, string, {}, {})
 
 
+_definition_context_stack = Stack()
+
+
+def _get_definition_context_stack() -> Stack:
+    global _definition_context_stack
+    return _definition_context_stack
+
+
 class DefinitionContext(FinalizableDelegator):
     def __init__(self, placer: PlacerBase):
         super().__init__()
         self._placer = placer
         self._builders = []
+        self._logs = []
         self._metadata = {}
         self.add_child("display", VerilogDisplayManager(weakref.ref(self)))
-        self._is_staged = self._placer.is_staged()
-        if self._is_staged:
-            stage_logger()
 
     @property
     def placer(self) -> PlacerBase:
@@ -89,6 +101,12 @@ class DefinitionContext(FinalizableDelegator):
 
     def add_builder(self, builder):
         self._builders.append(builder)
+
+    def add_log(self, log):
+        self._logs.append(log)
+
+    def add_logs(self, logs):
+        self._logs.extend(logs)
 
     def get_metadata(self, key: str) -> Any:
         return self._metadata[key]
@@ -107,7 +125,36 @@ class DefinitionContext(FinalizableDelegator):
 
     def finalize(self, defn):
         super().finalize()
-        if self._is_staged:
-            logs = unstage_logger()
-            defn._has_errors_ = any(log[1] is py_logging.ERROR for log in logs)
-            self._is_staged = False
+
+
+def push_definition_context(
+        ctx: DefinitionContext, use_staged_logger: bool = False):
+    push_log_capturer(ctx)
+    if use_staged_logger:
+        stage_logger()
+    _get_definition_context_stack().push(ctx)
+
+
+def pop_definition_context(
+        use_staged_logger: bool = False) -> DefinitionContext:
+    if use_staged_logger:
+        unstage_logger()
+    pop_log_capturer()
+    return _get_definition_context_stack().pop()
+
+
+def get_definition_context() -> DefinitionContext:
+    return _get_definition_context_stack().peek()
+
+
+@contextlib.contextmanager
+def definition_context_manager(
+        ctx: DefinitionContext, use_staged_logger: bool = False):
+    push_definition_context(ctx, use_staged_logger)
+    try:
+        yield
+    finally:
+        if use_staged_logger:
+            unstage_logger()
+        popped_ctx = pop_definition_context(use_staged_logger)
+        assert popped_ctx is ctx

--- a/magma/display.py
+++ b/magma/display.py
@@ -1,4 +1,4 @@
-from magma.circuit import peek_definition_context_stack
+from magma.definition_context import get_definition_context
 from magma.t import Type
 
 
@@ -132,7 +132,7 @@ end
 
 
 def display(display_str, *args, file=None):
-    context = peek_definition_context_stack()
+    context = get_definition_context()
     disp = Display(display_str, args, file)
     context.get_child("display").add_display(disp)
     return disp
@@ -143,7 +143,7 @@ class File:
         self.filename = filename
         self.mode = mode
 
-        context = peek_definition_context_stack()
+        context = get_definition_context()
         context.get_child("display").add_file(self)
 
     def __enter__(self):

--- a/magma/find_unconnected_ports.py
+++ b/magma/find_unconnected_ports.py
@@ -124,7 +124,7 @@ def _make_unconnected_port_diagnostic_visitor_cls():
     return _Visitor
 
 
-def check_unconnected(ckt):
+def find_and_log_unconnected_ports(ckt):
     infos = find_unconnected_ports_of_circuit(ckt)
     for info in infos:
         port = info.port

--- a/magma/find_unconnected_ports.py
+++ b/magma/find_unconnected_ports.py
@@ -1,0 +1,80 @@
+import dataclasses
+from typing import Optional
+
+from magma.clock import is_clock_or_nested_clock, ClockTypes
+from magma.compile_exception import make_unconnected_error_str
+from magma.debug import debug_info as debug_info_cls
+from magma.logging import root_logger
+from magma.t import Type
+from magma.wire_container import WiringLog
+
+
+_logger = root_logger()
+
+
+@dataclasses.dataclass(frozen=True)
+class UnconnectedPortInfo:
+    port: Type
+    debug_info: Optional[debug_info_cls]
+
+
+def find_unconnected_ports_of_port(port, debug_info):
+    if port.is_output():
+        return
+    if port.is_inout() and port.wired():
+        # TODO(leonardt/rsetaluri): Ideally, we should trace in both directions
+        # for an inout; for now we assume that if it's "wired()", then it is
+        # connected.
+        return
+    if port.is_mixed():
+        for elt in port:
+            yield from find_unconnected_ports_of_port(elt, debug_info)
+        return
+    if port.trace() is None:
+        # If we encounter a clock, issue a debug message that we are not
+        # counting this as an unconnected port and instead will attempt to
+        # automatically wire it downstream.
+        if isinstance(port, ClockTypes):
+            msg = "{} not driven, will attempt to automatically wire"
+            _logger.debug(WiringLog(msg, port), debug_info=debug_info)
+            return
+        # If there is a clock nested in @port, then we need to traverse its
+        # children. Note that although we use is_clock_or_nested_clock here,
+        # because of the preceding check for ClockTypes, this conditional will
+        # only catch the nested clock case.
+        if is_clock_or_nested_clock(type(port)):
+            for elt in port:
+                yield from find_unconnected_ports_of_port(elt, debug_info)
+            return
+        yield UnconnectedPortInfo(port, debug_info)
+        return
+    return
+
+
+def find_unconnected_ports_of_interface(interface, debug_info):
+    for port in interface.ports.values():
+        yield from find_unconnected_ports_of_port(port, debug_info)
+
+
+def find_unconnected_ports_of_circuit(ckt):
+    yield from find_unconnected_ports_of_interface(
+        ckt.interface, ckt.debug_info
+    )
+    for inst in ckt.instances:
+        yield from find_unconnected_ports_of_interface(
+            inst.interface, inst.debug_info
+        )
+
+
+def check_unconnected(ckt):
+    unconnected_ports = find_unconnected_ports_of_circuit(ckt)
+    for unconnected_port in unconnected_ports:
+        port = unconnected_port.port
+        debug_info = unconnected_port.debug_info
+        msg = "{} not driven\n\nUnconnected port info"
+        msg += "\n---------------------\n    "
+        error_msg, format_args = make_unconnected_error_str(port)
+        msg += "\n    ".join(error_msg.splitlines())
+        _logger.error(WiringLog(msg, port, *format_args),
+                      debug_info=debug_info)
+        ckt._has_errors_ = True

--- a/magma/find_unconnected_ports.py
+++ b/magma/find_unconnected_ports.py
@@ -77,4 +77,3 @@ def check_unconnected(ckt):
         msg += "\n    ".join(error_msg.splitlines())
         _logger.error(WiringLog(msg, port, *format_args),
                       debug_info=debug_info)
-        ckt._has_errors_ = True

--- a/magma/inline_verilog.py
+++ b/magma/inline_verilog.py
@@ -7,9 +7,9 @@ from ast_tools.stack import _SKIP_FRAME_DEBUG_STMT, get_symbol_table
 
 from magma.array import Array
 from magma.bit import Bit
-from magma.circuit import Circuit, peek_definition_context_stack
+from magma.circuit import Circuit
 from magma.clock import ClockTypes
-from magma.definition_context import DefinitionContext
+from magma.definition_context import DefinitionContext, get_definition_context
 from magma.digital import Digital
 from magma.interface import IO
 from magma.passes.passes import CircuitPass
@@ -254,7 +254,7 @@ def inline_verilog_impl(
         format_args: Mapping[str, ValueLike],
         symbol_table: Mapping,
         inline_wire_prefix: str):
-    context = peek_definition_context_stack()
+    context = get_definition_context()
     _process_inline_verilog(
         context, format_str, format_args, symbol_table, inline_wire_prefix)
 

--- a/magma/log.py
+++ b/magma/log.py
@@ -1,6 +1,6 @@
 import functools
 
-from magma.circuit import peek_definition_context_stack
+from magma.definition_context import get_definition_context
 from magma.display import Display
 
 
@@ -38,7 +38,7 @@ class Error(Log):
 def _make_log_func(T):
     @functools.wraps(_make_log_func)
     def log_func(log_str, *args, file=None):
-        context = peek_definition_context_stack()
+        context = get_definition_context()
         log = T(log_str, args, file=file)
         context.get_child("display").add_display(log)
         context.get_child("display").insert_default_log_level()

--- a/magma/logging.py
+++ b/magma/logging.py
@@ -158,6 +158,32 @@ def root_logger():
     return logging.getLogger("magma")
 
 
+# NOTE(rsetaluri): For some reason the following code which uses
+# contextlib.contextmanager results in the context manager being entered into
+# twice. It may be cached somewhere in the pipeline.
+#
+#    @contextlib.contextmanager
+#    def logging_level(level):
+#        root = root_logger()
+#        prev_level = root.level
+#        root.setLevel(level)
+#        try:
+#            yield
+#        finally:
+#            root.setLevel(prev_level)
+class logging_level:
+    def __init__(self, level):
+        self.level = level
+        self.root = root_logger()
+
+    def __enter__(self):
+        self.prev_level = self.root.level
+        self.root.setLevel(self.level)
+
+    def __exit__(self, *_):
+        self.root.setLevel(self.prev_level)
+
+
 def stage_logger():
     get_staged_logs_stack().push([])
 

--- a/magma/logging.py
+++ b/magma/logging.py
@@ -1,3 +1,4 @@
+import abc
 import colorlog
 import contextlib
 import inspect
@@ -173,3 +174,25 @@ def flush_all():
     while staged_logs_stack:
         staged_logs = staged_logs_stack.pop()
         _flush(staged_logs)
+
+
+@contextlib.contextmanager
+def staged_logs():
+    stage_logger()
+    staged_logs = get_staged_logs_stack().peek()
+    try:
+        yield staged_logs
+    finally:
+        unstage_logger()
+
+
+class StagedLogRecord(abc.ABC):
+    def __init__(self, tpl: str):
+        self._tpl = tpl
+
+    @abc.abstractmethod
+    def args(self):
+        raise NotImplementedError()
+
+    def __str__(self):
+        return self._tpl.format(*self.args())

--- a/magma/passes/find_errors.py
+++ b/magma/passes/find_errors.py
@@ -1,17 +1,16 @@
 import enum
+import logging as py_logging
 
-from magma.passes.passes import CircuitPass, pass_lambda
+from magma.passes.passes import DefinitionPass, pass_lambda
 from magma.compile_exception import MagmaCompileException
 
 
-_HAS_ERROR_KEY = "_has_errors_"
-
-
 def _has_errors(ckt):
-    return getattr(ckt, _HAS_ERROR_KEY, False)
+    levels = (level for level, _, _, _ in ckt.logs)
+    return any(level >= py_logging.ERROR for level in levels)
 
 
-class FindErrorsPass(CircuitPass):
+class FindErrorsPass(DefinitionPass):
 
     class ErrorReportingMode(enum.Enum):
         FIRST = enum.auto()

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -1,22 +1,28 @@
-from magma.logging import root_logger
+from magma.logging import root_logger, StagedLogRecord
 
 
 _logger = root_logger()
 
 
-class WiringLog:
-    def __init__(self, tpl, *bits):
-        self.tpl = tpl
-        self.bits = bits
+class WiringLogRecord(StagedLogRecord):
+    def __init__(self, tpl: str, *values):
+        super().__init__(tpl)
+        self._values = values
 
-    def get_debug_name(self, bit):
-        if isinstance(bit, int):
-            return bit
-        return bit.debug_name
+    @staticmethod
+    def _get_debug_name(value):
+        if isinstance(value, int):
+            return value
+        return value.debug_name
 
-    def __str__(self):
-        bits = [self.get_debug_name(bit) for bit in self.bits]
-        return self.tpl.format(*bits)
+    def args(self):
+        return [
+            WiringLogRecord._get_debug_name(value) for value in self._values
+        ]
+
+
+# TODO(rsetaluri): Remove this alias.
+WiringLog = WiringLogRecord
 
 
 class Wire:

--- a/tests/test_circuit/test_new_style_syntax.py
+++ b/tests/test_circuit/test_new_style_syntax.py
@@ -72,7 +72,13 @@ def test_new_style_unconnected(caplog):
         io.x @= 0
 
     assert m.isdefinition(_Foo)
-    assert has_error(caplog, "_Foo.O not driven")
+    assert has_error(caplog, """_Foo.O not driven
+
+Unconnected port info
+---------------------
+    _Foo.O
+        _Foo.O[0]: Connected
+        _Foo.O[1]: Unconnected""")
 
 
 def test_new_style_with_definition_method(caplog):
@@ -122,8 +128,16 @@ def test_inst_wiring_error(caplog):
     assert has_error(
         caplog,
         "Cannot wire _Foo._Bar_inst0.O (Out(Bits[1])) to _Foo.O (In(Bit))")
-    assert has_error(caplog, "_Foo.O not driven")
-    assert has_error(caplog, "_Foo._Bar_inst0.I not driven")
+    assert has_error(caplog, """_Foo.O not driven
+
+Unconnected port info
+---------------------
+    _Foo.O: Unconnected""")
+    assert has_error(caplog, """_Foo._Bar_inst0.I not driven
+
+Unconnected port info
+---------------------
+    _Foo._Bar_inst0.I: Unconnected""")
 
 
 def test_nested_definition():

--- a/tests/test_circuit/test_unconnected.py
+++ b/tests/test_circuit/test_unconnected.py
@@ -1,8 +1,11 @@
 import logging
 import pytest
+
 import magma as m
+from magma.common import wrap_with_context_manager
+from magma.logging import logging_level
 from magma.testing import magma_debug_section
-from magma.testing.utils import has_error
+from magma.testing.utils import has_error, has_debug
 
 
 def _make_unconnected_io():
@@ -48,30 +51,26 @@ def _make_unconnected_autowired(typ):
     return _Circuit
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_unconnected_io(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_io()
-        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:9\x1b[0m: _Circuit.O not driven
-
-Unconnected port info
----------------------
-    _Circuit.O
-        _Circuit.O[0]: Connected
-        _Circuit.O[1]: Unconnected
+        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:12\x1b[0m: _Circuit.O not driven
 >>     class _Circuit(m.Circuit):"""
         assert has_error(caplog, expected)
+        assert has_debug(caplog, "_Circuit.O")
+        assert has_debug(caplog, "    _Circuit.O[0]: Connected")
+        assert has_debug(caplog, "    _Circuit.O[1]: Unconnected")
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_unconnected_instance(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_instance()
-        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:28\x1b[0m: _Circuit.buf.I not driven
-
-Unconnected port info
----------------------
-    _Circuit.buf.I: Unconnected
+        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:31\x1b[0m: _Circuit.buf.I not driven
 >>         buf = _Buffer()"""
         assert has_error(caplog, expected)
+        assert has_debug(caplog, "_Circuit.buf.I: Unconnected")
 
 
 @pytest.mark.parametrize("typ", [m.Clock, m.Reset, m.AsyncReset])

--- a/tests/test_circuit/test_unconnected.py
+++ b/tests/test_circuit/test_unconnected.py
@@ -51,7 +51,7 @@ def _make_unconnected_autowired(typ):
 def test_unconnected_io(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_io()
-        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:8\x1b[0m: _Circuit.O not driven
+        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:9\x1b[0m: _Circuit.O not driven
 
 Unconnected port info
 ---------------------
@@ -65,7 +65,7 @@ Unconnected port info
 def test_unconnected_instance(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_instance()
-        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:27\x1b[0m: _Circuit.buf.I not driven
+        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:28\x1b[0m: _Circuit.buf.I not driven
 
 Unconnected port info
 ---------------------

--- a/tests/test_circuit/test_unconnected.py
+++ b/tests/test_circuit/test_unconnected.py
@@ -51,7 +51,13 @@ def _make_unconnected_autowired(typ):
 def test_unconnected_io(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_io()
-        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:9\x1b[0m: _Circuit.O not driven
+        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:8\x1b[0m: _Circuit.O not driven
+
+Unconnected port info
+---------------------
+    _Circuit.O
+        _Circuit.O[0]: Connected
+        _Circuit.O[1]: Unconnected
 >>     class _Circuit(m.Circuit):"""
         assert has_error(caplog, expected)
 
@@ -59,7 +65,11 @@ def test_unconnected_io(caplog):
 def test_unconnected_instance(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_instance()
-        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:28\x1b[0m: _Circuit.buf.I not driven
+        expected = """\x1b[1mtests/test_circuit/test_unconnected.py:27\x1b[0m: _Circuit.buf.I not driven
+
+Unconnected port info
+---------------------
+    _Circuit.buf.I: Unconnected
 >>         buf = _Buffer()"""
         assert has_error(caplog, expected)
 

--- a/tests/test_circuit/test_undriven_unused.py
+++ b/tests/test_circuit/test_undriven_unused.py
@@ -29,6 +29,7 @@ def test_ignore_unused_undriven_hierarchy():
         Bar = m.DeclareCircuit("Bar", "I", m.In(m.Bit))
 
     class Foo(m.Circuit):
+        _ignore_undriven_ = True
         io = m.IO(I0=m.In(m.Bit), I1=m.In(m.Bit),
                   O0=m.Out(m.Bit), O1=m.Out(m.Bit))
 

--- a/tests/test_compile/test_compile_exception.py
+++ b/tests/test_compile/test_compile_exception.py
@@ -1,0 +1,12 @@
+import pytest
+import magma as m
+
+
+def test_undriven():
+    class Foo(m.Circuit):
+        io = m.IO(x=m.Out(m.Bit), y=m.Out(m.Bit))
+        io.x @= 1
+
+    with pytest.raises(m.compile_exception.MagmaCompileException) as e:
+        m.compile("build/Foo", Foo)
+    assert str(e.value) == "Found circuit with errors: Foo"

--- a/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
+++ b/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
@@ -60,7 +60,7 @@ def _make_unconnected_autowired(typ):
 def test_unconnected_io(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_io()
-        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:8\x1b[0m: _Circuit.O not driven
+        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:9\x1b[0m: _Circuit.O not driven
 
 Unconnected port info
 ---------------------
@@ -74,7 +74,7 @@ Unconnected port info
 def test_unconnected_instance(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_instance()
-        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:32\x1b[0m: _Circuit.buf.I not driven
+        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:33\x1b[0m: _Circuit.buf.I not driven
 
 Unconnected port info
 ---------------------

--- a/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
+++ b/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
@@ -60,7 +60,13 @@ def _make_unconnected_autowired(typ):
 def test_unconnected_io(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_io()
-        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:9\x1b[0m: _Circuit.O not driven
+        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:8\x1b[0m: _Circuit.O not driven
+
+Unconnected port info
+---------------------
+    _Circuit.O
+        _Circuit.O[0]: Connected
+        _Circuit.O[1]: Unconnected
 >>     class _Circuit(m.Circuit):"""
         assert has_error(caplog, expected)
 
@@ -68,7 +74,11 @@ def test_unconnected_io(caplog):
 def test_unconnected_instance(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_instance()
-        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:33\x1b[0m: _Circuit.buf.I not driven
+        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:32\x1b[0m: _Circuit.buf.I not driven
+
+Unconnected port info
+---------------------
+    _Circuit.buf.I: Unconnected
 >>             buf = _Buffer()"""
         assert has_error(caplog, expected)
 

--- a/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
+++ b/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
@@ -1,8 +1,11 @@
 import logging
 import pytest
+
 import magma as m
+from magma.common import wrap_with_context_manager
+from magma.logging import logging_level
 from magma.testing import magma_debug_section
-from magma.testing.utils import has_error
+from magma.testing.utils import has_error, has_debug
 
 
 def _make_unconnected_io():
@@ -57,30 +60,26 @@ def _make_unconnected_autowired(typ):
     return _Circuit
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_unconnected_io(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_io()
-        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:9\x1b[0m: _Circuit.O not driven
-
-Unconnected port info
----------------------
-    _Circuit.O
-        _Circuit.O[0]: Connected
-        _Circuit.O[1]: Unconnected
+        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:12\x1b[0m: _Circuit.O not driven
 >>     class _Circuit(m.Circuit):"""
         assert has_error(caplog, expected)
+        assert has_debug(caplog, "_Circuit.O")
+        assert has_debug(caplog, "    _Circuit.O[0]: Connected")
+        assert has_debug(caplog, "    _Circuit.O[1]: Unconnected")
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_unconnected_instance(caplog):
     with magma_debug_section():
         Circuit = _make_unconnected_instance()
-        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:33\x1b[0m: _Circuit.buf.I not driven
-
-Unconnected port info
----------------------
-    _Circuit.buf.I: Unconnected
+        expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:36\x1b[0m: _Circuit.buf.I not driven
 >>             buf = _Buffer()"""
         assert has_error(caplog, expected)
+        assert has_debug(caplog, "_Circuit.buf.I: Unconnected")
 
 
 @pytest.mark.parametrize("typ", [m.Clock, m.Reset, m.AsyncReset])

--- a/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_undriven_unused.py
+++ b/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_undriven_unused.py
@@ -22,6 +22,7 @@ def test_ignore_unused_undriven_basic():
 
 def test_ignore_unused_undriven_hierarchy():
     class Foo(m.Circuit):
+        _ignore_undriven_ = True
         io = m.IO(I0=m.In(m.Bit), I1=m.In(m.Bit),
                   O0=m.Out(m.Bit), O1=m.Out(m.Bit))
 

--- a/tests/test_errors/test_array_errors.py
+++ b/tests/test_errors/test_array_errors.py
@@ -3,7 +3,7 @@ import pytest
 import magma as m
 
 
-def test_array_partial_unwired():
+def test_array_partial_unwired(caplog):
     class Foo(m.Circuit):
         io = m.IO(A=m.Out(m.Bits[2]), x=m.Out(m.Bit))
         io.A[0] @= 1
@@ -11,15 +11,18 @@ def test_array_partial_unwired():
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert str(e.value) == """\
-Found unconnected port: Foo.A
-Foo.A
-    Foo.A[0]: Connected
-    Foo.A[1]: Unconnected\
+    assert caplog.messages[0] == """\
+Foo.A not driven
+
+Unconnected port info
+---------------------
+    Foo.A
+        Foo.A[0]: Connected
+        Foo.A[1]: Unconnected\
 """
 
 
-def test_array_partial_unwired_nested():
+def test_array_partial_unwired_nested(caplog):
     class Foo(m.Circuit):
         io = m.IO(A=m.Out(m.Array[2, m.Bits[2]]), x=m.Out(m.Bit))
         io.A[0] @= 1
@@ -27,15 +30,18 @@ def test_array_partial_unwired_nested():
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert str(e.value) == """\
-Found unconnected port: Foo.A
-Foo.A
-    Foo.A[0]: Connected
-    Foo.A[1]: Unconnected\
+    assert caplog.messages[0] == """\
+Foo.A not driven
+
+Unconnected port info
+---------------------
+    Foo.A
+        Foo.A[0]: Connected
+        Foo.A[1]: Unconnected\
 """
 
 
-def test_array_partial_unwired_nested2():
+def test_array_partial_unwired_nested2(caplog):
     class Foo(m.Circuit):
         io = m.IO(A=m.Out(m.Array[2, m.Bits[2]]), x=m.Out(m.Bit))
         io.A[0] @= 1
@@ -44,13 +50,16 @@ def test_array_partial_unwired_nested2():
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert str(e.value) == """\
-Found unconnected port: Foo.A
-Foo.A
-    Foo.A[0]: Connected
-    Foo.A[1]
-        Foo.A[1][0]: Connected
-        Foo.A[1][1]: Unconnected\
+    assert caplog.messages[0] == """\
+Foo.A not driven
+
+Unconnected port info
+---------------------
+    Foo.A
+        Foo.A[0]: Connected
+        Foo.A[1]
+            Foo.A[1][0]: Connected
+            Foo.A[1][1]: Unconnected\
 """
 
 

--- a/tests/test_errors/test_array_errors.py
+++ b/tests/test_errors/test_array_errors.py
@@ -1,9 +1,13 @@
 import pytest
 
 import magma as m
+from magma.common import wrap_with_context_manager
+from magma.logging import logging_level
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_array_partial_unwired(caplog):
+
     class Foo(m.Circuit):
         io = m.IO(A=m.Out(m.Bits[2]), x=m.Out(m.Bit))
         io.A[0] @= 1
@@ -11,17 +15,13 @@ def test_array_partial_unwired(caplog):
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert caplog.messages[0] == """\
-Foo.A not driven
-
-Unconnected port info
----------------------
-    Foo.A
-        Foo.A[0]: Connected
-        Foo.A[1]: Unconnected\
-"""
+    assert caplog.messages[0] == "Foo.A not driven"
+    assert caplog.messages[1] == "Foo.A"
+    assert caplog.messages[2] == "    Foo.A[0]: Connected"
+    assert caplog.messages[3] == "    Foo.A[1]: Unconnected"
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_array_partial_unwired_nested(caplog):
     class Foo(m.Circuit):
         io = m.IO(A=m.Out(m.Array[2, m.Bits[2]]), x=m.Out(m.Bit))
@@ -30,17 +30,13 @@ def test_array_partial_unwired_nested(caplog):
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert caplog.messages[0] == """\
-Foo.A not driven
-
-Unconnected port info
----------------------
-    Foo.A
-        Foo.A[0]: Connected
-        Foo.A[1]: Unconnected\
-"""
+    assert caplog.messages[0] == "Foo.A not driven"
+    assert caplog.messages[1] == "Foo.A"
+    assert caplog.messages[2] == "    Foo.A[0]: Connected"
+    assert caplog.messages[3] == "    Foo.A[1]: Unconnected"
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_array_partial_unwired_nested2(caplog):
     class Foo(m.Circuit):
         io = m.IO(A=m.Out(m.Array[2, m.Bits[2]]), x=m.Out(m.Bit))
@@ -50,17 +46,12 @@ def test_array_partial_unwired_nested2(caplog):
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert caplog.messages[0] == """\
-Foo.A not driven
-
-Unconnected port info
----------------------
-    Foo.A
-        Foo.A[0]: Connected
-        Foo.A[1]
-            Foo.A[1][0]: Connected
-            Foo.A[1][1]: Unconnected\
-"""
+    assert caplog.messages[0] == "Foo.A not driven"
+    assert caplog.messages[1] == "Foo.A"
+    assert caplog.messages[2] == "    Foo.A[0]: Connected"
+    assert caplog.messages[3] == "    Foo.A[1]"
+    assert caplog.messages[4] == "        Foo.A[1][0]: Connected"
+    assert caplog.messages[5] == "        Foo.A[1][1]: Unconnected"
 
 
 @pytest.mark.parametrize("_slice", [slice(1, 4), slice(3, 4), slice(-1, -4),

--- a/tests/test_errors/test_tuple_errors.py
+++ b/tests/test_errors/test_tuple_errors.py
@@ -3,7 +3,7 @@ import pytest
 import magma as m
 
 
-def test_product_partial_unwired():
+def test_product_partial_unwired(caplog):
     class T(m.Product):
         x = m.Bit
         y = m.Bit
@@ -15,15 +15,18 @@ def test_product_partial_unwired():
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert str(e.value) == """\
-Found unconnected port: Foo.A
-Foo.A
-    Foo.A.x: Connected
-    Foo.A.y: Unconnected\
+    assert caplog.messages[0] == """\
+Foo.A not driven
+
+Unconnected port info
+---------------------
+    Foo.A
+        Foo.A.x: Connected
+        Foo.A.y: Unconnected\
 """
 
 
-def test_product_partial_nested_unwired():
+def test_product_partial_nested_unwired(caplog):
     class T(m.Product):
         x = m.Bit
         y = m.Bit
@@ -39,15 +42,18 @@ def test_product_partial_nested_unwired():
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert str(e.value) == """\
-Found unconnected port: Foo.A
-Foo.A
-    Foo.A.x: Connected
-    Foo.A.y: Unconnected\
+    assert caplog.messages[0] == """\
+Foo.A not driven
+
+Unconnected port info
+---------------------
+    Foo.A
+        Foo.A.x: Connected
+        Foo.A.y: Unconnected\
 """
 
 
-def test_product_partial_nested_unwired2():
+def test_product_partial_nested_unwired2(caplog):
     class T(m.Product):
         x = m.Bit
         y = m.Bit
@@ -64,17 +70,20 @@ def test_product_partial_nested_unwired2():
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert str(e.value) == """\
-Found unconnected port: Foo.A
-Foo.A
-    Foo.A.x: Connected
-    Foo.A.y
-        Foo.A.y.x: Connected
-        Foo.A.y.y: Unconnected\
+    assert caplog.messages[0] == """\
+Foo.A not driven
+
+Unconnected port info
+---------------------
+    Foo.A
+        Foo.A.x: Connected
+        Foo.A.y
+            Foo.A.y.x: Connected
+            Foo.A.y.y: Unconnected\
 """
 
 
-def test_product_arr():
+def test_product_arr(caplog):
     class T(m.Product):
         x = m.Bit
         y = m.Bit
@@ -87,15 +96,18 @@ def test_product_arr():
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert str(e.value) == """\
-Found unconnected port: Foo.A
-Foo.A
-    Foo.A[0]
-        Foo.A[0].x: Connected
-        Foo.A[0].y: Unconnected
-    Foo.A[1]
-        Foo.A[1].x: Unconnected
-        Foo.A[1].y: Connected\
+    assert caplog.messages[0] == """\
+Foo.A not driven
+
+Unconnected port info
+---------------------
+    Foo.A
+        Foo.A[0]
+            Foo.A[0].x: Connected
+            Foo.A[0].y: Unconnected
+        Foo.A[1]
+            Foo.A[1].x: Unconnected
+            Foo.A[1].y: Connected\
 """
 
 
@@ -125,7 +137,11 @@ Cannot wire Bits[1](1) (Out(Bits[1])) to Foo.A.x (In(Bits[2]))\
 Cannot wire Bits[3](2) (Out(Bits[3])) to Foo.A.y (In(Bits[4]))\
 """
     assert caplog.messages[2] == """\
-Foo.A not driven\
+Foo.A not driven
+
+Unconnected port info
+---------------------
+    Foo.A: Unconnected\
 """
 
 
@@ -164,5 +180,17 @@ def test_unwired_mixed(caplog):
         io.O @= foo.z.x
 
 
-    assert caplog.messages[0] == "Bar.z.x not driven"
-    assert caplog.messages[1] == "Foo_inst0.z.y not driven"
+    assert caplog.messages[0] == """\
+Bar.z.x not driven
+
+Unconnected port info
+---------------------
+    Bar.z.x: Unconnected\
+"""
+    assert caplog.messages[1] == """\
+Foo_inst0.z.y not driven
+
+Unconnected port info
+---------------------
+    Foo_inst0.z.y: Unconnected\
+"""

--- a/tests/test_errors/test_tuple_errors.py
+++ b/tests/test_errors/test_tuple_errors.py
@@ -1,8 +1,11 @@
 import pytest
 
 import magma as m
+from magma.common import wrap_with_context_manager
+from magma.logging import logging_level
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_product_partial_unwired(caplog):
     class T(m.Product):
         x = m.Bit
@@ -15,17 +18,13 @@ def test_product_partial_unwired(caplog):
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert caplog.messages[0] == """\
-Foo.A not driven
-
-Unconnected port info
----------------------
-    Foo.A
-        Foo.A.x: Connected
-        Foo.A.y: Unconnected\
-"""
+    assert caplog.messages[0] == "Foo.A not driven"
+    assert caplog.messages[1] == "Foo.A"
+    assert caplog.messages[2] == "    Foo.A.x: Connected"
+    assert caplog.messages[3] == "    Foo.A.y: Unconnected"
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_product_partial_nested_unwired(caplog):
     class T(m.Product):
         x = m.Bit
@@ -42,17 +41,13 @@ def test_product_partial_nested_unwired(caplog):
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert caplog.messages[0] == """\
-Foo.A not driven
-
-Unconnected port info
----------------------
-    Foo.A
-        Foo.A.x: Connected
-        Foo.A.y: Unconnected\
-"""
+    assert caplog.messages[0] == "Foo.A not driven"
+    assert caplog.messages[1] == "Foo.A"
+    assert caplog.messages[2] == "    Foo.A.x: Connected"
+    assert caplog.messages[3] == "    Foo.A.y: Unconnected"
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_product_partial_nested_unwired2(caplog):
     class T(m.Product):
         x = m.Bit
@@ -70,19 +65,15 @@ def test_product_partial_nested_unwired2(caplog):
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert caplog.messages[0] == """\
-Foo.A not driven
-
-Unconnected port info
----------------------
-    Foo.A
-        Foo.A.x: Connected
-        Foo.A.y
-            Foo.A.y.x: Connected
-            Foo.A.y.y: Unconnected\
-"""
+    assert caplog.messages[0] == "Foo.A not driven"
+    assert caplog.messages[1] == "Foo.A"
+    assert caplog.messages[2] == "    Foo.A.x: Connected"
+    assert caplog.messages[3] == "    Foo.A.y"
+    assert caplog.messages[4] == "        Foo.A.y.x: Connected"
+    assert caplog.messages[5] == "        Foo.A.y.y: Unconnected"
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_product_arr(caplog):
     class T(m.Product):
         x = m.Bit
@@ -96,21 +87,17 @@ def test_product_arr(caplog):
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    assert caplog.messages[0] == """\
-Foo.A not driven
-
-Unconnected port info
----------------------
-    Foo.A
-        Foo.A[0]
-            Foo.A[0].x: Connected
-            Foo.A[0].y: Unconnected
-        Foo.A[1]
-            Foo.A[1].x: Unconnected
-            Foo.A[1].y: Connected\
-"""
+    assert caplog.messages[0] == "Foo.A not driven"
+    assert caplog.messages[1] == "Foo.A"
+    assert caplog.messages[2] == "    Foo.A[0]"
+    assert caplog.messages[3] == "        Foo.A[0].x: Connected"
+    assert caplog.messages[4] == "        Foo.A[0].y: Unconnected"
+    assert caplog.messages[5] == "    Foo.A[1]"
+    assert caplog.messages[6] == "        Foo.A[1].x: Unconnected"
+    assert caplog.messages[7] == "        Foo.A[1].y: Connected"
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_product_width_mismatch(caplog):
     class T(m.Product):
         x = m.Bits[2]
@@ -127,22 +114,16 @@ def test_product_width_mismatch(caplog):
 
     with pytest.raises(Exception) as e:
         m.compile("build/Foo", Foo)
-    print(str(e.value))
-    assert str(e.value) == "Found circuit with errors: Foo"
 
+    assert str(e.value) == "Found circuit with errors: Foo"
     assert caplog.messages[0] == """\
 Cannot wire Bits[1](1) (Out(Bits[1])) to Foo.A.x (In(Bits[2]))\
 """
     assert caplog.messages[1] == """\
 Cannot wire Bits[3](2) (Out(Bits[3])) to Foo.A.y (In(Bits[4]))\
 """
-    assert caplog.messages[2] == """\
-Foo.A not driven
-
-Unconnected port info
----------------------
-    Foo.A: Unconnected\
-"""
+    assert caplog.messages[2] == "Foo.A not driven"
+    assert caplog.messages[3] == "Foo.A: Unconnected"
 
 
 def test_product_width_mismatch2(caplog):
@@ -164,6 +145,7 @@ Cannot wire Foo.A.x (Out(Bits[4])) to Foo.A.y (In(Bits[2]))\
 """
 
 
+@wrap_with_context_manager(logging_level("DEBUG"))
 def test_unwired_mixed(caplog):
     class T(m.Product):
         x = m.Out(m.Bit)
@@ -180,17 +162,8 @@ def test_unwired_mixed(caplog):
         io.O @= foo.z.x
 
 
-    assert caplog.messages[0] == """\
-Bar.z.x not driven
+    assert caplog.messages[0] == "Bar.z.x not driven"
+    assert caplog.messages[1] == "Bar.z.x: Unconnected"
 
-Unconnected port info
----------------------
-    Bar.z.x: Unconnected\
-"""
-    assert caplog.messages[1] == """\
-Foo_inst0.z.y not driven
-
-Unconnected port info
----------------------
-    Foo_inst0.z.y: Unconnected\
-"""
+    assert caplog.messages[2] == "Foo_inst0.z.y not driven"
+    assert caplog.messages[3] == "Foo_inst0.z.y: Unconnected"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,8 @@
 import magma as m
 
-from magma.logging import root_logger, stage_logger, unstage_logger
+from magma.logging import (
+    root_logger, stage_logger, unstage_logger, staged_logs
+)
 from magma.testing.utils import has_info
 
 
@@ -49,4 +51,19 @@ def test_nested_staging(caplog):
     logger.info(msg)
     msg.name = "bar"
     unstage_logger()
+    assert caplog.records[-1].message == "bar"
+
+
+def test_staged_logs_context_manager(caplog):
+    msg = _NamedObject("foo")
+    logger = root_logger()
+
+    # Check that the staged_logs() context manager appropriately stages logs,
+    # *and* the target returned from staged_logs() is the list of staged logs
+    # itself.
+    with staged_logs() as logs:
+        logger.info(msg)
+        msg.name = "bar"
+    assert len(logs) == 1
+    assert logs[0][2] is msg
     assert caplog.records[-1].message == "bar"

--- a/tests/test_wire/test_check_wiring_context.py
+++ b/tests/test_wire/test_check_wiring_context.py
@@ -51,6 +51,7 @@ def test_bad_temp2(caplog):
     class Foo(m.Circuit):
         io = m.IO(x=m.In(m.Bits[8]), y=m.Out(m.Bits[8]))
         z = m.Bits[8]()
+        z @= io.x
         io.y @= z
 
     class Bar(m.Circuit):
@@ -98,6 +99,7 @@ def test_bad_inst(caplog):
     class Bar(m.Circuit):
         io = m.IO(x=m.In(m.Bits[8]), y=m.Out(m.Bits[8]))
         foo = Foo()
+        foo.x @= io.x
         io.y @= foo.y
 
     class Baz(m.Circuit):
@@ -130,9 +132,10 @@ def test_bad_defn(caplog):
     class Foo(m.Circuit):
         io = m.IO(x=m.In(m.Bits[8]), y=m.Out(m.Bits[8]), z=m.Out(m.Bits[8]))
         io.z @= io.x
+        io.y @= io.x
 
     class Bar(m.Circuit):
-        io = m.IO(x=m.In(m.Bits[8]), y=m.Out(m.Bits[8]))
+        io = m.IO(x=m.In(m.Bits[8]))
         Foo.y @= io.x
 
     with pytest.raises(MagmaCompileException) as e:

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -186,10 +186,14 @@ def test_hanging_anon_error(caplog):
             m.compile("Foo", _Foo, output="coreir")
             assert False, "Did not raise excpected exception"
         except Exception as e:
-            assert str(e) == "Found unconnected port: _Foo.O\n_Foo.O: Unconnected"
+            assert str(e) == "Found circuit with errors: _Foo"
 
         msg = """\
 \033[1mtests/test_wire/test_errors.py:180\033[0m: _Foo.O not driven
+
+Unconnected port info
+---------------------
+    _Foo.O: Unconnected
 >>         class _Foo(m.Circuit):"""
         assert caplog.records[0].msg == msg
         assert has_error(caplog, msg)


### PR DESCRIPTION
This change refactors a bunch of the internals regarding logging, especially during the circuit creation pipeline.

Now, we explicitly stage logs from the caller side of the context manager. There is also generic machinery to capture logs (at any time) and now we use that to attach logs to a definition context. These logs can be used for diagnostics in general, but we primarily use them to raise logs as exceptions (in RaiseLogsAsExceptionsPass, previously FindErrorsPass). I think these new abstractions are more clear and maintainable.

The only externally visible change is that I got rid of multiline logging since it is generally bad practice and IMO looked a bit clunky. Instead I split those out into multiple debug log statements. Since we don't have any parallelism, it is probably easy enough to inspect the logs to see the breakdown of the connected-/unconnected-ness of complex types nearby. I plan to either (a) add an ID to those messages so they can all be grouped, or (b) write to a separate debug file so that the port can be debugged.