### PR TITLE
[when] fixes bug with nesting inside otherwise

### DIFF
--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -606,6 +606,8 @@ class ModuleVisitor:
             )
             if block.condition is None:
                 _make_assignments(connections)
+                for child in block.children():
+                    _process_when_block(child)
                 return
             cond = module.operands[input_to_index[block.condition]]
             if_op = sv.IfOp(operands=[cond])

--- a/tests/gold/test_when_nested_otherwise.mlir
+++ b/tests/gold/test_when_nested_otherwise.mlir
@@ -1,0 +1,21 @@
+hw.module @test_when_nested_otherwise(%I: i2, %S: i2) -> (O: i2) {
+    %1 = hw.constant -1 : i2
+    %0 = comb.icmp eq %S, %1 : i2
+    %2 = comb.extract %S from 1 : (i2) -> i1
+    %4 = hw.constant -1 : i2
+    %3 = comb.xor %4, %I : i2
+    %6 = sv.reg : !hw.inout<i2>
+    %5 = sv.read_inout %6 : !hw.inout<i2>
+    sv.alwayscomb {
+        sv.if %0 {
+            sv.bpassign %6, %I : i2
+        } else {
+            sv.if %2 {
+                sv.bpassign %6, %3 : i2
+            } else {
+                sv.bpassign %6, %I : i2
+            }
+        }
+    }
+    hw.output %5 : i2
+}

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -603,3 +603,23 @@ def test_when_double_elsewhen():
     basename = "test_when_double_elsewhen"
     m.compile(f"build/{basename}", _Test, output="mlir")
     assert check_gold(__file__, f"{basename}.mlir")
+
+
+def test_when_nested_otherwise():
+    class test_when_nested_otherwise(m.Circuit):
+        io = m.IO(I=m.In(m.Bits[2]), S=m.In(m.Bits[2]),
+                  O=m.Out(m.Bits[2]))
+
+        with m.when(io.S.reduce_and()):
+            io.O @= io.I
+        with m.otherwise():
+            with m.when(io.S[1]):
+                io.O @= ~io.I
+            with m.otherwise():
+                io.O @= io.I
+
+    m.compile("build/test_when_nested_otherwise",
+              test_when_nested_otherwise, output="mlir",
+              flatten_all_tuples=True)
+
+    assert check_gold(__file__, "test_when_nested_otherwise.mlir")


### PR DESCRIPTION
For an otherwise block, we should be processing the children even though we aren't creating a new `IfOp`