### PR TITLE
Add instance callback pass

### DIFF
--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -8,6 +8,7 @@ import functools
 import operator
 from collections import namedtuple
 import os
+from typing import Callable, Dict, List
 
 import six
 from . import cache_definition
@@ -55,6 +56,7 @@ __all__ += ['CopyInstance']
 __all__ += ['circuit_type_method']
 __all__ += ['circuit_generator']
 __all__ += ['CircuitBuilder', 'builder_method']
+__all__ += ['register_instance_callback', 'get_instance_callback']
 
 circuit_type_method = namedtuple('circuit_type_method', ['name', 'definition'])
 
@@ -921,3 +923,28 @@ class DebugDefineCircuitKind(DefineCircuitKind):
 
 class DebugCircuit(Circuit, metaclass=DebugDefineCircuitKind):
     pass
+
+
+InstanceCallback = Callable[[List[CircuitType], Dict], None]
+
+
+def register_instance_callback(
+        instance: CircuitType,
+        callback: InstanceCallback,
+):
+    if hasattr(instance, "_callback_"):
+        raise AttributeError(
+            f"Instance {instance} already has callback registered"
+        )
+    instance._callback_ = callback
+
+
+def get_instance_callback(instance: CircuitType) -> InstanceCallback:
+    try:
+        return instance._callback_
+    except AttributeError:
+        msg = (
+            f"Instance {instance} has no callback registered. Did you call "
+            f"m.register_instance_callback()?"
+        )
+        raise AttributeError(msg) from None

--- a/magma/compile.py
+++ b/magma/compile.py
@@ -13,9 +13,13 @@ from magma.inline_verilog import ProcessInlineVerilogPass
 from magma.is_definition import isdefinition
 from magma.passes.clock import WireClockPass
 from magma.passes.drive_undriven import drive_undriven
+from magma.passes.instance_callback_pass import instance_callback_pass
 from magma.passes.terminate_unused import terminate_unused
-from magma.uniquification import (uniquification_pass, UniquificationMode,
-                                  reset_names)
+from magma.uniquification import (
+    UniquificationMode,
+    uniquification_pass,
+    reset_names,
+)
 
 
 __all__ = ["compile"]
@@ -97,11 +101,15 @@ def compile(basename, main, output="coreir-verilog", **kwargs):
     if opts.get("terminate_unused", False):
         terminate_unused(main)
 
+    instance_callback_pass_data = instance_callback_pass(main)
+
     result = compiler.compile()
     result = {} if result is None else result
 
     if hasattr(main, "fpga"):
         main.fpga.constraints(basename)
+
+    result["instance_callback_pass_data"] = instance_callback_pass_data
 
     reset_names(original_names)
 

--- a/magma/passes/__init__.py
+++ b/magma/passes/__init__.py
@@ -1,2 +1,3 @@
 from .passes import *
 from .ir import IRPass
+from .instance_callback_pass import InstanceCallbackPass, instance_callback_pass

--- a/magma/passes/instance_callback_pass.py
+++ b/magma/passes/instance_callback_pass.py
@@ -1,0 +1,27 @@
+from typing import Dict, Optional
+
+from magma.circuit import get_instance_callback
+from magma.passes.passes import InstancePass
+
+
+class InstanceCallbackPass(InstancePass):
+    def __init__(self, main, data: Optional[Dict]):
+        super().__init__(main)
+        if data is None:
+            data = {}
+        self.data = data
+
+    def __call__(self, path):
+        inst = path[-1]
+        try:
+            callback = get_instance_callback(inst)
+        except AttributeError:
+            return
+        path = [self.main] + list(path)
+        callback(path, self.data)
+
+
+def instance_callback_pass(main, data: Optional[Dict] = None):
+    p = InstanceCallbackPass(main, data)
+    p.run()
+    return p.data

--- a/tests/test_circuit/test_instance.py
+++ b/tests/test_circuit/test_instance.py
@@ -1,0 +1,38 @@
+import pytest
+
+import magma as m
+
+
+def test_callback_basic():
+
+    def _callback(path, data):
+        data[0] = (path,)
+
+    class _Test(m.Circuit):
+        reg = m.Register(m.Bit)(name="r")
+        m.register_instance_callback(reg, _callback)
+
+    path = [_Test]
+    data = {}
+    callback = m.get_instance_callback(_Test.reg)
+    callback(path, data)
+    assert data[0] == (path,)
+
+
+def test_callback_missing():
+
+    class _Test(m.Circuit):
+        reg = m.Register(m.Bit)(name="r")
+
+    with pytest.raises(AttributeError):
+        m.get_instance_callback(_Test.reg)
+
+
+def test_callback_registered():
+
+    class _Test(m.Circuit):
+        reg = m.Register(m.Bit)(name="r")
+
+    m.register_instance_callback(_Test.reg, lambda _, __: None)
+    with pytest.raises(AttributeError):
+        m.register_instance_callback(_Test.reg, lambda _, __: None)

--- a/tests/test_passes/test_instance_callback_pass.py
+++ b/tests/test_passes/test_instance_callback_pass.py
@@ -1,0 +1,23 @@
+import pytest
+
+import magma as m
+
+
+@pytest.mark.parametrize("use_lambda", (False, True))
+def test_basic(use_lambda):
+
+    def _callback(path, data):
+        data[0] = path
+
+    class _Test(m.Circuit):
+        reg = m.Register(m.Bit)(name="r")
+        m.register_instance_callback(reg, _callback)
+
+    if use_lambda:
+        data = m.passes.instance_callback_pass(_Test)
+    else:
+        p = m.passes.InstanceCallbackPass(_Test, None)
+        p.run()
+        data = p.data
+
+    assert data == {0: [_Test, _Test.reg]}


### PR DESCRIPTION
Adds the `InstanceCallbackPass`, called by default in `m.compile()`. It can be defined as follows on an instance:

```python
def callback(path, data):
    log = data.setdefault("log", list())
    log.append(f"Visited inst '{path[-1]}' at hierarchical path '{path}'")


class Foo(m.Circuit):
    ...
    bar = Bar(name="bar")
    baz = Baz(name="baz")
    m.register_instance_callback(bar, callback)
    m.register_instance_callback(baz, callback)
    ...


class Top(m.Circuit):
    ...
    foo = Foo()
    ...


res = m.compile("top", Top, ...)
callback_log = res["instance_callback_pass_data"]["log"]
# This should print:
#   Visited inst 'bar' at hierarchical path '[Top, Foo_inst0, bar]'
#   Visited inst 'baz' at hierarchical path '[Top, Foo_inst0, baz]'
for entry in callback_log:
    print (entry)
```