### PR TITLE
[MLIR] Add support for coreir.neg

### DIFF
--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -423,6 +423,13 @@ class ModuleVisitor:
             sv.WireOp(results=[wire], sym=sym)
             sv.ReadInOutOp(operands=[wire], results=module.results)
             return True
+        if defn.coreir_name == "neg":
+            zero = self.make_constant(type(inst.I), 0)
+            comb.BaseOp(
+                op_name="sub",
+                operands=[zero, module.operands[0]],
+                results=module.results)
+            return True
         op_name = defn.coreir_name
         if op_name == "ashr":
             op_name = "shrs"

--- a/tests/test_backend/test_mlir/examples.py
+++ b/tests/test_backend/test_mlir/examples.py
@@ -523,3 +523,9 @@ class simple_undriven_instances(m.Circuit):
 
 
 drive_undriven(simple_undriven_instances)
+
+
+class simple_neg(m.Circuit):
+    T = m.UInt[8]
+    io = m.IO(a=m.In(T), y=m.Out(T))
+    io.y @= -io.a

--- a/tests/test_backend/test_mlir/golds/simple_neg.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_neg.mlir
@@ -1,0 +1,5 @@
+hw.module @simple_neg(%a: i8) -> (y: i8) {
+    %1 = hw.constant 0 : i8
+    %0 = comb.sub %1, %a : i8
+    hw.output %0 : i8
+}

--- a/tests/test_backend/test_mlir/golds/simple_neg.v
+++ b/tests/test_backend/test_mlir/golds/simple_neg.v
@@ -1,0 +1,7 @@
+module simple_neg(	// <stdin>:1:1
+  input  [7:0] a,
+  output [7:0] y);
+
+  assign y = 8'h0 - a;	// <stdin>:2:10, :3:10, :4:5
+endmodule
+

--- a/tests/test_backend/test_mlir/test_utils.py
+++ b/tests/test_backend/test_mlir/test_utils.py
@@ -180,6 +180,7 @@ def get_local_examples() -> List[DefineCircuitKind]:
         examples.complex_undriven,
         examples.simple_memory_wrapper,
         examples.simple_undriven_instances,
+        examples.simple_neg,
     ]
 
 


### PR DESCRIPTION
Emit `comb.sub 0, x` for `coreir.neg x`.