### PR TITLE
Fix bug in wire children logic missing unwire

### DIFF
--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -19,6 +19,16 @@ class WiringLog:
         return self.tpl.format(*bits)
 
 
+def stage_multiple_drivers_log(value, curr_driver, new_driver, debug_info):
+    _logger.warning(
+        WiringLog(
+            ("Wiring multiple outputs to same wire, using last "
+             "connection. Input: {}, Old Output: {}, New Output: {}"),
+            value, curr_driver, new_driver),
+        debug_info=debug_info
+    )
+
+
 class Wire:
     """
     Wire implements wiring.
@@ -49,13 +59,8 @@ class Wire:
         output, or both should be inouts
         """
         if self._driver is not None:
-            _logger.warning(
-                WiringLog(
-                    ("Wiring multiple outputs to same wire, using last "
-                     "connection. Input: {}, Old Output: {}, New Output: {}"),
-                    self._bit, self._driver._bit, other._bit),
-                debug_info=debug_info
-            )
+            stage_multiple_drivers_log(self._bit, self._driver._bit,
+                                       other._bit, debug_info)
         if self._bit.is_output():
             _logger.error(
                 WiringLog("Using `{}` (an output) as an input", self._bit),

--- a/tests/test_type/gold/test_array2_2d_tuple.v
+++ b/tests/test_type/gold/test_array2_2d_tuple.v
@@ -1,0 +1,16 @@
+module Foo (
+    input [3:0] I_c_0_a [3:0],
+    input [3:0] I_c_1_a [3:0],
+    output [3:0] O_c_0_a [3:0],
+    output [3:0] O_c_1_a [3:0]
+);
+assign O_c_0_a[3] = I_c_1_a[0];
+assign O_c_0_a[2] = I_c_1_a[1];
+assign O_c_0_a[1] = I_c_1_a[2];
+assign O_c_0_a[0] = I_c_1_a[3];
+assign O_c_1_a[3] = I_c_0_a[0];
+assign O_c_1_a[2] = I_c_0_a[1];
+assign O_c_1_a[1] = I_c_0_a[2];
+assign O_c_1_a[0] = I_c_0_a[3];
+endmodule
+

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -463,3 +463,24 @@ def test_slice_instref(caplog):
             assert elem.name.index == i % 2
             assert isinstance(elem.name.array.name, m.ref.InstRef)
             assert elem.name.array.name.inst is bar
+
+
+def test_array2_2d_tuple():
+    class X(m.Product):
+        a = m.Array[4, m.Bits[4]]
+
+    class Y(m.Product):
+        c = m.Array[2, X]
+
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(Y), O=m.Out(Y))
+        io.O @= io.I
+
+        temp = Y()
+
+        for i in range(4):
+            temp.c[0].a[3 - i] @= io.I.c[1].a[i]
+            temp.c[1].a[i] @= io.I.c[0].a[3 - i]
+        io.O @= temp
+
+    _check_compile("test_array2_2d_tuple", Foo, False)


### PR DESCRIPTION
Before, we were relying on the "overwriting" log message when wiring a
second driver to a child.  However, this is problematic because we don't
actually unwire the child being overwritten.  As as result, in various
code paths (e.g. error reporting) we can trigger one of the overwritten
drivers to expand itself, which in turn calls the
_resolve_driven_bulk_wires logic and corrupts the representation.  By
unwiring the overwritten driver, we avoid any code acciddentally
triggering the resolve logic.