### PR TITLE
[When] Fix bug with lazy array value creation

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -680,12 +680,12 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
 
     def _make_t(self, index):
         if issubclass(self.T, MagmaProtocol):
-            result = self.T._from_magma_value_(
-                self.T._to_magma_()(name=ArrayRef(self, index)))
-        else:
-            result = self.T(name=ArrayRef(self, index))
-        result.set_when_context(self._when_context)
-        return result
+            value = self.T._to_magma_()(name=ArrayRef(self, index))
+            value.set_when_context(self._when_context)
+            return self.T._from_magma_value_(value)
+        value = self.T(name=ArrayRef(self, index))
+        value.set_when_context(self._when_context)
+        return value
 
     def _resolve_slice_children(self, start, stop, slice_value):
         for i in range(start, stop):

--- a/magma/array.py
+++ b/magma/array.py
@@ -676,11 +676,11 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         If a child reference is made, we "expand" a bulk wire into the
         constiuent children to maintain consistency
         """
-        # TODO(leonardt): Because of
+        # NOTE(leonardt): Because of
         # https://github.com/phanrahan/magma/pull/1131, we can assume that bulk
         # wire resolution happens either when there is no when or before
         # entering a when context, so if it happens as part of a when entrance,
-        # we should resolve in the no when context first
+        # we should resolve in the no when context first.
         curr_when = get_curr_when_block()
         set_curr_when_block(None)
         if self._wire.driven():

--- a/magma/protocol_type.py
+++ b/magma/protocol_type.py
@@ -51,6 +51,16 @@ class MagmaProtocolMeta(type):
     def direction(cls) -> int:
         return cls._to_magma_().direction
 
+    def flat_length(cls):
+        return cls._to_magma_().flat_length()
+
+    def unflatten(cls, ts):
+        return cls._from_magma_value_(cls._to_magma_().unflatten(ts))
+
+    @property
+    def undirected_t(cls):
+        return cls._to_magma_().undirected_t
+
 
 class MagmaProtocol(metaclass=MagmaProtocolMeta):
     @abc.abstractmethod
@@ -84,8 +94,8 @@ class MagmaProtocol(metaclass=MagmaProtocolMeta):
     def value(self):
         return self._get_magma_value_().value()
 
-    def trace(self):
-        return self._get_magma_value_().trace()
+    def trace(self, skip_self=True):
+        return self._get_magma_value_().trace(skip_self)
 
     def driven(self):
         return self._get_magma_value_().driven()
@@ -106,10 +116,10 @@ class MagmaProtocol(metaclass=MagmaProtocolMeta):
             other = other._get_magma_value_()
         self._get_magma_value_().wire(other, debug_info)
 
-    def unwire(self, other):
+    def unwire(self, other, debug_info=None):
         if isinstance(other, MagmaProtocol):
             other = other._get_magma_value_()
-        self._get_magma_value_().unwire(other)
+        self._get_magma_value_().unwire(other, debug_info)
 
     def __imatmul__(self, other):
         self.wire(other)
@@ -117,6 +127,9 @@ class MagmaProtocol(metaclass=MagmaProtocolMeta):
 
     def connection_iter(self):
         return self._get_magma_value_().connection_iter()
+
+    def const(self):
+        return self._get_magma_value_().const()
 
 
 def magma_type(T):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -447,6 +447,10 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
     def has_children(self):
         return True
 
+    def set_when_context(self, ctx):
+        for value in self:
+            value.set_when_context(ctx)
+
 
 def _add_properties(ns, fields):
     def _make_prop(field_type, idx):

--- a/magma/when.py
+++ b/magma/when.py
@@ -290,6 +290,7 @@ def _reset_prev_block():
 
 
 get_curr_block = _get_curr_block
+set_curr_block = _set_curr_block
 
 
 def _reset_context():

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -170,12 +170,10 @@ class Wire:
 class Wireable:
     def __init__(self):
         self._wire = Wire(self)
-        if isinstance(self.name, ArrayRef):
-            # Lazily constructed children should inherit the parent value's
-            # context, TODO(leonardt): update for Tuple2 when merged
-            self._when_context = self.name.array._when_context
-        else:
-            self._when_context = get_curr_when_block()
+        self._when_context = get_curr_when_block()
+
+    def set_when_context(self, ctx):
+        self._when_context = ctx
 
     def wired(self):
         return self._wire.wired()

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -4,7 +4,6 @@ from magma.config import config, EnvConfig
 from magma.debug import debug_wire
 from magma.logging import root_logger, StagedLogRecord
 from magma.when import get_curr_block as get_curr_when_block
-from magma.ref import ArrayRef
 
 
 config._register(

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -4,6 +4,7 @@ from magma.config import config, EnvConfig
 from magma.debug import debug_wire
 from magma.logging import root_logger, StagedLogRecord
 from magma.when import get_curr_block as get_curr_when_block
+from magma.ref import ArrayRef
 
 
 config._register(
@@ -169,7 +170,12 @@ class Wire:
 class Wireable:
     def __init__(self):
         self._wire = Wire(self)
-        self._when_context = get_curr_when_block()
+        if isinstance(self.name, ArrayRef):
+            # Lazily constructed children should inherit the parent value's
+            # context, TODO(leonardt): update for Tuple2 when merged
+            self._when_context = self.name.array._when_context
+        else:
+            self._when_context = get_curr_when_block()
 
     def wired(self):
         return self._wire.wired()

--- a/tests/gold/test_when_lazy_array.mlir
+++ b/tests/gold/test_when_lazy_array.mlir
@@ -1,0 +1,22 @@
+hw.module @test_when_lazy_array(%S: i1) -> (O: i2) {
+    %0 = hw.constant 0 : i1
+    %1 = hw.constant 1 : i1
+    %4 = sv.reg : !hw.inout<i1>
+    %2 = sv.read_inout %4 : !hw.inout<i1>
+    %5 = sv.reg : !hw.inout<i1>
+    %3 = sv.read_inout %5 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %4, %0 : i1
+            sv.bpassign %5, %1 : i1
+        } else {
+            sv.bpassign %4, %1 : i1
+            sv.bpassign %5, %0 : i1
+        }
+    }
+    %6 = comb.concat %3, %2 : i1, i1
+    %8 = sv.wire sym @test_when_lazy_array.x {name="x"} : !hw.inout<i2>
+    sv.assign %8, %6 : i2
+    %7 = sv.read_inout %8 : !hw.inout<i2>
+    hw.output %7 : i2
+}

--- a/tests/gold/test_when_lazy_array_nested.mlir
+++ b/tests/gold/test_when_lazy_array_nested.mlir
@@ -10,11 +10,11 @@ hw.module @test_when_lazy_array_nested(%S: i1) -> (O: !hw.array<2x!hw.struct<0: 
     %9 = sv.reg : !hw.inout<i1>
     %5 = sv.read_inout %9 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %6, %0 : i1
-        sv.bpassign %7, %1 : i1
-        sv.bpassign %8, %0 : i1
-        sv.bpassign %9, %1 : i1
         sv.if %S {
+            sv.bpassign %6, %0 : i1
+            sv.bpassign %7, %1 : i1
+            sv.bpassign %8, %0 : i1
+            sv.bpassign %9, %1 : i1
         } else {
             sv.bpassign %6, %1 : i1
             sv.bpassign %7, %0 : i1

--- a/tests/gold/test_when_lazy_array_nested.mlir
+++ b/tests/gold/test_when_lazy_array_nested.mlir
@@ -1,0 +1,37 @@
+hw.module @test_when_lazy_array_nested(%S: i1) -> (O: !hw.array<2x!hw.struct<0: i1, 1: i1>>) {
+    %0 = hw.constant 0 : i1
+    %1 = hw.constant 1 : i1
+    %6 = sv.reg : !hw.inout<i1>
+    %2 = sv.read_inout %6 : !hw.inout<i1>
+    %7 = sv.reg : !hw.inout<i1>
+    %3 = sv.read_inout %7 : !hw.inout<i1>
+    %8 = sv.reg : !hw.inout<i1>
+    %4 = sv.read_inout %8 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %9 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.bpassign %6, %0 : i1
+        sv.bpassign %7, %1 : i1
+        sv.bpassign %8, %0 : i1
+        sv.bpassign %9, %1 : i1
+        sv.if %S {
+        } else {
+            sv.bpassign %6, %1 : i1
+            sv.bpassign %7, %0 : i1
+            sv.bpassign %8, %1 : i1
+            sv.bpassign %9, %0 : i1
+        }
+    }
+    %10 = comb.concat %5, %4, %3, %2 : i1, i1, i1, i1
+    %12 = sv.wire sym @test_when_lazy_array_nested.x {name="x"} : !hw.inout<i4>
+    sv.assign %12, %10 : i4
+    %11 = sv.read_inout %12 : !hw.inout<i4>
+    %13 = comb.extract %11 from 0 : (i4) -> i1
+    %14 = comb.extract %11 from 1 : (i4) -> i1
+    %15 = hw.struct_create (%13, %14) : !hw.struct<0: i1, 1: i1>
+    %16 = comb.extract %11 from 2 : (i4) -> i1
+    %17 = comb.extract %11 from 3 : (i4) -> i1
+    %18 = hw.struct_create (%16, %17) : !hw.struct<0: i1, 1: i1>
+    %19 = hw.array_create %18, %15 : !hw.struct<0: i1, 1: i1>
+    hw.output %19 : !hw.array<2x!hw.struct<0: i1, 1: i1>>
+}

--- a/tests/gold/test_when_lazy_array_protocol.mlir
+++ b/tests/gold/test_when_lazy_array_protocol.mlir
@@ -1,0 +1,22 @@
+hw.module @test_when_lazy_array_protocol(%S: i1) -> (O: !hw.array<2xi1>) {
+    %0 = hw.constant 0 : i1
+    %1 = hw.constant 1 : i1
+    %4 = sv.reg : !hw.inout<i1>
+    %2 = sv.read_inout %4 : !hw.inout<i1>
+    %5 = sv.reg : !hw.inout<i1>
+    %3 = sv.read_inout %5 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %4, %0 : i1
+            sv.bpassign %5, %0 : i1
+        } else {
+            sv.bpassign %4, %1 : i1
+            sv.bpassign %5, %1 : i1
+        }
+    }
+    %6 = comb.concat %3, %2 : i1, i1
+    %8 = sv.wire sym @test_when_lazy_array_protocol.x {name="x"} : !hw.inout<i2>
+    sv.assign %8, %6 : i2
+    %7 = sv.read_inout %8 : !hw.inout<i2>
+    hw.output %7 : i2
+}

--- a/tests/gold/test_when_lazy_array_resolve.mlir
+++ b/tests/gold/test_when_lazy_array_resolve.mlir
@@ -1,20 +1,20 @@
 hw.module @test_when_lazy_array_resolve(%I: i2, %S: i1) -> (O: i2) {
     %0 = comb.extract %I from 0 : (i2) -> i1
-    %1 = hw.constant 1 : i2
-    %2 = comb.shru %I, %1 : i2
-    %3 = comb.extract %2 from 0 : (i2) -> i1
-    %4 = comb.extract %I from 1 : (i2) -> i1
-    %5 = comb.extract %2 from 1 : (i2) -> i1
+    %1 = comb.extract %I from 1 : (i2) -> i1
+    %2 = hw.constant 1 : i2
+    %3 = comb.shru %I, %2 : i2
+    %4 = comb.extract %3 from 0 : (i2) -> i1
+    %5 = comb.extract %3 from 1 : (i2) -> i1
     %8 = sv.reg : !hw.inout<i1>
     %6 = sv.read_inout %8 : !hw.inout<i1>
     %9 = sv.reg : !hw.inout<i1>
     %7 = sv.read_inout %9 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %8, %0 : i1
-        sv.bpassign %9, %4 : i1
         sv.if %S {
+            sv.bpassign %8, %0 : i1
+            sv.bpassign %9, %1 : i1
         } else {
-            sv.bpassign %8, %3 : i1
+            sv.bpassign %8, %4 : i1
             sv.bpassign %9, %5 : i1
         }
     }

--- a/tests/gold/test_when_lazy_array_slice.mlir
+++ b/tests/gold/test_when_lazy_array_slice.mlir
@@ -1,28 +1,30 @@
 hw.module @test_when_lazy_array_slice(%S: i1) -> (O: i4) {
-    %0 = hw.constant 0 : i2
-    %1 = hw.constant 1 : i2
-    %2 = hw.constant 1 : i2
-    %3 = hw.constant 0 : i2
-    %6 = sv.reg : !hw.inout<i2>
-    %4 = sv.read_inout %6 : !hw.inout<i2>
-    %7 = sv.reg : !hw.inout<i2>
-    %5 = sv.read_inout %7 : !hw.inout<i2>
+    %0 = hw.constant 0 : i1
+    %1 = hw.constant 1 : i1
+    %6 = sv.reg : !hw.inout<i1>
+    %2 = sv.read_inout %6 : !hw.inout<i1>
+    %7 = sv.reg : !hw.inout<i1>
+    %3 = sv.read_inout %7 : !hw.inout<i1>
+    %8 = sv.reg : !hw.inout<i1>
+    %4 = sv.read_inout %8 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %9 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %6, %0 : i2
-            sv.bpassign %7, %1 : i2
+            sv.bpassign %6, %0 : i1
+            sv.bpassign %7, %0 : i1
+            sv.bpassign %8, %1 : i1
+            sv.bpassign %9, %0 : i1
         } else {
-            sv.bpassign %6, %2 : i2
-            sv.bpassign %7, %3 : i2
+            sv.bpassign %6, %1 : i1
+            sv.bpassign %7, %0 : i1
+            sv.bpassign %8, %0 : i1
+            sv.bpassign %9, %0 : i1
         }
     }
-    %8 = comb.extract %4 from 0 : (i2) -> i1
-    %9 = comb.extract %4 from 1 : (i2) -> i1
-    %10 = comb.extract %5 from 0 : (i2) -> i1
-    %11 = comb.extract %5 from 1 : (i2) -> i1
-    %12 = comb.concat %11, %10, %9, %8 : i1, i1, i1, i1
-    %14 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
-    sv.assign %14, %12 : i4
-    %13 = sv.read_inout %14 : !hw.inout<i4>
-    hw.output %13 : i4
+    %10 = comb.concat %5, %4, %3, %2 : i1, i1, i1, i1
+    %12 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
+    sv.assign %12, %10 : i4
+    %11 = sv.read_inout %12 : !hw.inout<i4>
+    hw.output %11 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice.mlir
+++ b/tests/gold/test_when_lazy_array_slice.mlir
@@ -1,0 +1,28 @@
+hw.module @test_when_lazy_array_slice(%S: i1) -> (O: i4) {
+    %0 = hw.constant 0 : i2
+    %1 = hw.constant 1 : i2
+    %2 = hw.constant 1 : i2
+    %3 = hw.constant 0 : i2
+    %6 = sv.reg : !hw.inout<i2>
+    %4 = sv.read_inout %6 : !hw.inout<i2>
+    %7 = sv.reg : !hw.inout<i2>
+    %5 = sv.read_inout %7 : !hw.inout<i2>
+    sv.alwayscomb {
+        sv.bpassign %6, %0 : i2
+        sv.bpassign %7, %2 : i2
+        sv.if %S {
+        } else {
+            sv.bpassign %6, %1 : i2
+            sv.bpassign %7, %3 : i2
+        }
+    }
+    %8 = comb.extract %4 from 0 : (i2) -> i1
+    %9 = comb.extract %4 from 1 : (i2) -> i1
+    %10 = comb.extract %5 from 0 : (i2) -> i1
+    %11 = comb.extract %5 from 1 : (i2) -> i1
+    %12 = comb.concat %11, %10, %9, %8 : i1, i1, i1, i1
+    %14 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
+    sv.assign %14, %12 : i4
+    %13 = sv.read_inout %14 : !hw.inout<i4>
+    hw.output %13 : i4
+}

--- a/tests/gold/test_when_lazy_array_slice.mlir
+++ b/tests/gold/test_when_lazy_array_slice.mlir
@@ -8,11 +8,11 @@ hw.module @test_when_lazy_array_slice(%S: i1) -> (O: i4) {
     %7 = sv.reg : !hw.inout<i2>
     %5 = sv.read_inout %7 : !hw.inout<i2>
     sv.alwayscomb {
-        sv.bpassign %6, %0 : i2
-        sv.bpassign %7, %2 : i2
         sv.if %S {
+            sv.bpassign %6, %0 : i2
+            sv.bpassign %7, %1 : i2
         } else {
-            sv.bpassign %6, %1 : i2
+            sv.bpassign %6, %2 : i2
             sv.bpassign %7, %3 : i2
         }
     }

--- a/tests/gold/test_when_memory_Bits8.mlir
+++ b/tests/gold/test_when_memory_Bits8.mlir
@@ -11,84 +11,84 @@ hw.module @Memory(%RADDR: i5, %CLK: i1, %WADDR: i5, %WDATA: i8, %WE: i1) -> (RDA
     hw.output %0 : i8
 }
 hw.module @test_when_memory_Bits8(%data0: i8, %addr0: i5, %en0: i1, %data1: i8, %addr1: i5, %en1: i1, %CLK: i1) -> (out: i8) {
-    %0 = hw.constant 1 : i1
-    %1 = comb.extract %addr0 from 0 : (i5) -> i1
-    %2 = comb.extract %addr1 from 0 : (i5) -> i1
-    %3 = comb.extract %addr0 from 1 : (i5) -> i1
-    %4 = comb.extract %addr1 from 1 : (i5) -> i1
-    %5 = comb.extract %addr0 from 2 : (i5) -> i1
-    %6 = comb.extract %addr1 from 2 : (i5) -> i1
-    %7 = comb.extract %addr0 from 3 : (i5) -> i1
-    %8 = comb.extract %addr1 from 3 : (i5) -> i1
-    %9 = comb.extract %addr0 from 4 : (i5) -> i1
-    %10 = comb.extract %addr1 from 4 : (i5) -> i1
-    %11 = comb.extract %data0 from 0 : (i8) -> i1
-    %12 = comb.extract %data1 from 0 : (i8) -> i1
-    %13 = comb.extract %data0 from 1 : (i8) -> i1
-    %14 = comb.extract %data1 from 1 : (i8) -> i1
-    %15 = comb.extract %data0 from 2 : (i8) -> i1
-    %16 = comb.extract %data1 from 2 : (i8) -> i1
-    %17 = comb.extract %data0 from 3 : (i8) -> i1
-    %18 = comb.extract %data1 from 3 : (i8) -> i1
-    %19 = comb.extract %data0 from 4 : (i8) -> i1
-    %20 = comb.extract %data1 from 4 : (i8) -> i1
-    %21 = comb.extract %data0 from 5 : (i8) -> i1
-    %22 = comb.extract %data1 from 5 : (i8) -> i1
-    %23 = comb.extract %data0 from 6 : (i8) -> i1
-    %24 = comb.extract %data1 from 6 : (i8) -> i1
-    %25 = comb.extract %data0 from 7 : (i8) -> i1
-    %26 = comb.extract %data1 from 7 : (i8) -> i1
-    %32 = comb.concat %31, %30, %29, %28, %27 : i1, i1, i1, i1, i1
-    %38 = comb.concat %37, %36, %35, %34, %33 : i1, i1, i1, i1, i1
-    %47 = comb.concat %46, %45, %44, %43, %42, %41, %40, %39 : i1, i1, i1, i1, i1, i1, i1, i1
-    %49 = hw.instance "Memory_inst0" @Memory(RADDR: %32: i5, CLK: %CLK: i1, WADDR: %38: i5, WDATA: %47: i8, WE: %48: i1) -> (RDATA: i8)
-    %50 = comb.extract %49 from 0 : (i8) -> i1
-    %51 = comb.extract %49 from 1 : (i8) -> i1
-    %52 = comb.extract %49 from 2 : (i8) -> i1
-    %53 = comb.extract %49 from 3 : (i8) -> i1
-    %54 = comb.extract %49 from 4 : (i8) -> i1
-    %55 = comb.extract %49 from 5 : (i8) -> i1
-    %56 = comb.extract %49 from 6 : (i8) -> i1
-    %57 = comb.extract %49 from 7 : (i8) -> i1
+    %0 = comb.extract %addr0 from 0 : (i5) -> i1
+    %1 = comb.extract %addr0 from 1 : (i5) -> i1
+    %2 = comb.extract %addr0 from 2 : (i5) -> i1
+    %3 = comb.extract %addr0 from 3 : (i5) -> i1
+    %4 = comb.extract %addr0 from 4 : (i5) -> i1
+    %5 = comb.extract %data0 from 0 : (i8) -> i1
+    %6 = comb.extract %data0 from 1 : (i8) -> i1
+    %7 = comb.extract %data0 from 2 : (i8) -> i1
+    %8 = comb.extract %data0 from 3 : (i8) -> i1
+    %9 = comb.extract %data0 from 4 : (i8) -> i1
+    %10 = comb.extract %data0 from 5 : (i8) -> i1
+    %11 = comb.extract %data0 from 6 : (i8) -> i1
+    %12 = comb.extract %data0 from 7 : (i8) -> i1
+    %13 = hw.constant 1 : i1
+    %14 = comb.extract %addr1 from 0 : (i5) -> i1
+    %15 = comb.extract %addr1 from 1 : (i5) -> i1
+    %16 = comb.extract %addr1 from 2 : (i5) -> i1
+    %17 = comb.extract %addr1 from 3 : (i5) -> i1
+    %18 = comb.extract %addr1 from 4 : (i5) -> i1
+    %24 = comb.concat %23, %22, %21, %20, %19 : i1, i1, i1, i1, i1
+    %30 = comb.concat %29, %28, %27, %26, %25 : i1, i1, i1, i1, i1
+    %39 = comb.concat %38, %37, %36, %35, %34, %33, %32, %31 : i1, i1, i1, i1, i1, i1, i1, i1
+    %41 = hw.instance "Memory_inst0" @Memory(RADDR: %24: i5, CLK: %CLK: i1, WADDR: %30: i5, WDATA: %39: i8, WE: %40: i1) -> (RDATA: i8)
+    %42 = comb.extract %41 from 0 : (i8) -> i1
+    %43 = comb.extract %41 from 1 : (i8) -> i1
+    %44 = comb.extract %41 from 2 : (i8) -> i1
+    %45 = comb.extract %41 from 3 : (i8) -> i1
+    %46 = comb.extract %41 from 4 : (i8) -> i1
+    %47 = comb.extract %41 from 5 : (i8) -> i1
+    %48 = comb.extract %41 from 6 : (i8) -> i1
+    %49 = comb.extract %41 from 7 : (i8) -> i1
+    %50 = comb.extract %data1 from 0 : (i8) -> i1
+    %51 = comb.extract %data1 from 1 : (i8) -> i1
+    %52 = comb.extract %data1 from 2 : (i8) -> i1
+    %53 = comb.extract %data1 from 3 : (i8) -> i1
+    %54 = comb.extract %data1 from 4 : (i8) -> i1
+    %55 = comb.extract %data1 from 5 : (i8) -> i1
+    %56 = comb.extract %data1 from 6 : (i8) -> i1
+    %57 = comb.extract %data1 from 7 : (i8) -> i1
     %58 = hw.constant 0 : i1
     %67 = sv.reg : !hw.inout<i1>
-    %48 = sv.read_inout %67 : !hw.inout<i1>
+    %25 = sv.read_inout %67 : !hw.inout<i1>
     %68 = sv.reg : !hw.inout<i1>
-    %33 = sv.read_inout %68 : !hw.inout<i1>
+    %26 = sv.read_inout %68 : !hw.inout<i1>
     %69 = sv.reg : !hw.inout<i1>
-    %34 = sv.read_inout %69 : !hw.inout<i1>
+    %27 = sv.read_inout %69 : !hw.inout<i1>
     %70 = sv.reg : !hw.inout<i1>
-    %35 = sv.read_inout %70 : !hw.inout<i1>
+    %28 = sv.read_inout %70 : !hw.inout<i1>
     %71 = sv.reg : !hw.inout<i1>
-    %36 = sv.read_inout %71 : !hw.inout<i1>
+    %29 = sv.read_inout %71 : !hw.inout<i1>
     %72 = sv.reg : !hw.inout<i1>
-    %37 = sv.read_inout %72 : !hw.inout<i1>
+    %31 = sv.read_inout %72 : !hw.inout<i1>
     %73 = sv.reg : !hw.inout<i1>
-    %39 = sv.read_inout %73 : !hw.inout<i1>
+    %32 = sv.read_inout %73 : !hw.inout<i1>
     %74 = sv.reg : !hw.inout<i1>
-    %40 = sv.read_inout %74 : !hw.inout<i1>
+    %33 = sv.read_inout %74 : !hw.inout<i1>
     %75 = sv.reg : !hw.inout<i1>
-    %41 = sv.read_inout %75 : !hw.inout<i1>
+    %34 = sv.read_inout %75 : !hw.inout<i1>
     %76 = sv.reg : !hw.inout<i1>
-    %42 = sv.read_inout %76 : !hw.inout<i1>
+    %35 = sv.read_inout %76 : !hw.inout<i1>
     %77 = sv.reg : !hw.inout<i1>
-    %43 = sv.read_inout %77 : !hw.inout<i1>
+    %36 = sv.read_inout %77 : !hw.inout<i1>
     %78 = sv.reg : !hw.inout<i1>
-    %44 = sv.read_inout %78 : !hw.inout<i1>
+    %37 = sv.read_inout %78 : !hw.inout<i1>
     %79 = sv.reg : !hw.inout<i1>
-    %45 = sv.read_inout %79 : !hw.inout<i1>
+    %38 = sv.read_inout %79 : !hw.inout<i1>
     %80 = sv.reg : !hw.inout<i1>
-    %46 = sv.read_inout %80 : !hw.inout<i1>
+    %40 = sv.read_inout %80 : !hw.inout<i1>
     %81 = sv.reg : !hw.inout<i1>
-    %27 = sv.read_inout %81 : !hw.inout<i1>
+    %19 = sv.read_inout %81 : !hw.inout<i1>
     %82 = sv.reg : !hw.inout<i1>
-    %28 = sv.read_inout %82 : !hw.inout<i1>
+    %20 = sv.read_inout %82 : !hw.inout<i1>
     %83 = sv.reg : !hw.inout<i1>
-    %29 = sv.read_inout %83 : !hw.inout<i1>
+    %21 = sv.read_inout %83 : !hw.inout<i1>
     %84 = sv.reg : !hw.inout<i1>
-    %30 = sv.read_inout %84 : !hw.inout<i1>
+    %22 = sv.read_inout %84 : !hw.inout<i1>
     %85 = sv.reg : !hw.inout<i1>
-    %31 = sv.read_inout %85 : !hw.inout<i1>
+    %23 = sv.read_inout %85 : !hw.inout<i1>
     %86 = sv.reg : !hw.inout<i1>
     %59 = sv.read_inout %86 : !hw.inout<i1>
     %87 = sv.reg : !hw.inout<i1>
@@ -106,73 +106,91 @@ hw.module @test_when_memory_Bits8(%data0: i8, %addr0: i5, %en0: i1, %data1: i8, 
     %93 = sv.reg : !hw.inout<i1>
     %66 = sv.read_inout %93 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %68, %1 : i1
-        sv.bpassign %69, %3 : i1
-        sv.bpassign %70, %5 : i1
-        sv.bpassign %71, %7 : i1
-        sv.bpassign %72, %9 : i1
-        sv.bpassign %73, %11 : i1
-        sv.bpassign %74, %13 : i1
-        sv.bpassign %75, %15 : i1
-        sv.bpassign %76, %17 : i1
-        sv.bpassign %77, %19 : i1
-        sv.bpassign %78, %21 : i1
-        sv.bpassign %79, %23 : i1
-        sv.bpassign %80, %25 : i1
-        sv.bpassign %81, %2 : i1
-        sv.bpassign %82, %4 : i1
-        sv.bpassign %83, %6 : i1
-        sv.bpassign %84, %8 : i1
-        sv.bpassign %85, %10 : i1
-        sv.bpassign %86, %50 : i1
-        sv.bpassign %87, %51 : i1
-        sv.bpassign %88, %52 : i1
-        sv.bpassign %89, %53 : i1
-        sv.bpassign %90, %54 : i1
-        sv.bpassign %91, %55 : i1
-        sv.bpassign %92, %56 : i1
-        sv.bpassign %93, %57 : i1
         sv.bpassign %67, %58 : i1
+        sv.bpassign %68, %58 : i1
+        sv.bpassign %69, %58 : i1
+        sv.bpassign %70, %58 : i1
+        sv.bpassign %71, %58 : i1
+        sv.bpassign %72, %58 : i1
+        sv.bpassign %73, %58 : i1
+        sv.bpassign %74, %58 : i1
+        sv.bpassign %75, %58 : i1
+        sv.bpassign %76, %58 : i1
+        sv.bpassign %77, %58 : i1
+        sv.bpassign %78, %58 : i1
+        sv.bpassign %79, %58 : i1
+        sv.bpassign %80, %58 : i1
+        sv.bpassign %81, %58 : i1
+        sv.bpassign %82, %58 : i1
+        sv.bpassign %83, %58 : i1
+        sv.bpassign %84, %58 : i1
+        sv.bpassign %85, %58 : i1
         sv.if %en0 {
             sv.bpassign %67, %0 : i1
+            sv.bpassign %68, %1 : i1
+            sv.bpassign %69, %2 : i1
+            sv.bpassign %70, %3 : i1
+            sv.bpassign %71, %4 : i1
+            sv.bpassign %72, %5 : i1
+            sv.bpassign %73, %6 : i1
+            sv.bpassign %74, %7 : i1
+            sv.bpassign %75, %8 : i1
+            sv.bpassign %76, %9 : i1
+            sv.bpassign %77, %10 : i1
+            sv.bpassign %78, %11 : i1
+            sv.bpassign %79, %12 : i1
+            sv.bpassign %80, %13 : i1
+            sv.bpassign %81, %14 : i1
+            sv.bpassign %82, %15 : i1
+            sv.bpassign %83, %16 : i1
+            sv.bpassign %84, %17 : i1
+            sv.bpassign %85, %18 : i1
+            sv.bpassign %86, %42 : i1
+            sv.bpassign %87, %43 : i1
+            sv.bpassign %88, %44 : i1
+            sv.bpassign %89, %45 : i1
+            sv.bpassign %90, %46 : i1
+            sv.bpassign %91, %47 : i1
+            sv.bpassign %92, %48 : i1
+            sv.bpassign %93, %49 : i1
         } else {
             sv.if %en1 {
-                sv.bpassign %68, %2 : i1
-                sv.bpassign %69, %4 : i1
-                sv.bpassign %70, %6 : i1
-                sv.bpassign %71, %8 : i1
-                sv.bpassign %72, %10 : i1
-                sv.bpassign %73, %12 : i1
-                sv.bpassign %74, %14 : i1
-                sv.bpassign %75, %16 : i1
-                sv.bpassign %76, %18 : i1
-                sv.bpassign %77, %20 : i1
-                sv.bpassign %78, %22 : i1
-                sv.bpassign %79, %24 : i1
-                sv.bpassign %80, %26 : i1
-                sv.bpassign %67, %0 : i1
-                sv.bpassign %81, %1 : i1
-                sv.bpassign %82, %3 : i1
-                sv.bpassign %83, %5 : i1
-                sv.bpassign %84, %7 : i1
-                sv.bpassign %85, %9 : i1
-                sv.bpassign %86, %50 : i1
-                sv.bpassign %87, %51 : i1
-                sv.bpassign %88, %52 : i1
-                sv.bpassign %89, %53 : i1
-                sv.bpassign %90, %54 : i1
-                sv.bpassign %91, %55 : i1
-                sv.bpassign %92, %56 : i1
-                sv.bpassign %93, %57 : i1
+                sv.bpassign %67, %14 : i1
+                sv.bpassign %68, %15 : i1
+                sv.bpassign %69, %16 : i1
+                sv.bpassign %70, %17 : i1
+                sv.bpassign %71, %18 : i1
+                sv.bpassign %72, %50 : i1
+                sv.bpassign %73, %51 : i1
+                sv.bpassign %74, %52 : i1
+                sv.bpassign %75, %53 : i1
+                sv.bpassign %76, %54 : i1
+                sv.bpassign %77, %55 : i1
+                sv.bpassign %78, %56 : i1
+                sv.bpassign %79, %57 : i1
+                sv.bpassign %80, %13 : i1
+                sv.bpassign %81, %0 : i1
+                sv.bpassign %82, %1 : i1
+                sv.bpassign %83, %2 : i1
+                sv.bpassign %84, %3 : i1
+                sv.bpassign %85, %4 : i1
+                sv.bpassign %86, %42 : i1
+                sv.bpassign %87, %43 : i1
+                sv.bpassign %88, %44 : i1
+                sv.bpassign %89, %45 : i1
+                sv.bpassign %90, %46 : i1
+                sv.bpassign %91, %47 : i1
+                sv.bpassign %92, %48 : i1
+                sv.bpassign %93, %49 : i1
             } else {
-                sv.bpassign %86, %0 : i1
-                sv.bpassign %87, %0 : i1
-                sv.bpassign %88, %0 : i1
-                sv.bpassign %89, %0 : i1
-                sv.bpassign %90, %0 : i1
-                sv.bpassign %91, %0 : i1
-                sv.bpassign %92, %0 : i1
-                sv.bpassign %93, %0 : i1
+                sv.bpassign %86, %13 : i1
+                sv.bpassign %87, %13 : i1
+                sv.bpassign %88, %13 : i1
+                sv.bpassign %89, %13 : i1
+                sv.bpassign %90, %13 : i1
+                sv.bpassign %91, %13 : i1
+                sv.bpassign %92, %13 : i1
+                sv.bpassign %93, %13 : i1
             }
         }
     }

--- a/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
+++ b/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
@@ -28,83 +28,83 @@ hw.module @Memory(%RADDR: i5, %CLK: i1, %WADDR: i5, %WDATA_x: i1, %WDATA_y: i7, 
     hw.output %12, %20 : i1, i7
 }
 hw.module @test_when_memory_Tuplex_Bit_y_Bits7(%data0_x: i1, %data0_y: i7, %addr0: i5, %en0: i1, %data1_x: i1, %data1_y: i7, %addr1: i5, %en1: i1, %CLK: i1) -> (out_x: i1, out_y: i7) {
-    %0 = hw.constant 1 : i1
-    %6 = comb.concat %5, %4, %3, %2, %1 : i1, i1, i1, i1, i1
-    %12 = comb.concat %11, %10, %9, %8, %7 : i1, i1, i1, i1, i1
-    %20 = comb.concat %19, %18, %17, %16, %15, %14, %13 : i1, i1, i1, i1, i1, i1, i1
-    %23, %24 = hw.instance "Memory_inst0" @Memory(RADDR: %6: i5, CLK: %CLK: i1, WADDR: %12: i5, WDATA_x: %21: i1, WDATA_y: %20: i7, WE: %22: i1) -> (RDATA_x: i1, RDATA_y: i7)
-    %25 = comb.extract %addr0 from 0 : (i5) -> i1
-    %26 = comb.extract %addr1 from 0 : (i5) -> i1
-    %27 = comb.extract %addr0 from 1 : (i5) -> i1
-    %28 = comb.extract %addr1 from 1 : (i5) -> i1
-    %29 = comb.extract %addr0 from 2 : (i5) -> i1
-    %30 = comb.extract %addr1 from 2 : (i5) -> i1
-    %31 = comb.extract %addr0 from 3 : (i5) -> i1
-    %32 = comb.extract %addr1 from 3 : (i5) -> i1
-    %33 = comb.extract %addr0 from 4 : (i5) -> i1
-    %34 = comb.extract %addr1 from 4 : (i5) -> i1
-    %35 = comb.extract %data0_y from 0 : (i7) -> i1
-    %36 = comb.extract %data1_y from 0 : (i7) -> i1
-    %37 = comb.extract %data0_y from 1 : (i7) -> i1
-    %38 = comb.extract %data1_y from 1 : (i7) -> i1
-    %39 = comb.extract %data0_y from 2 : (i7) -> i1
-    %40 = comb.extract %data1_y from 2 : (i7) -> i1
-    %41 = comb.extract %data0_y from 3 : (i7) -> i1
-    %42 = comb.extract %data1_y from 3 : (i7) -> i1
-    %43 = comb.extract %data0_y from 4 : (i7) -> i1
-    %44 = comb.extract %data1_y from 4 : (i7) -> i1
-    %45 = comb.extract %data0_y from 5 : (i7) -> i1
-    %46 = comb.extract %data1_y from 5 : (i7) -> i1
-    %47 = comb.extract %data0_y from 6 : (i7) -> i1
-    %48 = comb.extract %data1_y from 6 : (i7) -> i1
-    %49 = comb.extract %24 from 0 : (i7) -> i1
-    %50 = comb.extract %24 from 1 : (i7) -> i1
-    %51 = comb.extract %24 from 2 : (i7) -> i1
-    %52 = comb.extract %24 from 3 : (i7) -> i1
-    %53 = comb.extract %24 from 4 : (i7) -> i1
-    %54 = comb.extract %24 from 5 : (i7) -> i1
-    %55 = comb.extract %24 from 6 : (i7) -> i1
+    %0 = comb.extract %addr0 from 0 : (i5) -> i1
+    %1 = comb.extract %addr0 from 1 : (i5) -> i1
+    %2 = comb.extract %addr0 from 2 : (i5) -> i1
+    %3 = comb.extract %addr0 from 3 : (i5) -> i1
+    %4 = comb.extract %addr0 from 4 : (i5) -> i1
+    %5 = comb.extract %data0_y from 0 : (i7) -> i1
+    %6 = comb.extract %data0_y from 1 : (i7) -> i1
+    %7 = comb.extract %data0_y from 2 : (i7) -> i1
+    %8 = comb.extract %data0_y from 3 : (i7) -> i1
+    %9 = comb.extract %data0_y from 4 : (i7) -> i1
+    %10 = comb.extract %data0_y from 5 : (i7) -> i1
+    %11 = comb.extract %data0_y from 6 : (i7) -> i1
+    %12 = hw.constant 1 : i1
+    %13 = comb.extract %addr1 from 0 : (i5) -> i1
+    %14 = comb.extract %addr1 from 1 : (i5) -> i1
+    %15 = comb.extract %addr1 from 2 : (i5) -> i1
+    %16 = comb.extract %addr1 from 3 : (i5) -> i1
+    %17 = comb.extract %addr1 from 4 : (i5) -> i1
+    %23 = comb.concat %22, %21, %20, %19, %18 : i1, i1, i1, i1, i1
+    %29 = comb.concat %28, %27, %26, %25, %24 : i1, i1, i1, i1, i1
+    %37 = comb.concat %36, %35, %34, %33, %32, %31, %30 : i1, i1, i1, i1, i1, i1, i1
+    %40, %41 = hw.instance "Memory_inst0" @Memory(RADDR: %23: i5, CLK: %CLK: i1, WADDR: %29: i5, WDATA_x: %38: i1, WDATA_y: %37: i7, WE: %39: i1) -> (RDATA_x: i1, RDATA_y: i7)
+    %42 = comb.extract %41 from 0 : (i7) -> i1
+    %43 = comb.extract %41 from 1 : (i7) -> i1
+    %44 = comb.extract %41 from 2 : (i7) -> i1
+    %45 = comb.extract %41 from 3 : (i7) -> i1
+    %46 = comb.extract %41 from 4 : (i7) -> i1
+    %47 = comb.extract %41 from 5 : (i7) -> i1
+    %48 = comb.extract %41 from 6 : (i7) -> i1
+    %49 = comb.extract %data1_y from 0 : (i7) -> i1
+    %50 = comb.extract %data1_y from 1 : (i7) -> i1
+    %51 = comb.extract %data1_y from 2 : (i7) -> i1
+    %52 = comb.extract %data1_y from 3 : (i7) -> i1
+    %53 = comb.extract %data1_y from 4 : (i7) -> i1
+    %54 = comb.extract %data1_y from 5 : (i7) -> i1
+    %55 = comb.extract %data1_y from 6 : (i7) -> i1
     %56 = hw.constant 0 : i1
     %65 = sv.reg : !hw.inout<i1>
-    %21 = sv.read_inout %65 : !hw.inout<i1>
+    %24 = sv.read_inout %65 : !hw.inout<i1>
     %66 = sv.reg : !hw.inout<i1>
-    %22 = sv.read_inout %66 : !hw.inout<i1>
+    %25 = sv.read_inout %66 : !hw.inout<i1>
     %67 = sv.reg : !hw.inout<i1>
-    %57 = sv.read_inout %67 : !hw.inout<i1>
+    %26 = sv.read_inout %67 : !hw.inout<i1>
     %68 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %68 : !hw.inout<i1>
+    %27 = sv.read_inout %68 : !hw.inout<i1>
     %69 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %69 : !hw.inout<i1>
+    %28 = sv.read_inout %69 : !hw.inout<i1>
     %70 = sv.reg : !hw.inout<i1>
-    %9 = sv.read_inout %70 : !hw.inout<i1>
+    %38 = sv.read_inout %70 : !hw.inout<i1>
     %71 = sv.reg : !hw.inout<i1>
-    %10 = sv.read_inout %71 : !hw.inout<i1>
+    %30 = sv.read_inout %71 : !hw.inout<i1>
     %72 = sv.reg : !hw.inout<i1>
-    %11 = sv.read_inout %72 : !hw.inout<i1>
+    %31 = sv.read_inout %72 : !hw.inout<i1>
     %73 = sv.reg : !hw.inout<i1>
-    %13 = sv.read_inout %73 : !hw.inout<i1>
+    %32 = sv.read_inout %73 : !hw.inout<i1>
     %74 = sv.reg : !hw.inout<i1>
-    %14 = sv.read_inout %74 : !hw.inout<i1>
+    %33 = sv.read_inout %74 : !hw.inout<i1>
     %75 = sv.reg : !hw.inout<i1>
-    %15 = sv.read_inout %75 : !hw.inout<i1>
+    %34 = sv.read_inout %75 : !hw.inout<i1>
     %76 = sv.reg : !hw.inout<i1>
-    %16 = sv.read_inout %76 : !hw.inout<i1>
+    %35 = sv.read_inout %76 : !hw.inout<i1>
     %77 = sv.reg : !hw.inout<i1>
-    %17 = sv.read_inout %77 : !hw.inout<i1>
+    %36 = sv.read_inout %77 : !hw.inout<i1>
     %78 = sv.reg : !hw.inout<i1>
-    %18 = sv.read_inout %78 : !hw.inout<i1>
+    %39 = sv.read_inout %78 : !hw.inout<i1>
     %79 = sv.reg : !hw.inout<i1>
-    %19 = sv.read_inout %79 : !hw.inout<i1>
+    %18 = sv.read_inout %79 : !hw.inout<i1>
     %80 = sv.reg : !hw.inout<i1>
-    %1 = sv.read_inout %80 : !hw.inout<i1>
+    %19 = sv.read_inout %80 : !hw.inout<i1>
     %81 = sv.reg : !hw.inout<i1>
-    %2 = sv.read_inout %81 : !hw.inout<i1>
+    %20 = sv.read_inout %81 : !hw.inout<i1>
     %82 = sv.reg : !hw.inout<i1>
-    %3 = sv.read_inout %82 : !hw.inout<i1>
+    %21 = sv.read_inout %82 : !hw.inout<i1>
     %83 = sv.reg : !hw.inout<i1>
-    %4 = sv.read_inout %83 : !hw.inout<i1>
+    %22 = sv.read_inout %83 : !hw.inout<i1>
     %84 = sv.reg : !hw.inout<i1>
-    %5 = sv.read_inout %84 : !hw.inout<i1>
+    %57 = sv.read_inout %84 : !hw.inout<i1>
     %85 = sv.reg : !hw.inout<i1>
     %58 = sv.read_inout %85 : !hw.inout<i1>
     %86 = sv.reg : !hw.inout<i1>
@@ -120,74 +120,91 @@ hw.module @test_when_memory_Tuplex_Bit_y_Bits7(%data0_x: i1, %data0_y: i7, %addr
     %91 = sv.reg : !hw.inout<i1>
     %64 = sv.read_inout %91 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %68, %25 : i1
-        sv.bpassign %69, %27 : i1
-        sv.bpassign %70, %29 : i1
-        sv.bpassign %71, %31 : i1
-        sv.bpassign %72, %33 : i1
-        sv.bpassign %73, %35 : i1
-        sv.bpassign %74, %37 : i1
-        sv.bpassign %75, %39 : i1
-        sv.bpassign %76, %41 : i1
-        sv.bpassign %77, %43 : i1
-        sv.bpassign %78, %45 : i1
-        sv.bpassign %79, %47 : i1
-        sv.bpassign %80, %26 : i1
-        sv.bpassign %81, %28 : i1
-        sv.bpassign %82, %30 : i1
-        sv.bpassign %83, %32 : i1
-        sv.bpassign %84, %34 : i1
-        sv.bpassign %85, %49 : i1
-        sv.bpassign %86, %50 : i1
-        sv.bpassign %87, %51 : i1
-        sv.bpassign %88, %52 : i1
-        sv.bpassign %89, %53 : i1
-        sv.bpassign %90, %54 : i1
-        sv.bpassign %91, %55 : i1
         sv.bpassign %65, %56 : i1
         sv.bpassign %66, %56 : i1
+        sv.bpassign %67, %56 : i1
+        sv.bpassign %68, %56 : i1
+        sv.bpassign %69, %56 : i1
+        sv.bpassign %70, %56 : i1
+        sv.bpassign %71, %56 : i1
+        sv.bpassign %72, %56 : i1
+        sv.bpassign %73, %56 : i1
+        sv.bpassign %74, %56 : i1
+        sv.bpassign %75, %56 : i1
+        sv.bpassign %76, %56 : i1
+        sv.bpassign %77, %56 : i1
+        sv.bpassign %78, %56 : i1
+        sv.bpassign %79, %56 : i1
+        sv.bpassign %80, %56 : i1
+        sv.bpassign %81, %56 : i1
+        sv.bpassign %82, %56 : i1
+        sv.bpassign %83, %56 : i1
         sv.if %en0 {
-            sv.bpassign %65, %data0_x : i1
-            sv.bpassign %66, %0 : i1
-            sv.bpassign %67, %23 : i1
+            sv.bpassign %65, %0 : i1
+            sv.bpassign %66, %1 : i1
+            sv.bpassign %67, %2 : i1
+            sv.bpassign %68, %3 : i1
+            sv.bpassign %69, %4 : i1
+            sv.bpassign %70, %data0_x : i1
+            sv.bpassign %71, %5 : i1
+            sv.bpassign %72, %6 : i1
+            sv.bpassign %73, %7 : i1
+            sv.bpassign %74, %8 : i1
+            sv.bpassign %75, %9 : i1
+            sv.bpassign %76, %10 : i1
+            sv.bpassign %77, %11 : i1
+            sv.bpassign %78, %12 : i1
+            sv.bpassign %79, %13 : i1
+            sv.bpassign %80, %14 : i1
+            sv.bpassign %81, %15 : i1
+            sv.bpassign %82, %16 : i1
+            sv.bpassign %83, %17 : i1
+            sv.bpassign %84, %40 : i1
+            sv.bpassign %85, %42 : i1
+            sv.bpassign %86, %43 : i1
+            sv.bpassign %87, %44 : i1
+            sv.bpassign %88, %45 : i1
+            sv.bpassign %89, %46 : i1
+            sv.bpassign %90, %47 : i1
+            sv.bpassign %91, %48 : i1
         } else {
             sv.if %en1 {
-                sv.bpassign %68, %26 : i1
-                sv.bpassign %69, %28 : i1
-                sv.bpassign %70, %30 : i1
-                sv.bpassign %71, %32 : i1
-                sv.bpassign %72, %34 : i1
-                sv.bpassign %65, %data1_x : i1
-                sv.bpassign %73, %36 : i1
-                sv.bpassign %74, %38 : i1
-                sv.bpassign %75, %40 : i1
-                sv.bpassign %76, %42 : i1
-                sv.bpassign %77, %44 : i1
-                sv.bpassign %78, %46 : i1
-                sv.bpassign %79, %48 : i1
-                sv.bpassign %66, %0 : i1
-                sv.bpassign %80, %25 : i1
-                sv.bpassign %81, %27 : i1
-                sv.bpassign %82, %29 : i1
-                sv.bpassign %83, %31 : i1
-                sv.bpassign %84, %33 : i1
-                sv.bpassign %67, %23 : i1
-                sv.bpassign %85, %49 : i1
-                sv.bpassign %86, %50 : i1
-                sv.bpassign %87, %51 : i1
-                sv.bpassign %88, %52 : i1
-                sv.bpassign %89, %53 : i1
-                sv.bpassign %90, %54 : i1
-                sv.bpassign %91, %55 : i1
+                sv.bpassign %65, %13 : i1
+                sv.bpassign %66, %14 : i1
+                sv.bpassign %67, %15 : i1
+                sv.bpassign %68, %16 : i1
+                sv.bpassign %69, %17 : i1
+                sv.bpassign %70, %data1_x : i1
+                sv.bpassign %71, %49 : i1
+                sv.bpassign %72, %50 : i1
+                sv.bpassign %73, %51 : i1
+                sv.bpassign %74, %52 : i1
+                sv.bpassign %75, %53 : i1
+                sv.bpassign %76, %54 : i1
+                sv.bpassign %77, %55 : i1
+                sv.bpassign %78, %12 : i1
+                sv.bpassign %79, %0 : i1
+                sv.bpassign %80, %1 : i1
+                sv.bpassign %81, %2 : i1
+                sv.bpassign %82, %3 : i1
+                sv.bpassign %83, %4 : i1
+                sv.bpassign %84, %40 : i1
+                sv.bpassign %85, %42 : i1
+                sv.bpassign %86, %43 : i1
+                sv.bpassign %87, %44 : i1
+                sv.bpassign %88, %45 : i1
+                sv.bpassign %89, %46 : i1
+                sv.bpassign %90, %47 : i1
+                sv.bpassign %91, %48 : i1
             } else {
-                sv.bpassign %67, %0 : i1
-                sv.bpassign %85, %0 : i1
-                sv.bpassign %86, %0 : i1
-                sv.bpassign %87, %0 : i1
-                sv.bpassign %88, %0 : i1
-                sv.bpassign %89, %0 : i1
-                sv.bpassign %90, %0 : i1
-                sv.bpassign %91, %0 : i1
+                sv.bpassign %84, %12 : i1
+                sv.bpassign %85, %12 : i1
+                sv.bpassign %86, %12 : i1
+                sv.bpassign %87, %12 : i1
+                sv.bpassign %88, %12 : i1
+                sv.bpassign %89, %12 : i1
+                sv.bpassign %90, %12 : i1
+                sv.bpassign %91, %12 : i1
             }
         }
     }

--- a/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
+++ b/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
@@ -1,7 +1,41 @@
 hw.module @test_when_nested_Array2_AnonProductxBit_yBits2_Bit(%I_0_0_x: i1, %I_0_0_y: i2, %I_0_1_x: i1, %I_0_1_y: i2, %I_1_0_x: i1, %I_1_0_y: i2, %I_1_1_x: i1, %I_1_1_y: i2, %S: i1) -> (O_0_x: i1, O_0_y: i2, O_1_x: i1, O_1_y: i2) {
+    %0 = comb.extract %I_1_0_y from 0 : (i2) -> i1
+    %1 = comb.extract %I_0_0_y from 0 : (i2) -> i1
+    %2 = comb.extract %I_1_0_y from 1 : (i2) -> i1
+    %3 = comb.extract %I_0_0_y from 1 : (i2) -> i1
+    %4 = comb.extract %I_1_1_y from 0 : (i2) -> i1
+    %5 = comb.extract %I_0_1_y from 0 : (i2) -> i1
+    %6 = comb.extract %I_1_1_y from 1 : (i2) -> i1
+    %7 = comb.extract %I_0_1_y from 1 : (i2) -> i1
+    %14 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %15 : !hw.inout<i1>
+    %16 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %16 : !hw.inout<i1>
+    %17 = sv.reg : !hw.inout<i1>
+    %11 = sv.read_inout %17 : !hw.inout<i1>
+    %18 = sv.reg : !hw.inout<i1>
+    %12 = sv.read_inout %18 : !hw.inout<i1>
+    %19 = sv.reg : !hw.inout<i1>
+    %13 = sv.read_inout %19 : !hw.inout<i1>
     sv.alwayscomb {
+        sv.bpassign %14, %I_1_0_x : i1
+        sv.bpassign %15, %0 : i1
+        sv.bpassign %16, %2 : i1
+        sv.bpassign %17, %I_1_1_x : i1
+        sv.bpassign %18, %4 : i1
+        sv.bpassign %19, %6 : i1
         sv.if %S {
+            sv.bpassign %14, %I_0_0_x : i1
+            sv.bpassign %15, %1 : i1
+            sv.bpassign %16, %3 : i1
+            sv.bpassign %17, %I_0_1_x : i1
+            sv.bpassign %18, %5 : i1
+            sv.bpassign %19, %7 : i1
         }
     }
-    hw.output %I_0_0_x, %I_0_0_y, %I_0_1_x, %I_0_1_y : i1, i2, i1, i2
+    %20 = comb.concat %10, %9 : i1, i1
+    %21 = comb.concat %13, %12 : i1, i1
+    hw.output %8, %20, %11, %21 : i1, i2, i1, i2
 }

--- a/tests/gold/test_when_nested_Tuplex_Bits2_y_Bit.mlir
+++ b/tests/gold/test_when_nested_Tuplex_Bits2_y_Bit.mlir
@@ -1,11 +1,24 @@
 hw.module @test_when_nested_Tuplex_Bits2_y_Bit(%I_0_x: i2, %I_0_y: i1, %I_1_x: i2, %I_1_y: i1, %S: i1) -> (O_x: i2, O_y: i1) {
-    %1 = sv.reg : !hw.inout<i1>
-    %0 = sv.read_inout %1 : !hw.inout<i1>
+    %0 = comb.extract %I_1_x from 0 : (i2) -> i1
+    %1 = comb.extract %I_0_x from 0 : (i2) -> i1
+    %2 = comb.extract %I_1_x from 1 : (i2) -> i1
+    %3 = comb.extract %I_0_x from 1 : (i2) -> i1
+    %7 = sv.reg : !hw.inout<i1>
+    %4 = sv.read_inout %7 : !hw.inout<i1>
+    %8 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %8 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %9 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %1, %I_1_y : i1
+        sv.bpassign %7, %0 : i1
+        sv.bpassign %8, %2 : i1
+        sv.bpassign %9, %I_1_y : i1
         sv.if %S {
-            sv.bpassign %1, %I_0_y : i1
+            sv.bpassign %7, %1 : i1
+            sv.bpassign %8, %3 : i1
+            sv.bpassign %9, %I_0_y : i1
         }
     }
-    hw.output %I_0_x, %0 : i2, i1
+    %10 = comb.concat %5, %4 : i1, i1
+    hw.output %10, %6 : i2, i1
 }

--- a/tests/gold/test_when_nested_otherwise.mlir
+++ b/tests/gold/test_when_nested_otherwise.mlir
@@ -1,28 +1,28 @@
 hw.module @test_when_nested_otherwise(%I: i2, %S: i2) -> (O: i2) {
     %1 = hw.constant -1 : i2
     %0 = comb.icmp eq %S, %1 : i2
-    %2 = comb.extract %S from 1 : (i2) -> i1
-    %3 = comb.extract %I from 0 : (i2) -> i1
-    %5 = hw.constant -1 : i2
-    %4 = comb.xor %5, %I : i2
-    %6 = comb.extract %4 from 0 : (i2) -> i1
-    %7 = comb.extract %I from 1 : (i2) -> i1
-    %8 = comb.extract %4 from 1 : (i2) -> i1
+    %2 = comb.extract %I from 0 : (i2) -> i1
+    %3 = comb.extract %I from 1 : (i2) -> i1
+    %4 = comb.extract %S from 1 : (i2) -> i1
+    %6 = hw.constant -1 : i2
+    %5 = comb.xor %6, %I : i2
+    %7 = comb.extract %5 from 0 : (i2) -> i1
+    %8 = comb.extract %5 from 1 : (i2) -> i1
     %11 = sv.reg : !hw.inout<i1>
     %9 = sv.read_inout %11 : !hw.inout<i1>
     %12 = sv.reg : !hw.inout<i1>
     %10 = sv.read_inout %12 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %11, %3 : i1
-        sv.bpassign %12, %7 : i1
         sv.if %0 {
+            sv.bpassign %11, %2 : i1
+            sv.bpassign %12, %3 : i1
         } else {
-            sv.if %2 {
-                sv.bpassign %11, %6 : i1
+            sv.if %4 {
+                sv.bpassign %11, %7 : i1
                 sv.bpassign %12, %8 : i1
             } else {
-                sv.bpassign %11, %3 : i1
-                sv.bpassign %12, %7 : i1
+                sv.bpassign %11, %2 : i1
+                sv.bpassign %12, %3 : i1
             }
         }
     }

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -704,26 +704,3 @@ def test_when_lazy_array_nested(caplog):
 
     m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
-
-
-def test_when_lazy_array_protocol(caplog):
-
-    T = SimpleMagmaProtocol[m.Bit]
-
-    class _Test(m.Circuit):
-        name = "test_when_lazy_array_nested"
-        io = m.IO(S=m.In(m.Bit), O=m.Out(m.Array[2, T]))
-
-        x = m.Array[2, T](name="x")
-
-        with m.when(io.S):
-            x[0] @= 0
-            x[1] @= 0
-        with m.otherwise():
-            x[0] @= 1
-            x[1] @= 1
-
-        io.O @= x
-
-    m.compile(f"build/{_Test.name}", _Test, output="mlir")
-    assert check_gold(__file__, f"{_Test.name}.mlir")

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -636,3 +636,25 @@ def test_when_lazy_array_resolve(caplog):
 
     m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_lazy_array(caplog):
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array"
+        io = m.IO(S=m.In(m.Bit), O=m.Out(m.Bits[2]))
+
+        x = m.Bits[2](name="x")
+
+        with m.when(io.S):
+            x[0] @= 0
+            x[1] @= 1
+        with m.otherwise():
+            x[0] @= 1
+            x[1] @= 0
+
+        io.O @= x
+
+    basename = "test_when_lazy_array"
+    m.compile(f"build/{basename}", _Test, output="mlir")
+    assert check_gold(__file__, f"{basename}.mlir")

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -6,7 +6,7 @@ import fault as f
 
 import magma as m
 from magma.primitives.when import InferredLatchError
-from magma.testing.utils import check_gold, update_gold
+from magma.testing.utils import check_gold, update_gold, SimpleMagmaProtocol
 from magma.type_utils import type_to_sanitized_string
 
 
@@ -699,6 +699,29 @@ def test_when_lazy_array_nested(caplog):
             x[0][1] @= 0
             x[1][0] @= 1
             x[1][1] @= 0
+
+        io.O @= x
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_lazy_array_protocol(caplog):
+
+    T = SimpleMagmaProtocol[m.Bit]
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_nested"
+        io = m.IO(S=m.In(m.Bit), O=m.Out(m.Array[2, T]))
+
+        x = m.Array[2, T](name="x")
+
+        with m.when(io.S):
+            x[0] @= 0
+            x[1] @= 0
+        with m.otherwise():
+            x[0] @= 1
+            x[1] @= 1
 
         io.O @= x
 

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -704,3 +704,26 @@ def test_when_lazy_array_nested(caplog):
 
     m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_lazy_array_protocol(caplog):
+
+    T = SimpleMagmaProtocol[m.Bit]
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_protocol"
+        io = m.IO(S=m.In(m.Bit), O=m.Out(m.Array[2, T]))
+
+        x = m.Array[2, T](name="x")
+
+        with m.when(io.S):
+            x[0] @= 0
+            x[1] @= 0
+        with m.otherwise():
+            x[0] @= 1
+            x[1] @= 1
+
+        io.O @= x
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -658,3 +658,24 @@ def test_when_lazy_array(caplog):
     basename = "test_when_lazy_array"
     m.compile(f"build/{basename}", _Test, output="mlir")
     assert check_gold(__file__, f"{basename}.mlir")
+
+
+def test_when_lazy_array_slice(caplog):
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_slice"
+        io = m.IO(S=m.In(m.Bit), O=m.Out(m.Bits[4]))
+
+        x = m.Bits[4](name="x")
+
+        with m.when(io.S):
+            x[:2] @= 0
+            x[2:] @= 1
+        with m.otherwise():
+            x[:2] @= 1
+            x[2:] @= 0
+
+        io.O @= x
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -679,3 +679,28 @@ def test_when_lazy_array_slice(caplog):
 
     m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_lazy_array_nested(caplog):
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_nested"
+        io = m.IO(S=m.In(m.Bit), O=m.Out(m.Array[2, m.Tuple[m.Bit, m.Bit]]))
+
+        x = m.Array[2, m.Tuple[m.Bit, m.Bit]](name="x")
+
+        with m.when(io.S):
+            x[0][0] @= 0
+            x[0][1] @= 1
+            x[1][0] @= 0
+            x[1][1] @= 1
+        with m.otherwise():
+            x[0][0] @= 1
+            x[0][1] @= 0
+            x[1][0] @= 1
+            x[1][1] @= 0
+
+        io.O @= x
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")


### PR DESCRIPTION
Lazily created values should inherit the when context of its parent
(i.e. the active context when the original value was created), rather
than getting the currently active when context (problematic if the value
is referenced in a different context than the original parent value's
context)