### PR TITLE
Support wiring Bit and Bits[1]

### DIFF
--- a/magma/bit.py
+++ b/magma/bit.py
@@ -14,13 +14,8 @@ from .digital import VCC, GND  # TODO(rsetaluri): only here for b.c.
 from magma.compatibility import IntegerTypes
 from magma.debug import debug_wire
 from magma.family import get_family
-from magma.logging import root_logger
 from magma.protocol_type import magma_value
 from magma.operator_utils import output_only
-from magma.wire_container import WiringLog
-
-
-_logger = root_logger()
 
 
 def bit_cast(fn: tp.Callable[['Bit', 'Bit'], 'Bit']) -> \

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -200,8 +200,11 @@ class BitsMeta(AbstractBitVectorMeta, ArrayMeta):
             return True
         if issubclass(cls, UInt) and issubclass(rhs, SInt):
             return False
-        elif issubclass(cls, SInt) and issubclass(rhs, UInt):
+        if issubclass(cls, SInt) and issubclass(rhs, UInt):
             return False
+        if len(cls) == 1 and issubclass(rhs, Bit):
+            # TODO(leonardt): Should we make this work for general Array[1, T]?
+            return True
         return super().is_wireable(rhs)
 
 
@@ -247,6 +250,10 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
                     f"(bit_length={other.bit_length()}) to Bits ({len(self)})")
             from .conversions import bits
             other = bits(other, len(self))
+        if isinstance(other, Bit) and len(self) == 1:
+            # TODO(leonardt): Should we make this work for general Array[1, T]?
+            from .conversions import bits
+            other = bits(other, 1)
         super().wire(other, debug_info)
 
     @classmethod

--- a/tests/test_wire/test_wireable.py
+++ b/tests/test_wire/test_wireable.py
@@ -1,3 +1,4 @@
+import pytest
 import magma as m
 
 
@@ -20,3 +21,17 @@ Cannot wire Main.a (Out(UInt[16])) to Main.b (In(SInt[16]))\
 Cannot wire Main2.a (Out(SInt[16])) to Main2.b (In(UInt[16]))\
 """
     assert caplog.messages[1][-len(expected):] == expected
+
+
+@pytest.mark.parametrize('Ts', [
+    (m.Bit, m.Bits[1]),
+    (m.Bits[1], m.Bit),
+])
+def test_bit_bits1(Ts):
+    class Main(m.Circuit):
+        io = m.IO(a=m.In(Ts[0]), b=m.Out(Ts[1]))
+        io.b @= io.a
+
+    # NOTE: We  call compile here to ensure a wiring error was not reported
+    # (otherwise it would raise an exception)
+    m.compile('build/Main', Main)


### PR DESCRIPTION
Two implementation issues:
1. Should we support wiring T to Array[1, T] in general? Or have this be
   a Bits/Bit specific feature
2. Is there a way to avoid a circular import in this logic? The naive
   solution is to have Bit check if the driver is Bits[1], but this
   clearly requires a circular import.  Perhaps we could use some sort
   of `T.convert_to(other_T)` API?