### PR TITLE
[MLIR] Add ifdef inside compile guarded modules

### DIFF
--- a/tests/test_backend/test_mlir/golds/simple_compile_guard.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_compile_guard.mlir
@@ -1,24 +1,29 @@
 hw.module @COND1_compile_guard(%port_0: i1, %CLK: i1) -> () {
-    %1 = sv.reg {name = "Register_inst0"} : !hw.inout<i1>
-    sv.alwaysff(posedge %CLK) {
-        sv.passign %1, %port_0 : i1
+    sv.ifdef "COND1" {
+        %1 = sv.reg {name = "Register_inst0"} : !hw.inout<i1>
+        sv.alwaysff(posedge %CLK) {
+            sv.passign %1, %port_0 : i1
+        }
+        %2 = hw.constant 0 : i1
+        sv.initial {
+            sv.bpassign %1, %2 : i1
+        }
+        %0 = sv.read_inout %1 : !hw.inout<i1>
     }
-    %2 = hw.constant 0 : i1
-    sv.initial {
-        sv.bpassign %1, %2 : i1
-    }
-    %0 = sv.read_inout %1 : !hw.inout<i1>
 }
 hw.module @COND2_compile_guard(%port_0: i1, %CLK: i1) -> () {
-    %1 = sv.reg {name = "Register_inst0"} : !hw.inout<i1>
-    sv.alwaysff(posedge %CLK) {
-        sv.passign %1, %port_0 : i1
+    sv.ifdef "COND2" {
+    } else {
+        %1 = sv.reg {name = "Register_inst0"} : !hw.inout<i1>
+        sv.alwaysff(posedge %CLK) {
+            sv.passign %1, %port_0 : i1
+        }
+        %2 = hw.constant 0 : i1
+        sv.initial {
+            sv.bpassign %1, %2 : i1
+        }
+        %0 = sv.read_inout %1 : !hw.inout<i1>
     }
-    %2 = hw.constant 0 : i1
-    sv.initial {
-        sv.bpassign %1, %2 : i1
-    }
-    %0 = sv.read_inout %1 : !hw.inout<i1>
 }
 hw.module @simple_compile_guard(%I: i1, %CLK: i1) -> (O: i1) {
     sv.ifdef "COND1" {

--- a/tests/test_backend/test_mlir/golds/simple_compile_guard.v
+++ b/tests/test_backend/test_mlir/golds/simple_compile_guard.v
@@ -1,41 +1,45 @@
 module COND1_compile_guard(	// <stdin>:1:1
   input port_0, CLK);
 
-  reg Register_inst0;	// <stdin>:2:10
+  `ifdef COND1	// <stdin>:2:5
+    reg Register_inst0;	// <stdin>:3:14
 
-  always_ff @(posedge CLK)	// <stdin>:3:5
-    Register_inst0 <= port_0;	// <stdin>:4:9
-  initial	// <stdin>:7:5
-    Register_inst0 = 1'h0;	// <stdin>:6:10, :8:9
+    always_ff @(posedge CLK)	// <stdin>:4:9
+      Register_inst0 <= port_0;	// <stdin>:5:13
+    initial	// <stdin>:8:9
+      Register_inst0 = 1'h0;	// <stdin>:7:14, :9:13
+  `endif
 endmodule
 
-module COND2_compile_guard(	// <stdin>:12:1
+module COND2_compile_guard(	// <stdin>:14:1
   input port_0, CLK);
 
-  reg Register_inst0;	// <stdin>:13:10
+  `ifndef COND2	// <stdin>:15:5
+    reg Register_inst0;	// <stdin>:17:14
 
-  always_ff @(posedge CLK)	// <stdin>:14:5
-    Register_inst0 <= port_0;	// <stdin>:15:9
-  initial	// <stdin>:18:5
-    Register_inst0 = 1'h0;	// <stdin>:17:10, :19:9
+    always_ff @(posedge CLK)	// <stdin>:18:9
+      Register_inst0 <= port_0;	// <stdin>:19:13
+    initial	// <stdin>:22:9
+      Register_inst0 = 1'h0;	// <stdin>:21:14, :23:13
+  `endif
 endmodule
 
-module simple_compile_guard(	// <stdin>:23:1
+module simple_compile_guard(	// <stdin>:28:1
   input  I, CLK,
   output O);
 
-  `ifdef COND1	// <stdin>:24:5
-    COND1_compile_guard COND1_compile_guard (	// <stdin>:25:9
+  `ifdef COND1	// <stdin>:29:5
+    COND1_compile_guard COND1_compile_guard (	// <stdin>:30:9
       .port_0 (I),
       .CLK    (CLK)
     );
   `endif
-  `ifndef COND2	// <stdin>:27:5
-    COND2_compile_guard COND2_compile_guard (	// <stdin>:29:9
+  `ifndef COND2	// <stdin>:32:5
+    COND2_compile_guard COND2_compile_guard (	// <stdin>:34:9
       .port_0 (I),
       .CLK    (CLK)
     );
   `endif
-  assign O = I;	// <stdin>:31:5
+  assign O = I;	// <stdin>:36:5
 endmodule
 


### PR DESCRIPTION
This is a workaround for #1143.

Instead of generating

```verilog
module Top;
    `ifdef COND
    !! some invalid verilog !!
    `endif
endmodule;
```

this change will generate


```verilog
module Top;
   `ifdef COND
   CompileGuard0 CompileGuard0_inst0 (...);
   `endif
endmodule;

module CompileGuard0 (...);
   `ifdef COND
    !! some invalid verilog !!
   `endif
endmodule;
```

Note that rather than inlining the compile guarded definition, we simply "reguard" it with the same condition.