### PR TITLE
Alias m.Register to m.Reg

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -105,3 +105,11 @@ from magma.circuit_utils import circuit_stub, stubify, CircuitStub
 from magma.compile import MagmaCompileException
 from magma.linking import link_module, link_default_module, clear_link_info
 import magma.math
+
+################################################################################
+# BEGIN ALIASES
+################################################################################
+Reg = Register
+################################################################################
+# END ALIASES
+################################################################################

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,0 +1,15 @@
+import pytest
+
+import magma as m
+
+
+@pytest.mark.parametrize(
+    "original,alias",
+    [
+        (m.Register, m.Reg),
+    ]
+)
+def test_aliases(original, alias):
+    assert alias is original
+
+


### PR DESCRIPTION
Adds an alias to `m.Register` as `m.Reg`. This is done in a special section of `magma/__init__.py` with a simple equality statement. We could also do an `import .. as ...` but this seems simpler.