### PR TITLE
[When] Temporarily hotfix lazy arrays

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -602,12 +602,8 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         for i, child in self._enumerate_children():
             child.wire(o[i], debug_info)
 
-    @debug_wire
-    def wire(self, o, debug_info):
-        o = magma_value(o)
-        if not self._check_wireable(o, debug_info):
-            return
-        if (
+    def _should_wire_children(self, o):
+        return (
             self._has_elaborated_children() or
             o._has_elaborated_children() or
             self.T.is_mixed() or
@@ -615,7 +611,14 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
             # resolution, if we have a conditional wire let the children handle
             # it for now
             get_curr_when_block()
-        ):
+        )
+
+    @debug_wire
+    def wire(self, o, debug_info):
+        o = magma_value(o)
+        if not self._check_wireable(o, debug_info):
+            return
+        if self._should_wire_children(o):
             # Ensure the children maintain consistency with the bulk wire
             self._wire_children(o, debug_info)
         else:

--- a/magma/array.py
+++ b/magma/array.py
@@ -607,9 +607,9 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
             self._has_elaborated_children() or
             o._has_elaborated_children() or
             self.T.is_mixed() or
-            # TODO(leonardt): temporary fix for when issue with bulk wire
-            # resolution, if we have a conditional wire let the children handle
-            # it for now
+            # TODO(leonardt): This is a temporary fix for when with bulk wire
+            # resolution. The workaround is if we have a conditional wire, we just
+            # let the children handle it.
             get_curr_when_block()
         )
 

--- a/magma/array.py
+++ b/magma/array.py
@@ -17,6 +17,7 @@ from .protocol_type import magma_type, magma_value
 from magma.operator_utils import output_only
 from magma.wire_container import WiringLog, Wire, Wireable
 from magma.protocol_type import MagmaProtocol
+from magma.when import get_curr_block as get_curr_when_block
 
 
 _logger = root_logger()
@@ -606,9 +607,15 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         o = magma_value(o)
         if not self._check_wireable(o, debug_info):
             return
-        if (self._has_elaborated_children() or
-                o._has_elaborated_children() or
-                self.T.is_mixed()):
+        if (
+            self._has_elaborated_children() or
+            o._has_elaborated_children() or
+            self.T.is_mixed() or
+            # TODO(leonardt): temporary fix for when issue with bulk wire
+            # resolution, if we have a conditional wire let the children handle
+            # it for now
+            get_curr_when_block()
+        ):
             # Ensure the children maintain consistency with the bulk wire
             self._wire_children(o, debug_info)
         else:

--- a/magma/array.py
+++ b/magma/array.py
@@ -608,8 +608,8 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
             o._has_elaborated_children() or
             self.T.is_mixed() or
             # TODO(leonardt): This is a temporary fix for when with bulk wire
-            # resolution. The workaround is if we have a conditional wire, we just
-            # let the children handle it.
+            # resolution. The workaround is if we have a conditional wire, we
+            # just let the children handle it.
             get_curr_when_block()
         )
 

--- a/tests/gold/test_when_lazy_array_resolve.mlir
+++ b/tests/gold/test_when_lazy_array_resolve.mlir
@@ -1,0 +1,23 @@
+hw.module @test_when_lazy_array_resolve(%I: i2, %S: i1) -> (O: i2) {
+    %0 = comb.extract %I from 0 : (i2) -> i1
+    %1 = hw.constant 1 : i2
+    %2 = comb.shru %I, %1 : i2
+    %3 = comb.extract %2 from 0 : (i2) -> i1
+    %4 = comb.extract %I from 1 : (i2) -> i1
+    %5 = comb.extract %2 from 1 : (i2) -> i1
+    %8 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %8 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %9 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.bpassign %8, %0 : i1
+        sv.bpassign %9, %4 : i1
+        sv.if %S {
+        } else {
+            sv.bpassign %8, %3 : i1
+            sv.bpassign %9, %5 : i1
+        }
+    }
+    %10 = comb.concat %7, %6 : i1, i1
+    hw.output %10 : i2
+}

--- a/tests/gold/test_when_memory_Bits8.mlir
+++ b/tests/gold/test_when_memory_Bits8.mlir
@@ -12,44 +12,170 @@ hw.module @Memory(%RADDR: i5, %CLK: i1, %WADDR: i5, %WDATA: i8, %WE: i1) -> (RDA
 }
 hw.module @test_when_memory_Bits8(%data0: i8, %addr0: i5, %en0: i1, %data1: i8, %addr1: i5, %en1: i1, %CLK: i1) -> (out: i8) {
     %0 = hw.constant 1 : i1
-    %5 = hw.instance "Memory_inst0" @Memory(RADDR: %1: i5, CLK: %CLK: i1, WADDR: %2: i5, WDATA: %3: i8, WE: %4: i1) -> (RDATA: i8)
-    %6 = hw.constant 255 : i8
-    %7 = hw.constant 0 : i5
-    %8 = hw.constant 0 : i8
-    %9 = hw.constant 0 : i1
-    %10 = hw.constant 0 : i5
-    %12 = sv.reg : !hw.inout<i5>
-    %2 = sv.read_inout %12 : !hw.inout<i5>
-    %13 = sv.reg : !hw.inout<i8>
-    %3 = sv.read_inout %13 : !hw.inout<i8>
-    %14 = sv.reg : !hw.inout<i1>
-    %4 = sv.read_inout %14 : !hw.inout<i1>
-    %15 = sv.reg : !hw.inout<i5>
-    %1 = sv.read_inout %15 : !hw.inout<i5>
-    %16 = sv.reg : !hw.inout<i8>
-    %11 = sv.read_inout %16 : !hw.inout<i8>
+    %1 = comb.extract %addr0 from 0 : (i5) -> i1
+    %2 = comb.extract %addr1 from 0 : (i5) -> i1
+    %3 = comb.extract %addr0 from 1 : (i5) -> i1
+    %4 = comb.extract %addr1 from 1 : (i5) -> i1
+    %5 = comb.extract %addr0 from 2 : (i5) -> i1
+    %6 = comb.extract %addr1 from 2 : (i5) -> i1
+    %7 = comb.extract %addr0 from 3 : (i5) -> i1
+    %8 = comb.extract %addr1 from 3 : (i5) -> i1
+    %9 = comb.extract %addr0 from 4 : (i5) -> i1
+    %10 = comb.extract %addr1 from 4 : (i5) -> i1
+    %11 = comb.extract %data0 from 0 : (i8) -> i1
+    %12 = comb.extract %data1 from 0 : (i8) -> i1
+    %13 = comb.extract %data0 from 1 : (i8) -> i1
+    %14 = comb.extract %data1 from 1 : (i8) -> i1
+    %15 = comb.extract %data0 from 2 : (i8) -> i1
+    %16 = comb.extract %data1 from 2 : (i8) -> i1
+    %17 = comb.extract %data0 from 3 : (i8) -> i1
+    %18 = comb.extract %data1 from 3 : (i8) -> i1
+    %19 = comb.extract %data0 from 4 : (i8) -> i1
+    %20 = comb.extract %data1 from 4 : (i8) -> i1
+    %21 = comb.extract %data0 from 5 : (i8) -> i1
+    %22 = comb.extract %data1 from 5 : (i8) -> i1
+    %23 = comb.extract %data0 from 6 : (i8) -> i1
+    %24 = comb.extract %data1 from 6 : (i8) -> i1
+    %25 = comb.extract %data0 from 7 : (i8) -> i1
+    %26 = comb.extract %data1 from 7 : (i8) -> i1
+    %32 = comb.concat %31, %30, %29, %28, %27 : i1, i1, i1, i1, i1
+    %38 = comb.concat %37, %36, %35, %34, %33 : i1, i1, i1, i1, i1
+    %47 = comb.concat %46, %45, %44, %43, %42, %41, %40, %39 : i1, i1, i1, i1, i1, i1, i1, i1
+    %49 = hw.instance "Memory_inst0" @Memory(RADDR: %32: i5, CLK: %CLK: i1, WADDR: %38: i5, WDATA: %47: i8, WE: %48: i1) -> (RDATA: i8)
+    %50 = comb.extract %49 from 0 : (i8) -> i1
+    %51 = comb.extract %49 from 1 : (i8) -> i1
+    %52 = comb.extract %49 from 2 : (i8) -> i1
+    %53 = comb.extract %49 from 3 : (i8) -> i1
+    %54 = comb.extract %49 from 4 : (i8) -> i1
+    %55 = comb.extract %49 from 5 : (i8) -> i1
+    %56 = comb.extract %49 from 6 : (i8) -> i1
+    %57 = comb.extract %49 from 7 : (i8) -> i1
+    %58 = hw.constant 0 : i1
+    %67 = sv.reg : !hw.inout<i1>
+    %48 = sv.read_inout %67 : !hw.inout<i1>
+    %68 = sv.reg : !hw.inout<i1>
+    %33 = sv.read_inout %68 : !hw.inout<i1>
+    %69 = sv.reg : !hw.inout<i1>
+    %34 = sv.read_inout %69 : !hw.inout<i1>
+    %70 = sv.reg : !hw.inout<i1>
+    %35 = sv.read_inout %70 : !hw.inout<i1>
+    %71 = sv.reg : !hw.inout<i1>
+    %36 = sv.read_inout %71 : !hw.inout<i1>
+    %72 = sv.reg : !hw.inout<i1>
+    %37 = sv.read_inout %72 : !hw.inout<i1>
+    %73 = sv.reg : !hw.inout<i1>
+    %39 = sv.read_inout %73 : !hw.inout<i1>
+    %74 = sv.reg : !hw.inout<i1>
+    %40 = sv.read_inout %74 : !hw.inout<i1>
+    %75 = sv.reg : !hw.inout<i1>
+    %41 = sv.read_inout %75 : !hw.inout<i1>
+    %76 = sv.reg : !hw.inout<i1>
+    %42 = sv.read_inout %76 : !hw.inout<i1>
+    %77 = sv.reg : !hw.inout<i1>
+    %43 = sv.read_inout %77 : !hw.inout<i1>
+    %78 = sv.reg : !hw.inout<i1>
+    %44 = sv.read_inout %78 : !hw.inout<i1>
+    %79 = sv.reg : !hw.inout<i1>
+    %45 = sv.read_inout %79 : !hw.inout<i1>
+    %80 = sv.reg : !hw.inout<i1>
+    %46 = sv.read_inout %80 : !hw.inout<i1>
+    %81 = sv.reg : !hw.inout<i1>
+    %27 = sv.read_inout %81 : !hw.inout<i1>
+    %82 = sv.reg : !hw.inout<i1>
+    %28 = sv.read_inout %82 : !hw.inout<i1>
+    %83 = sv.reg : !hw.inout<i1>
+    %29 = sv.read_inout %83 : !hw.inout<i1>
+    %84 = sv.reg : !hw.inout<i1>
+    %30 = sv.read_inout %84 : !hw.inout<i1>
+    %85 = sv.reg : !hw.inout<i1>
+    %31 = sv.read_inout %85 : !hw.inout<i1>
+    %86 = sv.reg : !hw.inout<i1>
+    %59 = sv.read_inout %86 : !hw.inout<i1>
+    %87 = sv.reg : !hw.inout<i1>
+    %60 = sv.read_inout %87 : !hw.inout<i1>
+    %88 = sv.reg : !hw.inout<i1>
+    %61 = sv.read_inout %88 : !hw.inout<i1>
+    %89 = sv.reg : !hw.inout<i1>
+    %62 = sv.read_inout %89 : !hw.inout<i1>
+    %90 = sv.reg : !hw.inout<i1>
+    %63 = sv.read_inout %90 : !hw.inout<i1>
+    %91 = sv.reg : !hw.inout<i1>
+    %64 = sv.read_inout %91 : !hw.inout<i1>
+    %92 = sv.reg : !hw.inout<i1>
+    %65 = sv.read_inout %92 : !hw.inout<i1>
+    %93 = sv.reg : !hw.inout<i1>
+    %66 = sv.read_inout %93 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %12, %7 : i5
-        sv.bpassign %13, %8 : i8
-        sv.bpassign %14, %9 : i1
-        sv.bpassign %15, %10 : i5
+        sv.bpassign %68, %1 : i1
+        sv.bpassign %69, %3 : i1
+        sv.bpassign %70, %5 : i1
+        sv.bpassign %71, %7 : i1
+        sv.bpassign %72, %9 : i1
+        sv.bpassign %73, %11 : i1
+        sv.bpassign %74, %13 : i1
+        sv.bpassign %75, %15 : i1
+        sv.bpassign %76, %17 : i1
+        sv.bpassign %77, %19 : i1
+        sv.bpassign %78, %21 : i1
+        sv.bpassign %79, %23 : i1
+        sv.bpassign %80, %25 : i1
+        sv.bpassign %81, %2 : i1
+        sv.bpassign %82, %4 : i1
+        sv.bpassign %83, %6 : i1
+        sv.bpassign %84, %8 : i1
+        sv.bpassign %85, %10 : i1
+        sv.bpassign %86, %50 : i1
+        sv.bpassign %87, %51 : i1
+        sv.bpassign %88, %52 : i1
+        sv.bpassign %89, %53 : i1
+        sv.bpassign %90, %54 : i1
+        sv.bpassign %91, %55 : i1
+        sv.bpassign %92, %56 : i1
+        sv.bpassign %93, %57 : i1
+        sv.bpassign %67, %58 : i1
         sv.if %en0 {
-            sv.bpassign %12, %addr0 : i5
-            sv.bpassign %13, %data0 : i8
-            sv.bpassign %14, %0 : i1
-            sv.bpassign %15, %addr1 : i5
-            sv.bpassign %16, %5 : i8
+            sv.bpassign %67, %0 : i1
         } else {
             sv.if %en1 {
-                sv.bpassign %12, %addr1 : i5
-                sv.bpassign %13, %data1 : i8
-                sv.bpassign %14, %0 : i1
-                sv.bpassign %15, %addr0 : i5
-                sv.bpassign %16, %5 : i8
+                sv.bpassign %68, %2 : i1
+                sv.bpassign %69, %4 : i1
+                sv.bpassign %70, %6 : i1
+                sv.bpassign %71, %8 : i1
+                sv.bpassign %72, %10 : i1
+                sv.bpassign %73, %12 : i1
+                sv.bpassign %74, %14 : i1
+                sv.bpassign %75, %16 : i1
+                sv.bpassign %76, %18 : i1
+                sv.bpassign %77, %20 : i1
+                sv.bpassign %78, %22 : i1
+                sv.bpassign %79, %24 : i1
+                sv.bpassign %80, %26 : i1
+                sv.bpassign %67, %0 : i1
+                sv.bpassign %81, %1 : i1
+                sv.bpassign %82, %3 : i1
+                sv.bpassign %83, %5 : i1
+                sv.bpassign %84, %7 : i1
+                sv.bpassign %85, %9 : i1
+                sv.bpassign %86, %50 : i1
+                sv.bpassign %87, %51 : i1
+                sv.bpassign %88, %52 : i1
+                sv.bpassign %89, %53 : i1
+                sv.bpassign %90, %54 : i1
+                sv.bpassign %91, %55 : i1
+                sv.bpassign %92, %56 : i1
+                sv.bpassign %93, %57 : i1
             } else {
-                sv.bpassign %16, %6 : i8
+                sv.bpassign %86, %0 : i1
+                sv.bpassign %87, %0 : i1
+                sv.bpassign %88, %0 : i1
+                sv.bpassign %89, %0 : i1
+                sv.bpassign %90, %0 : i1
+                sv.bpassign %91, %0 : i1
+                sv.bpassign %92, %0 : i1
+                sv.bpassign %93, %0 : i1
             }
         }
     }
-    hw.output %11 : i8
+    %94 = comb.concat %66, %65, %64, %63, %62, %61, %60, %59 : i1, i1, i1, i1, i1, i1, i1, i1
+    hw.output %94 : i8
 }

--- a/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
+++ b/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
@@ -29,54 +29,168 @@ hw.module @Memory(%RADDR: i5, %CLK: i1, %WADDR: i5, %WDATA_x: i1, %WDATA_y: i7, 
 }
 hw.module @test_when_memory_Tuplex_Bit_y_Bits7(%data0_x: i1, %data0_y: i7, %addr0: i5, %en0: i1, %data1_x: i1, %data1_y: i7, %addr1: i5, %en1: i1, %CLK: i1) -> (out_x: i1, out_y: i7) {
     %0 = hw.constant 1 : i1
-    %6, %7 = hw.instance "Memory_inst0" @Memory(RADDR: %1: i5, CLK: %CLK: i1, WADDR: %2: i5, WDATA_x: %3: i1, WDATA_y: %4: i7, WE: %5: i1) -> (RDATA_x: i1, RDATA_y: i7)
-    %8 = hw.constant 127 : i7
-    %9 = hw.constant 0 : i5
-    %10 = hw.constant 0 : i1
-    %11 = hw.constant 0 : i7
-    %12 = hw.constant 0 : i5
-    %15 = sv.reg : !hw.inout<i5>
-    %2 = sv.read_inout %15 : !hw.inout<i5>
-    %16 = sv.reg : !hw.inout<i1>
-    %3 = sv.read_inout %16 : !hw.inout<i1>
-    %17 = sv.reg : !hw.inout<i7>
-    %4 = sv.read_inout %17 : !hw.inout<i7>
-    %18 = sv.reg : !hw.inout<i1>
-    %5 = sv.read_inout %18 : !hw.inout<i1>
-    %19 = sv.reg : !hw.inout<i5>
-    %1 = sv.read_inout %19 : !hw.inout<i5>
-    %20 = sv.reg : !hw.inout<i1>
-    %13 = sv.read_inout %20 : !hw.inout<i1>
-    %21 = sv.reg : !hw.inout<i7>
-    %14 = sv.read_inout %21 : !hw.inout<i7>
+    %6 = comb.concat %5, %4, %3, %2, %1 : i1, i1, i1, i1, i1
+    %12 = comb.concat %11, %10, %9, %8, %7 : i1, i1, i1, i1, i1
+    %20 = comb.concat %19, %18, %17, %16, %15, %14, %13 : i1, i1, i1, i1, i1, i1, i1
+    %23, %24 = hw.instance "Memory_inst0" @Memory(RADDR: %6: i5, CLK: %CLK: i1, WADDR: %12: i5, WDATA_x: %21: i1, WDATA_y: %20: i7, WE: %22: i1) -> (RDATA_x: i1, RDATA_y: i7)
+    %25 = comb.extract %addr0 from 0 : (i5) -> i1
+    %26 = comb.extract %addr1 from 0 : (i5) -> i1
+    %27 = comb.extract %addr0 from 1 : (i5) -> i1
+    %28 = comb.extract %addr1 from 1 : (i5) -> i1
+    %29 = comb.extract %addr0 from 2 : (i5) -> i1
+    %30 = comb.extract %addr1 from 2 : (i5) -> i1
+    %31 = comb.extract %addr0 from 3 : (i5) -> i1
+    %32 = comb.extract %addr1 from 3 : (i5) -> i1
+    %33 = comb.extract %addr0 from 4 : (i5) -> i1
+    %34 = comb.extract %addr1 from 4 : (i5) -> i1
+    %35 = comb.extract %data0_y from 0 : (i7) -> i1
+    %36 = comb.extract %data1_y from 0 : (i7) -> i1
+    %37 = comb.extract %data0_y from 1 : (i7) -> i1
+    %38 = comb.extract %data1_y from 1 : (i7) -> i1
+    %39 = comb.extract %data0_y from 2 : (i7) -> i1
+    %40 = comb.extract %data1_y from 2 : (i7) -> i1
+    %41 = comb.extract %data0_y from 3 : (i7) -> i1
+    %42 = comb.extract %data1_y from 3 : (i7) -> i1
+    %43 = comb.extract %data0_y from 4 : (i7) -> i1
+    %44 = comb.extract %data1_y from 4 : (i7) -> i1
+    %45 = comb.extract %data0_y from 5 : (i7) -> i1
+    %46 = comb.extract %data1_y from 5 : (i7) -> i1
+    %47 = comb.extract %data0_y from 6 : (i7) -> i1
+    %48 = comb.extract %data1_y from 6 : (i7) -> i1
+    %49 = comb.extract %24 from 0 : (i7) -> i1
+    %50 = comb.extract %24 from 1 : (i7) -> i1
+    %51 = comb.extract %24 from 2 : (i7) -> i1
+    %52 = comb.extract %24 from 3 : (i7) -> i1
+    %53 = comb.extract %24 from 4 : (i7) -> i1
+    %54 = comb.extract %24 from 5 : (i7) -> i1
+    %55 = comb.extract %24 from 6 : (i7) -> i1
+    %56 = hw.constant 0 : i1
+    %65 = sv.reg : !hw.inout<i1>
+    %21 = sv.read_inout %65 : !hw.inout<i1>
+    %66 = sv.reg : !hw.inout<i1>
+    %22 = sv.read_inout %66 : !hw.inout<i1>
+    %67 = sv.reg : !hw.inout<i1>
+    %57 = sv.read_inout %67 : !hw.inout<i1>
+    %68 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %68 : !hw.inout<i1>
+    %69 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %69 : !hw.inout<i1>
+    %70 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %70 : !hw.inout<i1>
+    %71 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %71 : !hw.inout<i1>
+    %72 = sv.reg : !hw.inout<i1>
+    %11 = sv.read_inout %72 : !hw.inout<i1>
+    %73 = sv.reg : !hw.inout<i1>
+    %13 = sv.read_inout %73 : !hw.inout<i1>
+    %74 = sv.reg : !hw.inout<i1>
+    %14 = sv.read_inout %74 : !hw.inout<i1>
+    %75 = sv.reg : !hw.inout<i1>
+    %15 = sv.read_inout %75 : !hw.inout<i1>
+    %76 = sv.reg : !hw.inout<i1>
+    %16 = sv.read_inout %76 : !hw.inout<i1>
+    %77 = sv.reg : !hw.inout<i1>
+    %17 = sv.read_inout %77 : !hw.inout<i1>
+    %78 = sv.reg : !hw.inout<i1>
+    %18 = sv.read_inout %78 : !hw.inout<i1>
+    %79 = sv.reg : !hw.inout<i1>
+    %19 = sv.read_inout %79 : !hw.inout<i1>
+    %80 = sv.reg : !hw.inout<i1>
+    %1 = sv.read_inout %80 : !hw.inout<i1>
+    %81 = sv.reg : !hw.inout<i1>
+    %2 = sv.read_inout %81 : !hw.inout<i1>
+    %82 = sv.reg : !hw.inout<i1>
+    %3 = sv.read_inout %82 : !hw.inout<i1>
+    %83 = sv.reg : !hw.inout<i1>
+    %4 = sv.read_inout %83 : !hw.inout<i1>
+    %84 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %84 : !hw.inout<i1>
+    %85 = sv.reg : !hw.inout<i1>
+    %58 = sv.read_inout %85 : !hw.inout<i1>
+    %86 = sv.reg : !hw.inout<i1>
+    %59 = sv.read_inout %86 : !hw.inout<i1>
+    %87 = sv.reg : !hw.inout<i1>
+    %60 = sv.read_inout %87 : !hw.inout<i1>
+    %88 = sv.reg : !hw.inout<i1>
+    %61 = sv.read_inout %88 : !hw.inout<i1>
+    %89 = sv.reg : !hw.inout<i1>
+    %62 = sv.read_inout %89 : !hw.inout<i1>
+    %90 = sv.reg : !hw.inout<i1>
+    %63 = sv.read_inout %90 : !hw.inout<i1>
+    %91 = sv.reg : !hw.inout<i1>
+    %64 = sv.read_inout %91 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %15, %9 : i5
-        sv.bpassign %16, %10 : i1
-        sv.bpassign %17, %11 : i7
-        sv.bpassign %18, %10 : i1
-        sv.bpassign %19, %12 : i5
+        sv.bpassign %68, %25 : i1
+        sv.bpassign %69, %27 : i1
+        sv.bpassign %70, %29 : i1
+        sv.bpassign %71, %31 : i1
+        sv.bpassign %72, %33 : i1
+        sv.bpassign %73, %35 : i1
+        sv.bpassign %74, %37 : i1
+        sv.bpassign %75, %39 : i1
+        sv.bpassign %76, %41 : i1
+        sv.bpassign %77, %43 : i1
+        sv.bpassign %78, %45 : i1
+        sv.bpassign %79, %47 : i1
+        sv.bpassign %80, %26 : i1
+        sv.bpassign %81, %28 : i1
+        sv.bpassign %82, %30 : i1
+        sv.bpassign %83, %32 : i1
+        sv.bpassign %84, %34 : i1
+        sv.bpassign %85, %49 : i1
+        sv.bpassign %86, %50 : i1
+        sv.bpassign %87, %51 : i1
+        sv.bpassign %88, %52 : i1
+        sv.bpassign %89, %53 : i1
+        sv.bpassign %90, %54 : i1
+        sv.bpassign %91, %55 : i1
+        sv.bpassign %65, %56 : i1
+        sv.bpassign %66, %56 : i1
         sv.if %en0 {
-            sv.bpassign %15, %addr0 : i5
-            sv.bpassign %16, %data0_x : i1
-            sv.bpassign %17, %data0_y : i7
-            sv.bpassign %18, %0 : i1
-            sv.bpassign %19, %addr1 : i5
-            sv.bpassign %20, %6 : i1
-            sv.bpassign %21, %7 : i7
+            sv.bpassign %65, %data0_x : i1
+            sv.bpassign %66, %0 : i1
+            sv.bpassign %67, %23 : i1
         } else {
             sv.if %en1 {
-                sv.bpassign %15, %addr1 : i5
-                sv.bpassign %16, %data1_x : i1
-                sv.bpassign %17, %data1_y : i7
-                sv.bpassign %18, %0 : i1
-                sv.bpassign %19, %addr0 : i5
-                sv.bpassign %20, %6 : i1
-                sv.bpassign %21, %7 : i7
+                sv.bpassign %68, %26 : i1
+                sv.bpassign %69, %28 : i1
+                sv.bpassign %70, %30 : i1
+                sv.bpassign %71, %32 : i1
+                sv.bpassign %72, %34 : i1
+                sv.bpassign %65, %data1_x : i1
+                sv.bpassign %73, %36 : i1
+                sv.bpassign %74, %38 : i1
+                sv.bpassign %75, %40 : i1
+                sv.bpassign %76, %42 : i1
+                sv.bpassign %77, %44 : i1
+                sv.bpassign %78, %46 : i1
+                sv.bpassign %79, %48 : i1
+                sv.bpassign %66, %0 : i1
+                sv.bpassign %80, %25 : i1
+                sv.bpassign %81, %27 : i1
+                sv.bpassign %82, %29 : i1
+                sv.bpassign %83, %31 : i1
+                sv.bpassign %84, %33 : i1
+                sv.bpassign %67, %23 : i1
+                sv.bpassign %85, %49 : i1
+                sv.bpassign %86, %50 : i1
+                sv.bpassign %87, %51 : i1
+                sv.bpassign %88, %52 : i1
+                sv.bpassign %89, %53 : i1
+                sv.bpassign %90, %54 : i1
+                sv.bpassign %91, %55 : i1
             } else {
-                sv.bpassign %20, %0 : i1
-                sv.bpassign %21, %8 : i7
+                sv.bpassign %67, %0 : i1
+                sv.bpassign %85, %0 : i1
+                sv.bpassign %86, %0 : i1
+                sv.bpassign %87, %0 : i1
+                sv.bpassign %88, %0 : i1
+                sv.bpassign %89, %0 : i1
+                sv.bpassign %90, %0 : i1
+                sv.bpassign %91, %0 : i1
             }
         }
     }
-    hw.output %13, %14 : i1, i7
+    %92 = comb.concat %64, %63, %62, %61, %60, %59, %58 : i1, i1, i1, i1, i1, i1, i1
+    hw.output %57, %92 : i1, i7
 }

--- a/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
+++ b/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
@@ -1,23 +1,7 @@
 hw.module @test_when_nested_Array2_AnonProductxBit_yBits2_Bit(%I_0_0_x: i1, %I_0_0_y: i2, %I_0_1_x: i1, %I_0_1_y: i2, %I_1_0_x: i1, %I_1_0_y: i2, %I_1_1_x: i1, %I_1_1_y: i2, %S: i1) -> (O_0_x: i1, O_0_y: i2, O_1_x: i1, O_1_y: i2) {
-    %4 = sv.reg : !hw.inout<i1>
-    %0 = sv.read_inout %4 : !hw.inout<i1>
-    %5 = sv.reg : !hw.inout<i2>
-    %1 = sv.read_inout %5 : !hw.inout<i2>
-    %6 = sv.reg : !hw.inout<i1>
-    %2 = sv.read_inout %6 : !hw.inout<i1>
-    %7 = sv.reg : !hw.inout<i2>
-    %3 = sv.read_inout %7 : !hw.inout<i2>
     sv.alwayscomb {
-        sv.bpassign %4, %I_1_0_x : i1
-        sv.bpassign %5, %I_1_0_y : i2
-        sv.bpassign %6, %I_1_1_x : i1
-        sv.bpassign %7, %I_1_1_y : i2
         sv.if %S {
-            sv.bpassign %4, %I_0_0_x : i1
-            sv.bpassign %5, %I_0_0_y : i2
-            sv.bpassign %6, %I_0_1_x : i1
-            sv.bpassign %7, %I_0_1_y : i2
         }
     }
-    hw.output %0, %1, %2, %3 : i1, i2, i1, i2
+    hw.output %I_0_0_x, %I_0_0_y, %I_0_1_x, %I_0_1_y : i1, i2, i1, i2
 }

--- a/tests/gold/test_when_nested_Tuplex_Bits2_y_Bit.mlir
+++ b/tests/gold/test_when_nested_Tuplex_Bits2_y_Bit.mlir
@@ -1,15 +1,11 @@
 hw.module @test_when_nested_Tuplex_Bits2_y_Bit(%I_0_x: i2, %I_0_y: i1, %I_1_x: i2, %I_1_y: i1, %S: i1) -> (O_x: i2, O_y: i1) {
-    %2 = sv.reg : !hw.inout<i2>
-    %0 = sv.read_inout %2 : !hw.inout<i2>
-    %3 = sv.reg : !hw.inout<i1>
-    %1 = sv.read_inout %3 : !hw.inout<i1>
+    %1 = sv.reg : !hw.inout<i1>
+    %0 = sv.read_inout %1 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %2, %I_1_x : i2
-        sv.bpassign %3, %I_1_y : i1
+        sv.bpassign %1, %I_1_y : i1
         sv.if %S {
-            sv.bpassign %2, %I_0_x : i2
-            sv.bpassign %3, %I_0_y : i1
+            sv.bpassign %1, %I_0_y : i1
         }
     }
-    hw.output %0, %1 : i2, i1
+    hw.output %I_0_x, %0 : i2, i1
 }

--- a/tests/gold/test_when_nested_otherwise.mlir
+++ b/tests/gold/test_when_nested_otherwise.mlir
@@ -2,20 +2,30 @@ hw.module @test_when_nested_otherwise(%I: i2, %S: i2) -> (O: i2) {
     %1 = hw.constant -1 : i2
     %0 = comb.icmp eq %S, %1 : i2
     %2 = comb.extract %S from 1 : (i2) -> i1
-    %4 = hw.constant -1 : i2
-    %3 = comb.xor %4, %I : i2
-    %6 = sv.reg : !hw.inout<i2>
-    %5 = sv.read_inout %6 : !hw.inout<i2>
+    %3 = comb.extract %I from 0 : (i2) -> i1
+    %5 = hw.constant -1 : i2
+    %4 = comb.xor %5, %I : i2
+    %6 = comb.extract %4 from 0 : (i2) -> i1
+    %7 = comb.extract %I from 1 : (i2) -> i1
+    %8 = comb.extract %4 from 1 : (i2) -> i1
+    %11 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %12 : !hw.inout<i1>
     sv.alwayscomb {
+        sv.bpassign %11, %3 : i1
+        sv.bpassign %12, %7 : i1
         sv.if %0 {
-            sv.bpassign %6, %I : i2
         } else {
             sv.if %2 {
-                sv.bpassign %6, %3 : i2
+                sv.bpassign %11, %6 : i1
+                sv.bpassign %12, %8 : i1
             } else {
-                sv.bpassign %6, %I : i2
+                sv.bpassign %11, %3 : i1
+                sv.bpassign %12, %7 : i1
             }
         }
     }
-    hw.output %5 : i2
+    %13 = comb.concat %10, %9 : i1, i1
+    hw.output %13 : i2
 }

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -623,3 +623,16 @@ def test_when_nested_otherwise():
               flatten_all_tuples=True)
 
     assert check_gold(__file__, "test_when_nested_otherwise.mlir")
+
+
+def test_when_lazy_array_resolve(caplog):
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_resolve"
+        io = m.IO(I=m.In(m.SInt[2]), S=m.In(m.Bit), O=m.Out(m.SInt[2]))
+        with m.when(io.S):
+            io.O @= io.I
+        with m.otherwise():
+            io.O @= m.sint(m.uint(io.I) >> 1)
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")


### PR DESCRIPTION
Until we fix the issue with bulk wire resolution, we can unblock current users by always wiring the children (effectively forcing bulk wire resolution before entering the when logic).