### PR TITLE
[MLIR] Fix magma mux code generation

### DIFF
--- a/magma/backend/mlir/compile_to_mlir_opts.py
+++ b/magma/backend/mlir/compile_to_mlir_opts.py
@@ -11,3 +11,4 @@ class CompileToMlirOpts:
     user_namespace: Optional[str] = None
     disable_initial_blocks: bool = False
     elaborate_magma_registers: bool = False
+    extend_non_power_of_two_muxes: bool = False

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -130,6 +130,11 @@ def make_mux(
         data: List[MlirValue],
         select: MlirValue,
         result: MlirValue):
+    if ctx.opts.extend_non_power_of_two_muxes:
+        closest_power_of_two_size = 2 ** clog2(len(data))
+        if closest_power_of_two_size != len(data):
+            extension = [data[0]] * (closest_power_of_two_size - len(data))
+            data = extension + data
     mlir_type = hw.ArrayType((len(data),), data[0].type)
     array = ctx.new_value(mlir_type)
     hw.ArrayCreateOp(

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -490,8 +490,13 @@ class ModuleVisitor:
             stride = len(data) // height
             assert len(module.results) == stride
             for i in range(stride):
-                make_mux(self._ctx, data[i::stride], select, module.results[i])
+                inputs = list(reversed(data[i::stride]))
+                make_mux(self._ctx, inputs, select, module.results[i])
             return True
+        # NOTE(rsetaluri): Reversing data needs to be done *after* we check for
+        # tuple flattening. Otherwise the tuple field ordering gets reversed as
+        # well.
+        data = list(reversed(data))
         make_mux(self._ctx, data, select, module.results[0])
         return True
 

--- a/tests/test_backend/test_mlir/examples.py
+++ b/tests/test_backend/test_mlir/examples.py
@@ -103,6 +103,15 @@ class aggregate_mux_wrapper(m.Circuit):
     io.y @= m.mux([io.a, not_a], io.s)
 
 
+class non_power_of_two_mux_wrapper(m.Circuit):
+    T = m.Product.from_fields("anon", dict(x=m.Bits[8], y=m.Bit))
+    io = m.IO(a=m.In(T), s=m.In(m.Bits[4]), y=m.Out(T))
+    not_a = T(*map(lambda x: ~x, io.a))
+    inputs = [io.a, not_a]
+    inputs += [not_a] * 10
+    io.y @= m.mux(inputs, io.s)
+
+
 class simple_register_wrapper(m.Circuit):
     T = m.Bits[8]
     io = m.IO(a=m.In(T), y=m.Out(T))

--- a/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper.mlir
+++ b/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper.mlir
@@ -6,7 +6,7 @@ hw.module @aggregate_mux_wrapper(%a: !hw.struct<x: i8, y: i1>, %s: i1) -> (y: !h
     %5 = hw.constant -1 : i1
     %4 = comb.xor %5, %3 : i1
     %6 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
-    %8 = hw.array_create %a, %6 : !hw.struct<x: i8, y: i1>
+    %8 = hw.array_create %6, %a : !hw.struct<x: i8, y: i1>
     %7 = hw.array_get %8[%s] : !hw.array<2x!hw.struct<x: i8, y: i1>>
     hw.output %7 : !hw.struct<x: i8, y: i1>
 }

--- a/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper.v
+++ b/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper.v
@@ -4,7 +4,7 @@ module aggregate_mux_wrapper(	// <stdin>:1:1
   output struct packed {logic [7:0] x; logic y; } y);
 
 wire struct packed {logic [7:0] x; logic y; } _T = '{x: (~a.x), y: (~a.y)};	// <stdin>:2:10, :4:10, :5:10, :7:10, :8:10
-wire struct packed {logic [7:0] x; logic y; }[1:0] _T_0 = {{a}, {_T}};	// <stdin>:9:10
+wire struct packed {logic [7:0] x; logic y; }[1:0] _T_0 = {{_T}, {a}};	// <stdin>:9:10
   assign y = _T_0[s];	// <stdin>:10:10, :11:5
 endmodule
 

--- a/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_extend_non_power_of_two_muxes.mlir
+++ b/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_extend_non_power_of_two_muxes.mlir
@@ -1,0 +1,12 @@
+hw.module @aggregate_mux_wrapper(%a: !hw.struct<x: i8, y: i1>, %s: i1) -> (y: !hw.struct<x: i8, y: i1>) {
+    %0 = hw.struct_extract %a["x"] : !hw.struct<x: i8, y: i1>
+    %2 = hw.constant -1 : i8
+    %1 = comb.xor %2, %0 : i8
+    %3 = hw.struct_extract %a["y"] : !hw.struct<x: i8, y: i1>
+    %5 = hw.constant -1 : i1
+    %4 = comb.xor %5, %3 : i1
+    %6 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %8 = hw.array_create %6, %a : !hw.struct<x: i8, y: i1>
+    %7 = hw.array_get %8[%s] : !hw.array<2x!hw.struct<x: i8, y: i1>>
+    hw.output %7 : !hw.struct<x: i8, y: i1>
+}

--- a/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_extend_non_power_of_two_muxes.v
+++ b/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_extend_non_power_of_two_muxes.v
@@ -1,0 +1,10 @@
+module aggregate_mux_wrapper(	// <stdin>:1:1
+  input  struct packed {logic [7:0] x; logic y; } a,
+  input                                           s,
+  output struct packed {logic [7:0] x; logic y; } y);
+
+wire struct packed {logic [7:0] x; logic y; } _T = '{x: (~a.x), y: (~a.y)};	// <stdin>:2:10, :4:10, :5:10, :7:10, :8:10
+wire struct packed {logic [7:0] x; logic y; }[1:0] _T_0 = {{_T}, {a}};	// <stdin>:9:10
+  assign y = _T_0[s];	// <stdin>:10:10, :11:5
+endmodule
+

--- a/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_extend_non_power_of_two_muxes_flatten_all_tuples.mlir
+++ b/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_extend_non_power_of_two_muxes_flatten_all_tuples.mlir
@@ -1,0 +1,11 @@
+hw.module @aggregate_mux_wrapper(%a_x: i8, %a_y: i1, %s: i1) -> (y_x: i8, y_y: i1) {
+    %1 = hw.constant -1 : i8
+    %0 = comb.xor %1, %a_x : i8
+    %3 = hw.constant -1 : i1
+    %2 = comb.xor %3, %a_y : i1
+    %6 = hw.array_create %0, %a_x : i8
+    %4 = hw.array_get %6[%s] : !hw.array<2xi8>
+    %7 = hw.array_create %2, %a_y : i1
+    %5 = hw.array_get %7[%s] : !hw.array<2xi1>
+    hw.output %4, %5 : i8, i1
+}

--- a/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_extend_non_power_of_two_muxes_flatten_all_tuples.v
+++ b/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_extend_non_power_of_two_muxes_flatten_all_tuples.v
@@ -1,0 +1,12 @@
+module aggregate_mux_wrapper(	// <stdin>:1:1
+  input  [7:0] a_x,
+  input        a_y, s,
+  output [7:0] y_x,
+  output       y_y);
+
+wire [1:0][7:0] _T = {{~a_x}, {a_x}};	// <stdin>:3:10, :6:10
+wire [1:0] _T_0 = {{~a_y}, {a_y}};	// <stdin>:5:10, :8:10
+  assign y_x = _T[s];	// <stdin>:7:10, :10:5
+  assign y_y = _T_0[s];	// <stdin>:9:10, :10:5
+endmodule
+

--- a/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_flatten_all_tuples.mlir
+++ b/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_flatten_all_tuples.mlir
@@ -3,9 +3,9 @@ hw.module @aggregate_mux_wrapper(%a_x: i8, %a_y: i1, %s: i1) -> (y_x: i8, y_y: i
     %0 = comb.xor %1, %a_x : i8
     %3 = hw.constant -1 : i1
     %2 = comb.xor %3, %a_y : i1
-    %6 = hw.array_create %a_x, %0 : i8
+    %6 = hw.array_create %0, %a_x : i8
     %4 = hw.array_get %6[%s] : !hw.array<2xi8>
-    %7 = hw.array_create %a_y, %2 : i1
+    %7 = hw.array_create %2, %a_y : i1
     %5 = hw.array_get %7[%s] : !hw.array<2xi1>
     hw.output %4, %5 : i8, i1
 }

--- a/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_flatten_all_tuples.v
+++ b/tests/test_backend/test_mlir/golds/aggregate_mux_wrapper_flatten_all_tuples.v
@@ -4,8 +4,8 @@ module aggregate_mux_wrapper(	// <stdin>:1:1
   output [7:0] y_x,
   output       y_y);
 
-wire [1:0][7:0] _T = {{a_x}, {~a_x}};	// <stdin>:3:10, :6:10
-wire [1:0] _T_0 = {{a_y}, {~a_y}};	// <stdin>:5:10, :8:10
+wire [1:0][7:0] _T = {{~a_x}, {a_x}};	// <stdin>:3:10, :6:10
+wire [1:0] _T_0 = {{~a_y}, {a_y}};	// <stdin>:5:10, :8:10
   assign y_x = _T[s];	// <stdin>:7:10, :10:5
   assign y_y = _T_0[s];	// <stdin>:9:10, :10:5
 endmodule

--- a/tests/test_backend/test_mlir/golds/complex_register_wrapper_elaborate_magma_registers.mlir
+++ b/tests/test_backend/test_mlir/golds/complex_register_wrapper_elaborate_magma_registers.mlir
@@ -9,7 +9,7 @@ hw.module @Register(%I: !hw.struct<x: i8, y: i1>, %CE: i1, %CLK: i1, %ASYNCRESET
     %9 = comb.concat %7, %6, %5, %4, %3, %2, %1, %8 : i1, i1, i1, i1, i1, i1, i1, i1
     %10 = comb.extract %0 from 8 : (i9) -> i1
     %11 = hw.struct_create (%9, %10) : !hw.struct<x: i8, y: i1>
-    %13 = hw.array_create %11, %I : !hw.struct<x: i8, y: i1>
+    %13 = hw.array_create %I, %11 : !hw.struct<x: i8, y: i1>
     %12 = hw.array_get %13[%CE] : !hw.array<2x!hw.struct<x: i8, y: i1>>
     %14 = hw.struct_extract %12["x"] : !hw.struct<x: i8, y: i1>
     %15 = comb.extract %14 from 0 : (i8) -> i1

--- a/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper.mlir
+++ b/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper.mlir
@@ -1,0 +1,22 @@
+hw.module @non_power_of_two_mux_wrapper(%a: !hw.struct<x: i8, y: i1>, %s: i4) -> (y: !hw.struct<x: i8, y: i1>) {
+    %0 = hw.struct_extract %a["x"] : !hw.struct<x: i8, y: i1>
+    %2 = hw.constant -1 : i8
+    %1 = comb.xor %2, %0 : i8
+    %3 = hw.struct_extract %a["y"] : !hw.struct<x: i8, y: i1>
+    %5 = hw.constant -1 : i1
+    %4 = comb.xor %5, %3 : i1
+    %6 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %7 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %8 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %9 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %10 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %11 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %12 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %13 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %14 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %15 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %16 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %18 = hw.array_create %16, %15, %14, %13, %12, %11, %10, %9, %8, %7, %6, %a : !hw.struct<x: i8, y: i1>
+    %17 = hw.array_get %18[%s] : !hw.array<12x!hw.struct<x: i8, y: i1>>
+    hw.output %17 : !hw.struct<x: i8, y: i1>
+}

--- a/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper.v
+++ b/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper.v
@@ -1,0 +1,23 @@
+module non_power_of_two_mux_wrapper(	// <stdin>:1:1
+  input  struct packed {logic [7:0] x; logic y; } a,
+  input  [3:0]                                    s,
+  output struct packed {logic [7:0] x; logic y; } y);
+
+wire [7:0] _T = a.x;	// <stdin>:2:10
+wire _T_0 = a.y;	// <stdin>:5:10
+wire struct packed {logic [7:0] x; logic y; } _T_1 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :8:10
+wire struct packed {logic [7:0] x; logic y; } _T_2 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :9:10
+wire struct packed {logic [7:0] x; logic y; } _T_3 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :10:10
+wire struct packed {logic [7:0] x; logic y; } _T_4 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :11:10
+wire struct packed {logic [7:0] x; logic y; } _T_5 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :12:11
+wire struct packed {logic [7:0] x; logic y; } _T_6 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :13:11
+wire struct packed {logic [7:0] x; logic y; } _T_7 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :14:11
+wire struct packed {logic [7:0] x; logic y; } _T_8 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :15:11
+wire struct packed {logic [7:0] x; logic y; } _T_9 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :16:11
+wire struct packed {logic [7:0] x; logic y; } _T_10 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :17:11
+wire struct packed {logic [7:0] x; logic y; } _T_11 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :18:11
+wire struct packed {logic [7:0] x; logic y; }[11:0] _T_12 = {{_T_11}, {_T_10}, {_T_9}, {_T_8}, {_T_7}, {_T_6}, {_T_5}, {_T_4}, {_T_3}, {_T_2}, {_T_1},
+                {a}};	// <stdin>:19:11
+  assign y = _T_12[s];	// <stdin>:20:11, :21:5
+endmodule
+

--- a/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper_extend_non_power_of_two_muxes.mlir
+++ b/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper_extend_non_power_of_two_muxes.mlir
@@ -1,0 +1,22 @@
+hw.module @non_power_of_two_mux_wrapper(%a: !hw.struct<x: i8, y: i1>, %s: i4) -> (y: !hw.struct<x: i8, y: i1>) {
+    %0 = hw.struct_extract %a["x"] : !hw.struct<x: i8, y: i1>
+    %2 = hw.constant -1 : i8
+    %1 = comb.xor %2, %0 : i8
+    %3 = hw.struct_extract %a["y"] : !hw.struct<x: i8, y: i1>
+    %5 = hw.constant -1 : i1
+    %4 = comb.xor %5, %3 : i1
+    %6 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %7 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %8 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %9 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %10 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %11 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %12 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %13 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %14 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %15 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %16 = hw.struct_create (%1, %4) : !hw.struct<x: i8, y: i1>
+    %18 = hw.array_create %16, %16, %16, %16, %16, %15, %14, %13, %12, %11, %10, %9, %8, %7, %6, %a : !hw.struct<x: i8, y: i1>
+    %17 = hw.array_get %18[%s] : !hw.array<16x!hw.struct<x: i8, y: i1>>
+    hw.output %17 : !hw.struct<x: i8, y: i1>
+}

--- a/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper_extend_non_power_of_two_muxes.v
+++ b/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper_extend_non_power_of_two_muxes.v
@@ -1,0 +1,23 @@
+module non_power_of_two_mux_wrapper(	// <stdin>:1:1
+  input  struct packed {logic [7:0] x; logic y; } a,
+  input  [3:0]                                    s,
+  output struct packed {logic [7:0] x; logic y; } y);
+
+wire [7:0] _T = a.x;	// <stdin>:2:10
+wire _T_0 = a.y;	// <stdin>:5:10
+wire struct packed {logic [7:0] x; logic y; } _T_1 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :8:10
+wire struct packed {logic [7:0] x; logic y; } _T_2 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :9:10
+wire struct packed {logic [7:0] x; logic y; } _T_3 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :10:10
+wire struct packed {logic [7:0] x; logic y; } _T_4 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :11:10
+wire struct packed {logic [7:0] x; logic y; } _T_5 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :12:11
+wire struct packed {logic [7:0] x; logic y; } _T_6 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :13:11
+wire struct packed {logic [7:0] x; logic y; } _T_7 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :14:11
+wire struct packed {logic [7:0] x; logic y; } _T_8 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :15:11
+wire struct packed {logic [7:0] x; logic y; } _T_9 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :16:11
+wire struct packed {logic [7:0] x; logic y; } _T_10 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :17:11
+wire struct packed {logic [7:0] x; logic y; } _T_11 = '{x: (~_T), y: (~_T_0)};	// <stdin>:4:10, :7:10, :18:11
+wire struct packed {logic [7:0] x; logic y; }[15:0] _T_12 = {{_T_11}, {_T_11}, {_T_11}, {_T_11}, {_T_11}, {_T_10}, {_T_9}, {_T_8}, {_T_7}, {_T_6},
+                {_T_5}, {_T_4}, {_T_3}, {_T_2}, {_T_1}, {a}};	// <stdin>:19:11
+  assign y = _T_12[s];	// <stdin>:20:11, :21:5
+endmodule
+

--- a/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper_extend_non_power_of_two_muxes_flatten_all_tuples.mlir
+++ b/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper_extend_non_power_of_two_muxes_flatten_all_tuples.mlir
@@ -1,0 +1,11 @@
+hw.module @non_power_of_two_mux_wrapper(%a_x: i8, %a_y: i1, %s: i4) -> (y_x: i8, y_y: i1) {
+    %1 = hw.constant -1 : i8
+    %0 = comb.xor %1, %a_x : i8
+    %3 = hw.constant -1 : i1
+    %2 = comb.xor %3, %a_y : i1
+    %6 = hw.array_create %0, %0, %0, %0, %0, %0, %0, %0, %0, %0, %0, %0, %0, %0, %0, %a_x : i8
+    %4 = hw.array_get %6[%s] : !hw.array<16xi8>
+    %7 = hw.array_create %2, %2, %2, %2, %2, %2, %2, %2, %2, %2, %2, %2, %2, %2, %2, %a_y : i1
+    %5 = hw.array_get %7[%s] : !hw.array<16xi1>
+    hw.output %4, %5 : i8, i1
+}

--- a/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper_extend_non_power_of_two_muxes_flatten_all_tuples.v
+++ b/tests/test_backend/test_mlir/golds/non_power_of_two_mux_wrapper_extend_non_power_of_two_muxes_flatten_all_tuples.v
@@ -1,0 +1,15 @@
+module non_power_of_two_mux_wrapper(	// <stdin>:1:1
+  input  [7:0] a_x,
+  input        a_y,
+  input  [3:0] s,
+  output [7:0] y_x,
+  output       y_y);
+
+wire [15:0][7:0] _T = {{~a_x}, {~a_x}, {~a_x}, {~a_x}, {~a_x}, {~a_x}, {~a_x}, {~a_x}, {~a_x}, {~a_x}, {~a_x},
+                {~a_x}, {~a_x}, {~a_x}, {~a_x}, {a_x}};	// <stdin>:3:10, :6:10
+wire [15:0] _T_0 = {{~a_y}, {~a_y}, {~a_y}, {~a_y}, {~a_y}, {~a_y}, {~a_y}, {~a_y}, {~a_y}, {~a_y}, {~a_y},
+                {~a_y}, {~a_y}, {~a_y}, {~a_y}, {a_y}};	// <stdin>:5:10, :8:10
+  assign y_x = _T[s];	// <stdin>:7:10, :10:5
+  assign y_y = _T_0[s];	// <stdin>:9:10, :10:5
+endmodule
+

--- a/tests/test_backend/test_mlir/golds/simple_mux_wrapper.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_mux_wrapper.mlir
@@ -1,7 +1,7 @@
 hw.module @simple_mux_wrapper(%a: i8, %s: i1) -> (y: i8) {
     %1 = hw.constant -1 : i8
     %0 = comb.xor %1, %a : i8
-    %3 = hw.array_create %a, %0 : i8
+    %3 = hw.array_create %0, %a : i8
     %2 = hw.array_get %3[%s] : !hw.array<2xi8>
     hw.output %2 : i8
 }

--- a/tests/test_backend/test_mlir/golds/simple_mux_wrapper.v
+++ b/tests/test_backend/test_mlir/golds/simple_mux_wrapper.v
@@ -3,7 +3,7 @@ module simple_mux_wrapper(	// <stdin>:1:1
   input        s,
   output [7:0] y);
 
-wire [1:0][7:0] _T = {{a}, {~a}};	// <stdin>:3:10, :4:10
+wire [1:0][7:0] _T = {{~a}, {a}};	// <stdin>:3:10, :4:10
   assign y = _T[s];	// <stdin>:5:10, :6:5
 endmodule
 

--- a/tests/test_backend/test_mlir/test_compile_to_mlir_local_examples.py
+++ b/tests/test_backend/test_mlir/test_compile_to_mlir_local_examples.py
@@ -1,11 +1,16 @@
+import itertools
 import pytest
 
 import magma as m
 from magma.primitives.mux import CoreIRCommonLibMuxN
 
 from examples import (
-    simple_aggregates_product, aggregate_mux_wrapper, complex_register_wrapper,
-    complex_bind, simple_comb,
+    simple_aggregates_product,
+    aggregate_mux_wrapper,
+    non_power_of_two_mux_wrapper,
+    complex_register_wrapper,
+    complex_bind,
+    simple_comb,
     simple_register_wrapper,
 )
 from test_utils import get_local_examples, run_test_compile_to_mlir
@@ -82,5 +87,25 @@ def test_compile_to_mlir_elaborate_magma_registers(ckt):
     kwargs = {
         "elaborate_magma_registers": True,
         "gold_name": f"{ckt.name}_elaborate_magma_registers"
+    }
+    run_test_compile_to_mlir(ckt, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "ckt,flatten_all_tuples",
+    itertools.product(
+        [aggregate_mux_wrapper, non_power_of_two_mux_wrapper],
+        (True, False),
+    )
+)
+def test_compile_to_mlir_extend_non_power_of_two_muxes(
+        ckt, flatten_all_tuples: bool):
+    gold_name = f"{ckt.name}_extend_non_power_of_two_muxes"
+    if flatten_all_tuples:
+        gold_name += "_flatten_all_tuples"
+    kwargs = {
+        "extend_non_power_of_two_muxes": True,
+        "flatten_all_tuples": flatten_all_tuples,
+        "gold_name": gold_name,
     }
     run_test_compile_to_mlir(ckt, **kwargs)

--- a/tests/test_backend/test_mlir/test_utils.py
+++ b/tests/test_backend/test_mlir/test_utils.py
@@ -143,6 +143,7 @@ def get_local_examples() -> List[DefineCircuitKind]:
         examples.aggregate_constant,
         examples.simple_mux_wrapper,
         examples.aggregate_mux_wrapper,
+        examples.non_power_of_two_mux_wrapper,
         examples.simple_register_wrapper,
         examples.complex_register_wrapper,
         examples.counter,


### PR DESCRIPTION
* Fixes flipped ordering of hw array create for mux selection
* Adds option to extend non-power-of-two muxes with the "MSB" input (disabled by default)