### PR TITLE
[when] Fixes bug in bulk wire resolution for array

### DIFF
--- a/magma/bit.py
+++ b/magma/bit.py
@@ -112,11 +112,11 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
         return self._mux([f_branch, t_branch], self)
 
     @debug_wire
-    def wire(self, o, debug_info):
+    def wire(self, o, debug_info, check_when_context=True):
         # Cast to Bit here so we don't get a Digital instead
         if isinstance(o, (IntegerTypes, bool, ht.Bit)):
             o = Bit(o)
-        return super().wire(o, debug_info)
+        return super().wire(o, debug_info, check_when_context)
 
 
 BitIn = Bit[Direction.In]

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -236,7 +236,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
         return BitVector[len(self)](self.bits()).as_uint()
 
     @debug_wire
-    def wire(self, other, debug_info):
+    def wire(self, other, debug_info, check_when_context=True):
         if isinstance(other, (IntegerTypes, BitVector)):
             N = (other.bit_length()
                  if isinstance(other, IntegerTypes)
@@ -247,7 +247,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
                     f"(bit_length={other.bit_length()}) to Bits ({len(self)})")
             from .conversions import bits
             other = bits(other, len(self))
-        super().wire(other, debug_info)
+        super().wire(other, debug_info, check_when_context)
 
     @classmethod
     def make_constant(cls, value, num_bits: tp.Optional[int] = None) -> \

--- a/magma/debug.py
+++ b/magma/debug.py
@@ -28,9 +28,20 @@ def debug_wire(fn):
     """
     # TODO: We could check that fn has the correct interface
     #       wire(i, o, debug_info)
+    def wire(i, o=None, debug_info=None, check_when_context=True):
+        if get_debug_mode() and debug_info is None:
+            debug_info = get_callee_frame_info()
+        return fn(i, o, debug_info, check_when_context)
+    return wire
+
+
+def debug_unwire(fn):
+    """
+    Automatically populates the `debug_info` argument for a unwire call if it's
+    not already passed as an argument
+    """
     def wire(i, o=None, debug_info=None):
         if get_debug_mode() and debug_info is None:
             debug_info = get_callee_frame_info()
         return fn(i, o, debug_info)
     return wire
-

--- a/magma/debug.py
+++ b/magma/debug.py
@@ -45,3 +45,6 @@ def debug_unwire(fn):
             debug_info = get_callee_frame_info()
         return fn(i, o, debug_info)
     return wire
+
+
+debug_rewire = debug_unwire

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -3,7 +3,7 @@ import weakref
 from abc import ABCMeta
 import hwtypes as ht
 from .t import Kind, Direction, Type, In, Out
-from .debug import debug_wire, get_callee_frame_info
+from .debug import debug_wire, get_callee_frame_info, debug_unwire
 from .compatibility import IntegerTypes
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
@@ -167,7 +167,7 @@ class Digital(Type, Wireable, metaclass=DigitalMeta):
         return self.wire(output, get_callee_frame_info())
 
     @debug_wire
-    def wire(self, o, debug_info):
+    def wire(self, o, debug_info, check_when_context=True):
         # promote integer types to LOW/HIGH
         if isinstance(o, (IntegerTypes, bool, ht.Bit)):
             o = HIGH if o else LOW
@@ -181,9 +181,9 @@ class Digital(Type, Wireable, metaclass=DigitalMeta):
                 debug_info=debug_info
             )
             return
-        Wireable.wire(self, o, debug_info)
+        Wireable.wire(self, o, debug_info, check_when_context)
 
-    @debug_wire
+    @debug_unwire
     def unwire(self, o=None, debug_info=None):
         return Wireable.unwire(self, o, debug_info)
 

--- a/magma/protocol_type.py
+++ b/magma/protocol_type.py
@@ -101,10 +101,10 @@ class MagmaProtocol(metaclass=MagmaProtocolMeta):
         return self._get_magma_value_().name
 
     @debug_wire
-    def wire(self, other, debug_info):
+    def wire(self, other, debug_info, check_when_context=True):
         if isinstance(other, MagmaProtocol):
             other = other._get_magma_value_()
-        self._get_magma_value_().wire(other, debug_info)
+        self._get_magma_value_().wire(other, debug_info, check_when_context)
 
     def unwire(self, other):
         if isinstance(other, MagmaProtocol):

--- a/magma/smart/smart_bits.py
+++ b/magma/smart/smart_bits.py
@@ -381,9 +381,10 @@ class SmartBits(SmartBitsExpr, metaclass=SmartBitsMeta):
         return SmartBits.from_bits(self._value[key_or_slice])
 
     @debug_wire
-    def wire(self, other, debug_info):
+    def wire(self, other, debug_info, check_when_context=True):
         if isinstance(other, Bits):
-            MagmaProtocol.wire(self, other, debug_info)
+            MagmaProtocol.wire(self, other, debug_info,
+                               check_when_context)
             return
         if not isinstance(other, SmartExpr):
             raise ValueError(f"Can not wire {type(self)} to {type(other)}")
@@ -392,7 +393,8 @@ class SmartBits(SmartBitsExpr, metaclass=SmartBitsMeta):
         # of SmartBits.
         from magma.smart.eval import evaluate_assignment
         other = evaluate_assignment(self, other)
-        MagmaProtocol.wire(self, other, debug_info)
+        MagmaProtocol.wire(self, other, debug_info,
+                           check_when_context)
 
     @staticmethod
     def from_bits(value):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -15,10 +15,9 @@ from hwtypes import BitVector, Bit
 from hwtypes.adt_meta import BoundMeta, RESERVED_SUNDERS
 from hwtypes.util import TypedProperty, OrderedFrozenDict
 from .common import deprecated
-from .ref import AnonRef, TupleRef
 from .t import Type, Kind, Direction
 from .compatibility import IntegerTypes
-from .debug import debug_wire, get_callee_frame_info
+from .debug import debug_wire, get_callee_frame_info, debug_unwire
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
@@ -26,6 +25,7 @@ from magma.wire_container import WiringLog
 from magma.wire import wire
 from magma.protocol_type import MagmaProtocol
 from magma.operator_utils import output_only
+from magma.ref import DerivedRef, TupleRef
 
 
 _logger = root_logger()
@@ -276,9 +276,8 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
     def __call__(self, o):
         return self.wire(o, get_callee_frame_info())
 
-
     @debug_wire
-    def wire(i, o, debug_info):
+    def wire(i, o, debug_info, check_when_context=True):
         o = magma_value(o)
         if not isinstance(o, Tuple):
             _logger.error(
@@ -302,9 +301,9 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
         for i_elem, o_elem in zip(i, o):
             i_elem = magma_value(i_elem)
             o_elem = magma_value(o_elem)
-            wire(o_elem, i_elem, debug_info)
+            wire(o_elem, i_elem, debug_info, check_when_context)
 
-    @debug_wire
+    @debug_unwire
     def unwire(self, o=None, debug_info=None):
         for k, t in self.items():
             if o is None:

--- a/magma/wire.py
+++ b/magma/wire.py
@@ -16,7 +16,7 @@ _CONSTANTS = (IntegerTypes, BitVector, Bit)
 
 
 @debug_wire
-def wire(o, i, debug_info=None):
+def wire(o, i, debug_info=None, check_when_context=True):
     o = magma_value(o)
     i = magma_value(i)
 
@@ -62,9 +62,9 @@ def wire(o, i, debug_info=None):
         return
 
     # Wire(o, Type).
-    i.wire(o, debug_info)
+    i.wire(o, debug_info, check_when_context)
 
 
 @debug_wire
-def unwire(input, output=None, debug_info=None):
+def unwire(input, output=None, debug_info=None, check_when_context=True):
     input.unwire(output, debug_info)

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -1,7 +1,7 @@
 import logging as py_logging
 
 from magma.config import config, EnvConfig
-from magma.debug import debug_wire
+from magma.debug import debug_rewire
 from magma.logging import root_logger, StagedLogRecord
 from magma.when import get_curr_block as get_curr_when_block
 from magma.ref import ArrayRef
@@ -216,7 +216,7 @@ class Wireable:
             return
         curr_when_block.add_conditional_wire(self, o)
 
-    @debug_wire
+    @debug_rewire
     def rewire(self, o, debug_info=None):
         self.unwire(debug_info=debug_info)
         self.wire(o, debug_info=debug_info)

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -204,9 +204,10 @@ class Wireable:
         self.debug_info = debug_info
         o.debug_info = debug_info
 
-    def wire(self, o, debug_info):
+    def wire(self, o, debug_info, check_when_context):
         curr_when_block = get_curr_when_block()
         is_conditional = (
+            check_when_context and
             curr_when_block is not None
             and curr_when_block is not self._when_context
         )

--- a/tests/gold/test_when_lazy_array_resolve.mlir
+++ b/tests/gold/test_when_lazy_array_resolve.mlir
@@ -1,0 +1,23 @@
+hw.module @test_when_lazy_array_resolve(%S: i1) -> (O: i2) {
+    %0 = hw.constant 1 : i2
+    %2 = sv.wire sym @test_when_lazy_array_resolve.x {name="x"} : !hw.inout<i2>
+    sv.assign %2, %0 : i2
+    %1 = sv.read_inout %2 : !hw.inout<i2>
+    %3 = comb.extract %1 from 0 : (i2) -> i1
+    %4 = comb.extract %1 from 1 : (i2) -> i1
+    %7 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %7 : !hw.inout<i1>
+    %8 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %8 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %7, %3 : i1
+            sv.bpassign %8, %4 : i1
+        } else {
+            sv.bpassign %7, %4 : i1
+            sv.bpassign %8, %3 : i1
+        }
+    }
+    %9 = comb.concat %6, %5 : i1, i1
+    hw.output %9 : i2
+}

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -625,3 +625,25 @@ def test_when_lazy_array(caplog):
     basename = "test_when_lazy_array"
     m.compile(f"build/{basename}", _Test, output="mlir")
     assert check_gold(__file__, f"{basename}.mlir")
+
+
+def test_when_lazy_array_resolve(caplog):
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_resolve"
+        io = m.IO(S=m.In(m.Bit), O=m.Out(m.Bits[2]))
+
+        x = m.Bits[2](name="x")
+
+        x @= 1
+
+        with m.when(io.S):
+            io.O[0] @= x[0]
+            io.O[1] @= x[1]
+        with m.otherwise():
+            io.O[0] @= x[1]
+            io.O[1] @= x[0]
+
+    basename = "test_when_lazy_array_resolve"
+    m.compile(f"build/{basename}", _Test, output="mlir")
+    assert check_gold(__file__, f"{basename}.mlir")


### PR DESCRIPTION
Related to https://github.com/phanrahan/magma/pull/1121, when array
children are wired during bulk wire resolution, they should skip the
when context check because the conditional wiring logic was already
handled during the origin bulk wire and the children should
unconditionally use the current wiring.