### PR TITLE
[MLIR] Add support for unconnected module

### DIFF
--- a/magma/backend/mlir/errors.py
+++ b/magma/backend/mlir/errors.py
@@ -1,0 +1,10 @@
+class MlirCompilerErrorBase(RuntimeError):
+    pass
+
+
+class MlirCompilerInternalError(MlirCompilerErrorBase):
+    pass
+
+
+class MlirCompilerError(MlirCompilerErrorBase):
+    pass

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -14,6 +14,7 @@ from magma.backend.mlir.builtin import builtin
 from magma.backend.mlir.comb import comb
 from magma.backend.mlir.common import wrap_with_not_implemented_error
 from magma.backend.mlir.compile_to_mlir_opts import CompileToMlirOpts
+from magma.backend.mlir.errors import MlirCompilerInternalError
 from magma.backend.mlir.graph_lib import Graph
 from magma.backend.mlir.hw import hw
 from magma.backend.mlir.magma_common import (
@@ -238,6 +239,13 @@ class ModuleWrapper:
 
 
 class ModuleVisitor:
+
+    class VisitError(RuntimeError):
+        pass
+
+    class RevisitedModuleError(VisitError):
+        pass
+
     def __init__(self, graph: Graph, ctx):
         self._graph = graph
         self._ctx = ctx
@@ -789,20 +797,25 @@ class ModuleVisitor:
         if isinstance(module.module, MagmaInstanceWrapper):
             return self.visit_instance_wrapper(module)
 
-    def visit(self, module: MagmaModuleLike):
-        if module in self._visited:
-            raise RuntimeError(f"Can not re-visit module")
-        self._visited.add(module)
-        for predecessor in self._graph.predecessors(module):
+    def _process_magma_module(self, magma_module: MagmaModuleLike):
+        if not self._graph.has_node(magma_module):
+            return
+        for predecessor in self._graph.predecessors(magma_module):
             if predecessor in self._visited:
                 continue
             self.visit(predecessor)
-        for src, _, data in self._graph.in_edges(module, data=True):
+        for src, _, data in self._graph.in_edges(magma_module, data=True):
             info = data["info"]
             src_port, dst_port = info["src"], info["dst"]
             src_value = self._ctx.get_or_make_mapped_value(src_port)
             self._ctx.set_mapped_value(dst_port, src_value)
-        assert self.visit_module(ModuleWrapper.make(module, self._ctx))
+
+    def visit(self, module: MagmaModuleLike):
+        if module in self._visited:
+            raise ModuleVisitor.RevisitedModuleError(module)
+        self._visited.add(module)
+        self._process_magma_module(module)
+        self.visit_module(ModuleWrapper.make(module, self._ctx))
         instances = getattr(module, "instances", [])
         for inst in instances:
             if inst in self._visited:
@@ -1097,7 +1110,10 @@ class HardwareModule:
             self._magma_defn_or_decl, build_magma_graph_opts)
         visitor = ModuleVisitor(graph, self)
         with push_block(op):
-            visitor.visit(self._magma_defn_or_decl)
+            try:
+                visitor.visit(self._magma_defn_or_decl)
+            except ModuleVisitor.VisitError:
+                raise MlirCompilerInternalError(visitor)
             bind_processor.process()
             output_values = new_values(self.get_or_make_mapped_value, i)
             if named_outputs:

--- a/magma/backend/mlir/mlir_compiler_exception.py
+++ b/magma/backend/mlir/mlir_compiler_exception.py
@@ -1,2 +1,0 @@
-class MlirCompilerException(Exception):
-    pass

--- a/magma/backend/mlir/mlir_to_verilog.py
+++ b/magma/backend/mlir/mlir_to_verilog.py
@@ -5,15 +5,15 @@ import subprocess
 import sys
 from typing import List, Optional
 
-from magma.backend.mlir.mlir_compiler_exception import MlirCompilerException
 from magma.backend.mlir.common import try_call
+from magma.backend.mlir.errors import MlirCompilerError
 from magma.config import config, EnvConfig
 
 
 config._register(circt_home=EnvConfig("CIRCT_HOME", "./circt"))
 
 
-class MlirToVerilogException(MlirCompilerException):
+class MlirToVerilogError(MlirCompilerError):
     pass
 
 
@@ -83,7 +83,7 @@ def mlir_to_verilog(istream: io.RawIOBase, ostream: io.RawIOBase = sys.stdout):
     returncode = _run_subprocess(cmd, istream, ostream)
     if returncode != 0:
         cmd_str = " ".join(cmd)
-        raise MlirToVerilogException(
+        raise MlirToVerilogError(
             f"Error running {cmd_str}, got returncode {returncode}"
         )
 

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -12,8 +12,8 @@ from magma.config import get_compile_dir
 from magma.inline_verilog import ProcessInlineVerilogPass
 from magma.is_definition import isdefinition
 from magma.passes.clock import WireClockPass
-from magma.passes.drive_undriven import DriveUndrivenPass
-from magma.passes.terminate_unused import TerminateUnusedPass
+from magma.passes.drive_undriven import drive_undriven
+from magma.passes.terminate_unused import terminate_unused
 from magma.uniquification import (uniquification_pass, UniquificationMode,
                                   reset_names)
 
@@ -93,9 +93,9 @@ def compile(basename, main, output="coreir-verilog", **kwargs):
              opts.get("verilog_prefix")).run()
 
     if opts.get("drive_undriven", False):
-        DriveUndrivenPass(main).run()
+        drive_undriven(main)
     if opts.get("terminate_unused", False):
-        TerminateUnusedPass(main).run()
+        terminate_unused(main)
 
     result = compiler.compile()
     result = {} if result is None else result

--- a/magma/passes/drive_undriven.py
+++ b/magma/passes/drive_undriven.py
@@ -1,9 +1,11 @@
-from .passes import EditDefinitionPass
-from ..is_definition import isdefinition
 from magma.array import Array
 from magma.clock import is_clock_or_nested_clock
+from magma.is_definition import isdefinition
 from magma.passes.clock import (
-    drive_all_undriven_clocks_in_value, get_all_output_clocks_in_defn)
+    drive_all_undriven_clocks_in_value,
+    get_all_output_clocks_in_defn,
+)
+from magma.passes.passes import EditDefinitionPass, pass_lambda
 from magma.tuple import Tuple
 
 
@@ -47,3 +49,6 @@ class DriveUndrivenPass(EditDefinitionPass):
             return
         for inst in circuit.instances:
             _drive_undriven(inst.interface, clocks)
+
+
+drive_undriven = pass_lambda(DriveUndrivenPass)

--- a/magma/passes/terminate_unused.py
+++ b/magma/passes/terminate_unused.py
@@ -1,5 +1,5 @@
-from .passes import EditDefinitionPass
-from ..is_definition import isdefinition
+from magma.is_definition import isdefinition
+from magma.passes.passes import EditDefinitionPass, pass_lambda
 
 
 def _terminate_if_unwired_output(port):
@@ -28,3 +28,6 @@ class TerminateUnusedPass(EditDefinitionPass):
             return
         for inst in circuit.instances:
             _terminate_unused(inst.interface)
+
+
+terminate_unused = pass_lambda(TerminateUnusedPass)

--- a/tests/test_backend/test_mlir/examples.py
+++ b/tests/test_backend/test_mlir/examples.py
@@ -2,6 +2,7 @@ import itertools
 
 import magma as m
 from magma.inline_verilog import ProcessInlineVerilogPass
+from magma.passes.drive_undriven import drive_undriven
 
 
 class simple_comb(m.Circuit):
@@ -513,3 +514,12 @@ class simple_memory_wrapper(m.Circuit):
 
 
 m.passes.clock.WireClockPass(simple_memory_wrapper).run()
+
+
+class simple_undriven_instances(m.Circuit):
+    io = m.IO()
+    simple_comb()
+    simple_comb()
+
+
+drive_undriven(simple_undriven_instances)

--- a/tests/test_backend/test_mlir/golds/simple_undriven_instances.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_undriven_instances.mlir
@@ -1,0 +1,23 @@
+hw.module @simple_comb(%a: i16, %b: i16, %c: i16) -> (y: i16, z: i16) {
+    %1 = hw.constant -1 : i16
+    %0 = comb.xor %1, %a : i16
+    %2 = comb.or %a, %0 : i16
+    %3 = comb.or %2, %b : i16
+    hw.output %3, %3 : i16, i16
+}
+hw.module @simple_undriven_instances() -> () {
+    %1 = sv.wire sym @simple_undriven_instances.undriven_inst0 : !hw.inout<i16>
+    %0 = sv.read_inout %1 : !hw.inout<i16>
+    %3 = sv.wire sym @simple_undriven_instances.undriven_inst1 : !hw.inout<i16>
+    %2 = sv.read_inout %3 : !hw.inout<i16>
+    %5 = sv.wire sym @simple_undriven_instances.undriven_inst2 : !hw.inout<i16>
+    %4 = sv.read_inout %5 : !hw.inout<i16>
+    %6, %7 = hw.instance "simple_comb_inst0" @simple_comb(a: %0: i16, b: %2: i16, c: %4: i16) -> (y: i16, z: i16)
+    %9 = sv.wire sym @simple_undriven_instances.undriven_inst3 : !hw.inout<i16>
+    %8 = sv.read_inout %9 : !hw.inout<i16>
+    %11 = sv.wire sym @simple_undriven_instances.undriven_inst4 : !hw.inout<i16>
+    %10 = sv.read_inout %11 : !hw.inout<i16>
+    %13 = sv.wire sym @simple_undriven_instances.undriven_inst5 : !hw.inout<i16>
+    %12 = sv.read_inout %13 : !hw.inout<i16>
+    %14, %15 = hw.instance "simple_comb_inst1" @simple_comb(a: %8: i16, b: %10: i16, c: %12: i16) -> (y: i16, z: i16)
+}

--- a/tests/test_backend/test_mlir/golds/simple_undriven_instances.v
+++ b/tests/test_backend/test_mlir/golds/simple_undriven_instances.v
@@ -1,0 +1,36 @@
+module simple_comb(	// <stdin>:1:1
+  input  [15:0] a, b, c,
+  output [15:0] y, z);
+
+  assign y = 16'hFFFF;	// <stdin>:2:10, :6:5
+  assign z = 16'hFFFF;	// <stdin>:2:10, :6:5
+endmodule
+
+module simple_undriven_instances();	// <stdin>:8:1
+  wire [15:0] simple_comb_inst1_y;	// <stdin>:22:16
+  wire [15:0] simple_comb_inst1_z;	// <stdin>:22:16
+  wire [15:0] simple_comb_inst0_y;	// <stdin>:15:14
+  wire [15:0] simple_comb_inst0_z;	// <stdin>:15:14
+  wire [15:0] _T;	// <stdin>:9:10
+  wire [15:0] _T_0;	// <stdin>:11:10
+  wire [15:0] _T_1;	// <stdin>:13:10
+  wire [15:0] _T_2;	// <stdin>:16:10
+  wire [15:0] _T_3;	// <stdin>:18:11
+  wire [15:0] _T_4;	// <stdin>:20:11
+
+  simple_comb simple_comb_inst0 (	// <stdin>:15:14
+    .a (_T),	// <stdin>:10:10
+    .b (_T_0),	// <stdin>:12:10
+    .c (_T_1),	// <stdin>:14:10
+    .y (simple_comb_inst0_y),
+    .z (simple_comb_inst0_z)
+  );
+  simple_comb simple_comb_inst1 (	// <stdin>:22:16
+    .a (_T_2),	// <stdin>:17:10
+    .b (_T_3),	// <stdin>:19:11
+    .c (_T_4),	// <stdin>:21:11
+    .y (simple_comb_inst1_y),
+    .z (simple_comb_inst1_z)
+  );
+endmodule
+

--- a/tests/test_backend/test_mlir/test_mlir_to_verilog.py
+++ b/tests/test_backend/test_mlir/test_mlir_to_verilog.py
@@ -6,7 +6,7 @@ import magma as m
 from magma.backend.mlir.mlir_to_verilog import (
     mlir_to_verilog,
     circt_opt_binary_exists,
-    MlirToVerilogException,
+    MlirToVerilogError,
 )
 from magma.testing.utils import with_config
 
@@ -50,5 +50,5 @@ def test_module():
 
 def test_bad_input():
     _skip_if_circt_opt_binary_does_not_exist()
-    with pytest.raises(MlirToVerilogException):
+    with pytest.raises(MlirToVerilogError):
         _run_test("blahblahblah")

--- a/tests/test_backend/test_mlir/test_utils.py
+++ b/tests/test_backend/test_mlir/test_utils.py
@@ -179,6 +179,7 @@ def get_local_examples() -> List[DefineCircuitKind]:
         examples.simple_undriven,
         examples.complex_undriven,
         examples.simple_memory_wrapper,
+        examples.simple_undriven_instances,
     ]
 
 


### PR DESCRIPTION
Adds support for the case where a module definition has no connections.
This could happen, for example, where the module is simply a container
for undriven instances (as in the added test).