### PR TITLE
[MLIR] Add undriven support

### DIFF
--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -358,6 +358,12 @@ class ModuleVisitor:
             return self.visit_coreir_wire(module)
         if defn.coreir_name == "term":
             return True
+        if defn.coreir_name == "undriven":
+            mlir_type = hw.InOutType(module.results[0].type)
+            wire = self._ctx.new_value(mlir_type)
+            sv.WireOp(results=[wire])
+            sv.ReadInOutOp(operands=[wire], results=module.results)
+            return True
         op_name = defn.coreir_name
         if op_name == "ashr":
             op_name = "shrs"

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -361,7 +361,9 @@ class ModuleVisitor:
         if defn.coreir_name == "undriven":
             mlir_type = hw.InOutType(module.results[0].type)
             wire = self._ctx.new_value(mlir_type)
-            sv.WireOp(results=[wire])
+            sym = self._ctx.parent.get_or_make_mapped_symbol(
+                inst, name=f"{self._ctx.name}.{inst.name}", force=True)
+            sv.WireOp(results=[wire], sym=sym)
             sv.ReadInOutOp(operands=[wire], results=module.results)
             return True
         op_name = defn.coreir_name

--- a/magma/backend/mlir/sv.py
+++ b/magma/backend/mlir/sv.py
@@ -127,7 +127,7 @@ class InitialOp(MlirOp):
 @dataclasses.dataclass
 class WireOp(MlirOp):
     results: List[MlirValue]
-    name: str
+    name: Optional[str] = None
     sym: Optional[MlirSymbol] = None
 
     def print_op(self, printer: PrinterBase):
@@ -135,7 +135,9 @@ class WireOp(MlirOp):
         printer.print(" = sv.wire ")
         if self.sym is not None:
             printer.print(f"sym {self.sym.name} ")
-        printer.print(f"{{name=\"{self.name}\"}} : ")
+        if self.name is not None:
+            printer.print(f"{{name=\"{self.name}\"}} ")
+        printer.print(": ")
         print_types(self.results, printer)
 
 

--- a/tests/test_backend/test_mlir/examples.py
+++ b/tests/test_backend/test_mlir/examples.py
@@ -477,3 +477,14 @@ class simple_module_params_instance(m.Circuit):
     io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
     inst = simple_module_params(width=10, height=20)
     io.O @= inst(io.I)
+
+
+class simple_undriven(m.Circuit):
+    io = m.IO(O=m.Out(m.Bit))
+    io.O.undriven()
+
+
+class complex_undriven(m.Circuit):
+    T = m.Product.from_fields("anon", dict(x=m.Bits[8], y=m.Bit))
+    io = m.IO(O=m.Out(T))
+    io.O.undriven()

--- a/tests/test_backend/test_mlir/golds/complex_undriven.mlir
+++ b/tests/test_backend/test_mlir/golds/complex_undriven.mlir
@@ -1,0 +1,8 @@
+hw.module @complex_undriven() -> (O: !hw.struct<x: i8, y: i1>) {
+    %1 = sv.wire : !hw.inout<i8>
+    %0 = sv.read_inout %1 : !hw.inout<i8>
+    %3 = sv.wire : !hw.inout<i1>
+    %2 = sv.read_inout %3 : !hw.inout<i1>
+    %4 = hw.struct_create (%0, %2) : !hw.struct<x: i8, y: i1>
+    hw.output %4 : !hw.struct<x: i8, y: i1>
+}

--- a/tests/test_backend/test_mlir/golds/complex_undriven.mlir
+++ b/tests/test_backend/test_mlir/golds/complex_undriven.mlir
@@ -1,7 +1,7 @@
 hw.module @complex_undriven() -> (O: !hw.struct<x: i8, y: i1>) {
-    %1 = sv.wire : !hw.inout<i8>
+    %1 = sv.wire sym @complex_undriven.undriven_inst0 : !hw.inout<i8>
     %0 = sv.read_inout %1 : !hw.inout<i8>
-    %3 = sv.wire : !hw.inout<i1>
+    %3 = sv.wire sym @complex_undriven.corebit_undriven_inst0 : !hw.inout<i1>
     %2 = sv.read_inout %3 : !hw.inout<i1>
     %4 = hw.struct_create (%0, %2) : !hw.struct<x: i8, y: i1>
     hw.output %4 : !hw.struct<x: i8, y: i1>

--- a/tests/test_backend/test_mlir/golds/complex_undriven.v
+++ b/tests/test_backend/test_mlir/golds/complex_undriven.v
@@ -1,0 +1,6 @@
+module complex_undriven(	// <stdin>:1:1
+  output struct packed {logic [7:0] x; logic y; } O);
+
+  assign O = '{x: (8'bx), y: (1'bx)};	// <stdin>:2:10, :4:10, :6:10, :7:5
+endmodule
+

--- a/tests/test_backend/test_mlir/golds/complex_undriven.v
+++ b/tests/test_backend/test_mlir/golds/complex_undriven.v
@@ -1,6 +1,9 @@
 module complex_undriven(	// <stdin>:1:1
   output struct packed {logic [7:0] x; logic y; } O);
 
-  assign O = '{x: (8'bx), y: (1'bx)};	// <stdin>:2:10, :4:10, :6:10, :7:5
+  wire [7:0] _T;	// <stdin>:2:10
+  wire       _T_0;	// <stdin>:4:10
+
+  assign O = '{x: _T, y: _T_0};	// <stdin>:3:10, :5:10, :6:10, :7:5
 endmodule
 

--- a/tests/test_backend/test_mlir/golds/simple_undriven.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_undriven.mlir
@@ -1,0 +1,5 @@
+hw.module @simple_undriven() -> (O: i1) {
+    %1 = sv.wire : !hw.inout<i1>
+    %0 = sv.read_inout %1 : !hw.inout<i1>
+    hw.output %0 : i1
+}

--- a/tests/test_backend/test_mlir/golds/simple_undriven.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_undriven.mlir
@@ -1,5 +1,5 @@
 hw.module @simple_undriven() -> (O: i1) {
-    %1 = sv.wire : !hw.inout<i1>
+    %1 = sv.wire sym @simple_undriven.corebit_undriven_inst0 : !hw.inout<i1>
     %0 = sv.read_inout %1 : !hw.inout<i1>
     hw.output %0 : i1
 }

--- a/tests/test_backend/test_mlir/golds/simple_undriven.v
+++ b/tests/test_backend/test_mlir/golds/simple_undriven.v
@@ -1,6 +1,8 @@
 module simple_undriven(	// <stdin>:1:1
   output O);
 
-  assign O = 1'bx;	// <stdin>:2:10, :4:5
+  wire _T;	// <stdin>:2:10
+
+  assign O = _T;	// <stdin>:3:10, :4:5
 endmodule
 

--- a/tests/test_backend/test_mlir/golds/simple_undriven.v
+++ b/tests/test_backend/test_mlir/golds/simple_undriven.v
@@ -1,0 +1,6 @@
+module simple_undriven(	// <stdin>:1:1
+  output O);
+
+  assign O = 1'bx;	// <stdin>:2:10, :4:5
+endmodule
+

--- a/tests/test_backend/test_mlir/test_utils.py
+++ b/tests/test_backend/test_mlir/test_utils.py
@@ -176,6 +176,8 @@ def get_local_examples() -> List[DefineCircuitKind]:
         examples.simple_compile_guard,
         examples.simple_custom_verilog_name,
         examples.simple_module_params_instance,
+        examples.simple_undriven,
+        examples.complex_undriven,
     ]
 
 


### PR DESCRIPTION
This change adds support for the coreir.undriven primitive in the MLIR backend. The MLIR (IR) we emit contains dangling wires that hook up to "undriven" ports.

NOTE: SV::WireOp canonicalization converts undriven wires to be driven by X. So if we run canonicalization (which we definitely should), the dangling wires will be assigned to `X`.