### PR TITLE
Avoid unnecessary array expansion in repr

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -873,7 +873,7 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         return ts
 
     def __repr__(self):
-        if self.name.anon():
+        if self.name.anon() and self._has_elaborated_children():
             t_strs = ', '.join(repr(t) for t in self.ts)
             return f'array([{t_strs}])'
         return Type.__repr__(self)

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -113,13 +113,13 @@ def _make_wires(value, wired):
         return "".join(_make_wires(v, wired)
                        for v, _ in value.connection_iter())
     driver = value.value()
+    while driver is not None and driver.is_driven_anon_temporary():
+        driver = driver.value()
     if driver is None:
         return ""
     if driver.has_children() and driver.name.anon():
         return "".join(_make_wires(v, wired)
                        for v, _ in value.connection_iter())
-    while driver is not None and driver.is_driven_anon_temporary():
-        driver = driver.value()
     s = ""
     while driver is not None:
         if (driver, value) in wired:

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -483,6 +483,20 @@ def test_array2_2d_tuple():
             temp.c[1].a[i] @= io.I.c[0].a[3 - i]
         io.O @= temp
 
+    expected = """\
+Foo = DefineCircuit("Foo", "I", Tuple(c=Array[(2, X)]), "O", Tuple(c=Array[(2, X)]))
+wire(Foo.I.c[1].a[3], Foo.O.c[0].a[0])
+wire(Foo.I.c[1].a[2], Foo.O.c[0].a[1])
+wire(Foo.I.c[1].a[1], Foo.O.c[0].a[2])
+wire(Foo.I.c[1].a[0], Foo.O.c[0].a[3])
+wire(Foo.I.c[0].a[3], Foo.O.c[1].a[0])
+wire(Foo.I.c[0].a[2], Foo.O.c[1].a[1])
+wire(Foo.I.c[0].a[1], Foo.O.c[1].a[2])
+wire(Foo.I.c[0].a[0], Foo.O.c[1].a[3])
+EndCircuit()\
+"""
+    assert repr(Foo) == expected, repr(Foo)
+
     _check_compile("test_array2_2d_tuple", Foo, False)
 
 


### PR DESCRIPTION
Noticed this in debugging, before this change we were getting:
```
        wire(Foo.I.c[1].a[3][0], Foo.O.c[0].a[0][0])
        wire(Foo.I.c[1].a[3][1], Foo.O.c[0].a[0][1])
        wire(Foo.I.c[1].a[3][2], Foo.O.c[0].a[0][2])
        wire(Foo.I.c[1].a[3][3], Foo.O.c[0].a[0][3])
        wire(Foo.I.c[1].a[2][0], Foo.O.c[0].a[1][0])
        wire(Foo.I.c[1].a[2][1], Foo.O.c[0].a[1][1])
        wire(Foo.I.c[1].a[2][2], Foo.O.c[0].a[1][2])
        ...
```

The issue was in two places: first, we were recursing before traversing
the anon temporary values (causing expansion), and second in the logging
we were calling repr on an unelaborated anon array which was triggering
the elaboration logic by default.  Instead, we only emit the `array([t0,
t1, ...])` style if we have elaborated children, otherwise we fall back
to the normal value repr (emits automatic anon name).