### PR TITLE
Fix #1073

### DIFF
--- a/magma/find_unconnected_ports.py
+++ b/magma/find_unconnected_ports.py
@@ -131,6 +131,6 @@ def find_and_log_unconnected_ports(ckt):
         debug_info = info.debug_info
         _logger.error(WiringLog("{} not driven", port), debug_info=debug_info)
         visitor = _make_unconnected_port_diagnostic_visitor_cls()()
-        diagnostics = visitor.visit(port)
+        diagnostics = list(visitor.visit(port))
         for diagnostic in diagnostics:
-            _logger.debug(diagnostic.make_wiring_log())
+            _logger.error(diagnostic.make_wiring_log())

--- a/magma/find_unconnected_ports.py
+++ b/magma/find_unconnected_ports.py
@@ -131,6 +131,6 @@ def find_and_log_unconnected_ports(ckt):
         debug_info = info.debug_info
         _logger.error(WiringLog("{} not driven", port), debug_info=debug_info)
         visitor = _make_unconnected_port_diagnostic_visitor_cls()()
-        diagnostics = list(visitor.visit(port))
+        diagnostics = visitor.visit(port)
         for diagnostic in diagnostics:
             _logger.error(diagnostic.make_wiring_log())

--- a/tests/test_circuit/test_new_style_syntax.py
+++ b/tests/test_circuit/test_new_style_syntax.py
@@ -1,7 +1,7 @@
 import magma as m
 from magma.common import wrap_with_context_manager
 from magma.logging import logging_level
-from magma.testing.utils import has_warning, has_error, has_debug
+from magma.testing.utils import has_warning, has_error
 
 
 def _check_foo_interface(Foo):
@@ -76,9 +76,9 @@ def test_new_style_unconnected(caplog):
 
     assert m.isdefinition(_Foo)
     assert has_error(caplog, "_Foo.O not driven")
-    assert has_debug(caplog, "_Foo.O")
-    assert has_debug(caplog, "    _Foo.O[0]: Connected")
-    assert has_debug(caplog, "    _Foo.O[1]: Unconnected")
+    assert has_error(caplog, "_Foo.O")
+    assert has_error(caplog, "    _Foo.O[0]: Connected")
+    assert has_error(caplog, "    _Foo.O[1]: Unconnected")
 
 
 def test_new_style_with_definition_method(caplog):
@@ -130,9 +130,9 @@ def test_inst_wiring_error(caplog):
         caplog,
         "Cannot wire _Foo._Bar_inst0.O (Out(Bits[1])) to _Foo.O (In(Bit))")
     assert has_error(caplog, "_Foo.O not driven")
-    assert has_debug(caplog, "_Foo.O: Unconnected")
+    assert has_error(caplog, "_Foo.O: Unconnected")
     assert has_error(caplog, "_Foo._Bar_inst0.I not driven")
-    assert has_debug(caplog, "_Foo._Bar_inst0.I: Unconnected")
+    assert has_error(caplog, "_Foo._Bar_inst0.I: Unconnected")
 
 
 def test_nested_definition():

--- a/tests/test_circuit/test_unconnected.py
+++ b/tests/test_circuit/test_unconnected.py
@@ -5,7 +5,7 @@ import magma as m
 from magma.common import wrap_with_context_manager
 from magma.logging import logging_level
 from magma.testing import magma_debug_section
-from magma.testing.utils import has_error, has_debug
+from magma.testing.utils import has_error
 
 
 def _make_unconnected_io():
@@ -58,9 +58,9 @@ def test_unconnected_io(caplog):
         expected = """\x1b[1mtests/test_circuit/test_unconnected.py:12\x1b[0m: _Circuit.O not driven
 >>     class _Circuit(m.Circuit):"""
         assert has_error(caplog, expected)
-        assert has_debug(caplog, "_Circuit.O")
-        assert has_debug(caplog, "    _Circuit.O[0]: Connected")
-        assert has_debug(caplog, "    _Circuit.O[1]: Unconnected")
+        assert has_error(caplog, "_Circuit.O")
+        assert has_error(caplog, "    _Circuit.O[0]: Connected")
+        assert has_error(caplog, "    _Circuit.O[1]: Unconnected")
 
 
 @wrap_with_context_manager(logging_level("DEBUG"))
@@ -70,7 +70,7 @@ def test_unconnected_instance(caplog):
         expected = """\x1b[1mtests/test_circuit/test_unconnected.py:31\x1b[0m: _Circuit.buf.I not driven
 >>         buf = _Buffer()"""
         assert has_error(caplog, expected)
-        assert has_debug(caplog, "_Circuit.buf.I: Unconnected")
+        assert has_error(caplog, "_Circuit.buf.I: Unconnected")
 
 
 @pytest.mark.parametrize("typ", [m.Clock, m.Reset, m.AsyncReset])

--- a/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
+++ b/tests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py
@@ -5,7 +5,7 @@ import magma as m
 from magma.common import wrap_with_context_manager
 from magma.logging import logging_level
 from magma.testing import magma_debug_section
-from magma.testing.utils import has_error, has_debug
+from magma.testing.utils import has_error
 
 
 def _make_unconnected_io():
@@ -67,9 +67,9 @@ def test_unconnected_io(caplog):
         expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:12\x1b[0m: _Circuit.O not driven
 >>     class _Circuit(m.Circuit):"""
         assert has_error(caplog, expected)
-        assert has_debug(caplog, "_Circuit.O")
-        assert has_debug(caplog, "    _Circuit.O[0]: Connected")
-        assert has_debug(caplog, "    _Circuit.O[1]: Unconnected")
+        assert has_error(caplog, "_Circuit.O")
+        assert has_error(caplog, "    _Circuit.O[0]: Connected")
+        assert has_error(caplog, "    _Circuit.O[1]: Unconnected")
 
 
 @wrap_with_context_manager(logging_level("DEBUG"))
@@ -79,7 +79,7 @@ def test_unconnected_instance(caplog):
         expected = """\x1b[1mtests/test_deprecated/test_old_io_syntax/test_old_io_syntax_unconnected.py:36\x1b[0m: _Circuit.buf.I not driven
 >>             buf = _Buffer()"""
         assert has_error(caplog, expected)
-        assert has_debug(caplog, "_Circuit.buf.I: Unconnected")
+        assert has_error(caplog, "_Circuit.buf.I: Unconnected")
 
 
 @pytest.mark.parametrize("typ", [m.Clock, m.Reset, m.AsyncReset])

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -4,7 +4,7 @@ from magma import *
 from magma.common import wrap_with_context_manager
 from magma.logging import logging_level
 from magma.testing.utils import (
-    has_error, has_warning, has_debug, magma_debug_section
+    has_error, has_warning, magma_debug_section
 )
 
 
@@ -200,7 +200,7 @@ def test_hanging_anon_error(caplog):
         assert has_error(caplog, msg)
         msg = "_Foo.O: Unconnected"
         assert caplog.records[1].message == msg
-        assert has_debug(caplog, msg)
+        assert has_error(caplog, msg)
 
 
 def test_wire_tuple_to_clock():


### PR DESCRIPTION
I think reporting diagnostics for errors should use error logging level
by default since it will be immediately helpful for users debugging.