### PR TITLE
Export product constructor

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -32,7 +32,6 @@ from .bfloat import BFloat
 from .tuple import *
 from .clock import *
 from .clock_io import ClockIO
-from .conversions import *
 from .interface import *
 from .ref import LazyDefnRef, LazyInstRef
 
@@ -91,6 +90,17 @@ from .syntax.combinational2 import combinational2
 from .syntax.inline_combinational import inline_combinational
 from .syntax.coroutine import coroutine
 
+from magma.conversions import (
+    bit,
+    clock, reset, enable, asyncreset, asyncresetn,
+    array,
+    bits, uint, sint,
+    tuple_, namedtuple, product,
+    concat, repeat,
+    sext, zext, sext_to, sext_by, zext_to, zext_by,
+    replace,
+    as_bits, from_bits
+)
 from magma.primitives import (LUT, Mux, mux, dict_lookup, list_lookup,
                               Register, get_slice, set_slice, slice,
                               Memory, set_index, register, Wire)

--- a/magma/conversions.py
+++ b/magma/conversions.py
@@ -17,23 +17,9 @@ from .bitutils import int2seq
 import hwtypes as ht
 from magma.array import Array
 from magma.circuit import coreir_port_mapping
-from magma.common import is_int, Finalizable, lca_of_types
+from magma.common import is_int, Finalizable, lca_of_types, deprecated
 from magma.generator import Generator2
 from magma.interface import IO
-
-
-__all__ = ['bit']
-__all__ += ['clock', 'reset', 'enable', 'asyncreset', 'asyncresetn']
-
-__all__ += ['array']
-__all__ += ['bits', 'uint', 'sint']
-
-__all__ += ['tuple_', 'namedtuple']
-
-__all__ += ['concat', 'repeat']
-__all__ += ['sext', 'zext', 'sext_to', 'sext_by', 'zext_to', 'zext_by']
-__all__ += ['replace']
-__all__ += ['as_bits', 'from_bits']
 
 
 class _Concatter(Finalizable):
@@ -372,7 +358,7 @@ def _tuple(value, n=None, t=Tuple):
     assert t == Product
     return t.from_fields("anon", decl)(*args)
 
-
+@deprecated(msg="namedtuple() is deprecated, use product() instead")
 def namedtuple(**kwargs):
     return _tuple(kwargs, t=Product)
 


### PR DESCRIPTION
Exports `magma/conversions.py:product()` and deprecates `magma/conversions.py:namedtuple()`.