### PR TITLE
[When] Detect latches

### DIFF
--- a/magma/backend/mlir/check_latches.py
+++ b/magma/backend/mlir/check_latches.py
@@ -10,7 +10,7 @@ class LatchError(Exception):
         latches_str = ", ".join(latch.debug_name for latch in latches)
         defn_str = str(ctx.magma_defn_or_decl)
         msg = (f"Error while compiling {defn_str}, "
-               f"detected latches: [{latches_str}]")
+               f"detected potential latches: [{latches_str}]")
         super().__init__(msg)
 
 

--- a/magma/backend/mlir/check_latches.py
+++ b/magma/backend/mlir/check_latches.py
@@ -1,0 +1,50 @@
+from typing import Dict
+
+from magma.t import Type
+from magma.backend.mlir.sv import sv
+from magma.backend.mlir.mlir import MlirValue
+
+
+class LatchError(Exception):
+    def __init__(self, latches, ctx):
+        latches_str = ", ".join(latch.debug_name for latch in latches)
+        defn_str = str(ctx.magma_defn_or_decl)
+        msg = (f"Error while compiling {defn_str}, "
+               f"detected latches: [{latches_str}]")
+        super().__init__(msg)
+
+
+def _get_latches_and_assigned_values(operations):
+    assigned_values = set()
+    latches = set()
+    for op in operations:
+        if isinstance(op, sv.BPAssignOp):
+            assigned_values.add(op.operands[0])
+        elif isinstance(op, sv.IfOp):
+            then_latches, then_assigned_values = \
+                _get_latches_and_assigned_values(op._then_block.operations)
+            if op._else_block is not None:
+                else_latches, else_assigned_values = \
+                    _get_latches_and_assigned_values(op._else_block.operations)
+                latches.update(then_latches.difference(assigned_values))
+                latches.update(else_latches.difference(assigned_values))
+                latches.update(
+                    then_assigned_values.symmetric_difference(
+                        else_assigned_values).difference(assigned_values))
+                assigned_values.update(
+                    then_assigned_values.union(else_assigned_values))
+            else:
+                latches.update(then_latches.difference(assigned_values))
+                latches.update(
+                    then_assigned_values.difference(
+                        assigned_values))
+    return latches, assigned_values
+
+
+def check_latches(always: sv.AlwaysCombOp,
+                  reg_to_val_map: Dict[MlirValue, Type],
+                  ctx):
+    latches, _ = _get_latches_and_assigned_values(always.body_block.operations)
+    if latches:
+        values = [reg_to_val_map[latch] for latch in latches]
+        raise LatchError(values, ctx)


### PR DESCRIPTION
Adds a conservative latch detection check.

Note, we do this on the generated MLIR because it has a regular syntax structure we can use to do the analysis as a standard recursive tree traversal.  Doing this at the magma level is difficult for a few reasons: 
1. It's difficult to do at when context enter/exit time because we have optional elsewhen/otherwise statements that make it difficult for us to determine when to run the analysis (i.e. when the chain has finished).  
2. It's difficult to do at definition close time because the representation used internally does not immediately map to the original when structure (which is useful for doing the standard recursive tree traversal approach).  The next step would be to convert the IR into the original when structure to do the analysis, but that's what the MLIR transformation does, so then it seems simpler to do on the MLIR representation since we already have the desired structure at that time.

Finally, this is likely to be a generally useful pass for the MLIR SV dialect, so the long term plan may be to migrate this logic into MLIR for more general reuse/improvement.