### PR TITLE
[When] Lazy type integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ prof
 
 *.sublime-*
 benchmarks/*stats
+*bind_files.list

--- a/magma/array.py
+++ b/magma/array.py
@@ -646,11 +646,10 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
     def _get_conditional_drivee_info(self):
         conditional_wires = []
         default_drivers = []
-        wired_when_contexts = self._wired_when_contexts
-        for ctx in wired_when_contexts:
+        for ctx in self._wired_when_contexts:
             conditional_wires.append(ctx.get_conditional_wires_for_drivee(self))
             default_drivers.append(ctx._default_drivers.pop(self, None))
-        return wired_when_contexts, conditional_wires, default_drivers
+        return self._wired_when_contexts, conditional_wires, default_drivers
 
     def _rewire_conditional_children(self, wired_when_contexts,
                                      conditional_wires, default_drivers):

--- a/magma/array.py
+++ b/magma/array.py
@@ -1130,9 +1130,10 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         return True
 
     def set_enclosing_when_context(self, ctx):
-        # This code assumes set_enclosing_when_context is called when a child of a lazy
-        # value is created, so it should not have any children elaborated yet
-        # (and any future elaborations will inherit this context).
+        # This code assumes set_enclosing_when_context is called when a child
+        # of a lazy value is created, so it should not have any children
+        # elaborated yet (and any future elaborations will inherit this
+        # context).
         assert not self._ts
         assert not self._slices
         super().set_enclosing_when_context(ctx)

--- a/magma/array.py
+++ b/magma/array.py
@@ -719,6 +719,10 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
     def _resolve_driving_bulk_wire(self):
         driving = self._wire.driving()
         for drivee in driving:
+            # Force drivee to resolve by triggering the
+            # _resolve_driven_bulk_wire logic which occurs when referencing a
+            # child which begins the elaboration process.  Using this pattern
+            # avoids having to duplicate the logic for driving/driven
             drivee[0]
         return
 

--- a/magma/array.py
+++ b/magma/array.py
@@ -9,7 +9,7 @@ from .compatibility import IntegerTypes
 from .digital import Digital
 from .bit import Bit
 from .bitutils import int2seq
-from .debug import debug_wire, get_callee_frame_info
+from .debug import debug_wire, get_callee_frame_info, debug_unwire
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
@@ -622,14 +622,15 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
             # Perform a bulk wire
             Wireable.wire(self, o, debug_info)
 
-    @debug_wire
-    def unwire(self, o=None, debug_info=None):
+    @debug_unwire
+    def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if self._has_elaborated_children():
             for i, child in self._enumerate_children():
                 o_i = None if o is None else o[i]
-                child.unwire(o_i, debug_info=debug_info)
+                child.unwire(o_i, debug_info=debug_info,
+                             keep_wired_when_contexts=keep_wired_when_contexts)
         else:
-            Wireable.unwire(self, o, debug_info)
+            Wireable.unwire(self, o, debug_info, keep_wired_when_contexts)
 
     def iswhole(self):
         if self._has_elaborated_children():

--- a/magma/array.py
+++ b/magma/array.py
@@ -649,11 +649,7 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         wired_when_contexts = self._wired_when_contexts
         for ctx in wired_when_contexts:
             conditional_wires.append(ctx.get_conditional_wires_for_drivee(self))
-            if self in ctx._default_drivers:
-                default_drivers.append(ctx._default_drivers[self])
-                del ctx._default_drivers[self]
-            else:
-                default_drivers.append(None)
+            default_drivers.append(ctx._default_drivers.pop(self, None))
         return wired_when_contexts, conditional_wires, default_drivers
 
     def _rewire_conditional_children(self, wired_when_contexts,

--- a/magma/array.py
+++ b/magma/array.py
@@ -609,11 +609,7 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         return (
             self._has_elaborated_children() or
             o._has_elaborated_children() or
-            self.T.is_mixed() or
-            # TODO(leonardt): This is a temporary fix for when with bulk wire
-            # resolution. The workaround is if we have a conditional wire, we
-            # just let the children handle it.
-            get_curr_when_block()
+            self.T.is_mixed()
         )
 
     @debug_wire

--- a/magma/array.py
+++ b/magma/array.py
@@ -739,8 +739,7 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         # When we encounter an overlapping slice that is already bulk driven,
         # we ensure the corresponding children are updated to their current
         # values
-        if value._wire.driven():
-            value._resolve_driven_bulk_wire()
+        value._resolve_bulk_wire()
 
     def _remove_slice(self, key):
         """

--- a/magma/array.py
+++ b/magma/array.py
@@ -641,15 +641,6 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         return False
 
     def _get_conditional_drivee_info(self):
-        conditional_wires = []
-        default_drivers = []
-        for ctx in self._wired_when_contexts:
-            conditional_wires.append(ctx.get_conditional_wires_for_drivee(self))
-            default_drivers.append(ctx._default_drivers.pop(self, None))
-        return self._wired_when_contexts, conditional_wires, default_drivers
-
-    def _rewire_conditional_children(self, wired_when_contexts,
-                                     conditional_wires, default_drivers):
         """
         * wired_when_contexts: list of contexts in which this value appears as
                                conditionally driven.
@@ -661,6 +652,15 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         * default_drivers: for each ctx in `wired_when_contexts`, contains the
                            default driver (if it exists) for `self`.
         """
+        conditional_wires = []
+        default_drivers = []
+        for ctx in self._wired_when_contexts:
+            conditional_wires.append(ctx.get_conditional_wires_for_drivee(self))
+            default_drivers.append(ctx._default_drivers.pop(self, None))
+        return self._wired_when_contexts, conditional_wires, default_drivers
+
+    def _rewire_conditional_children(self, wired_when_contexts,
+                                     conditional_wires, default_drivers):
         for i, child in self._enumerate_children():
             for ctx, wires, default_driver in zip(wired_when_contexts,
                                                   conditional_wires,

--- a/magma/backend/coreir/insert_coreir_wires.py
+++ b/magma/backend/coreir/insert_coreir_wires.py
@@ -61,13 +61,7 @@ class InsertCoreIRWires(DefinitionPass):
 
         # Could be already wired for fanout cases
         if not wire_input.driven():
-            if isinstance(wire_input, Array):
-                for d, w in zip(driver, wire_input):
-                    # Could have wired up child elements already
-                    if not w.driven():
-                        w @= d
-            else:
-                wire_input @= driver
+            wire_input @= driver
         if (isinstance(value, _ClockType) and
                 not isinstance(wire_output, type(value))):
             # This mean it was cast by the user (e.g. m.clock(value)), so we

--- a/magma/backend/mlir/build_magma_graph.py
+++ b/magma/backend/mlir/build_magma_graph.py
@@ -79,7 +79,6 @@ class ModuleContext:
 
 def _visit_driver(
         ctx: ModuleContext, value: Type, driver: Type, module: ModuleLike):
-    print(value, driver)
     if driver.const():
         if isinstance(driver, Digital):
             as_bool = _const_digital_to_bool(driver)
@@ -107,7 +106,6 @@ def _visit_driver(
             T = type(driver)
             creator = MagmaArrayCreateOp(T)
             for i, element in enumerate(driver):
-                print(value[i].trace().debug_name, type(element.name))
                 creator_input = getattr(creator, f"I{i}")
                 _visit_driver(ctx, creator_input, element, creator)
             info = dict(src=creator.O, dst=value)
@@ -158,7 +156,6 @@ def _visit_driver(
 
 def _visit_input(ctx: ModuleContext, value: Type, module: ModuleLike):
     driver = value.trace()
-    print(value, driver)
     if driver is None:
         raise UnconnectedPortException(value)
     _visit_driver(ctx, value, driver, module)
@@ -178,10 +175,8 @@ def _visit_inputs(
 def build_magma_graph(
         ckt: DefineCircuitKind,
         opts: BuildMagmaGrahOpts = BuildMagmaGrahOpts()) -> Graph:
-    print(ckt)
     ctx = ModuleContext(Graph(), opts)
     _visit_inputs(ctx, ckt, opts.flatten_all_tuples)
     for inst in ckt.instances:
-        print(inst)
         _visit_inputs(ctx, inst, opts.flatten_all_tuples)
     return ctx.graph

--- a/magma/backend/mlir/build_magma_graph.py
+++ b/magma/backend/mlir/build_magma_graph.py
@@ -92,7 +92,6 @@ def _visit_driver(
             ctx.graph.add_edge(const, module, info=info)
             return
     ref = driver.name
-    assert not isinstance(ref, LazyInstRef) or ref._inst, ref
     if isinstance(ref, InstRef):
         info = dict(src=driver, dst=value)
         ctx.graph.add_edge(ref.inst, module, info=info)

--- a/magma/backend/mlir/build_magma_graph.py
+++ b/magma/backend/mlir/build_magma_graph.py
@@ -15,7 +15,7 @@ from magma.bits import Bits
 from magma.circuit import DefineCircuitKind
 from magma.compile_exception import UnconnectedPortException
 from magma.digital import Digital
-from magma.ref import InstRef, DefnRef, AnonRef, ArrayRef, TupleRef, LazyInstRef
+from magma.ref import InstRef, DefnRef, AnonRef, ArrayRef, TupleRef
 from magma.t import Type
 from magma.tuple import Tuple as m_Tuple
 

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -560,7 +560,7 @@ class ModuleVisitor:
             # `value` occurs as more than one input (for example, it could be
             # used as a conditional driver for multiple values).  We could
             # optimize the logic to always share the same argument, but for now
-            # we just use the "last" index
+            # we just use the "last" index.
             value_to_index[value] = next(counter)
 
         counter = itertools.count()

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -555,7 +555,6 @@ class ModuleVisitor:
         output_to_index = {}
 
         def _visit(value, counter, value_to_index):
-            assert value not in value_to_index
             value_to_index[value] = next(counter)
 
         counter = itertools.count()

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -555,7 +555,12 @@ class ModuleVisitor:
         output_to_index = {}
 
         def _visit(value, counter, value_to_index):
-            assert value not in value_to_index
+            # NOTE: value may already be in value_to_index, in which case we
+            # update it to a new index.  This is okay and it just means that
+            # `value` occurs as more than one input (for example, it could be
+            # used as a conditional driver for multiple values).  We could
+            # optimize the logic to always share the same argument, but for now
+            # we just use the "last" index
             value_to_index[value] = next(counter)
 
         counter = itertools.count()

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -555,10 +555,10 @@ class ModuleVisitor:
         output_to_index = {}
 
         def _visit(value, counter, value_to_index):
-            # NOTE(leonardt): value may already be in value_to_index, in which case we
-            # update it to a new index.  This is okay and it just means that
-            # `value` occurs as more than one input (for example, it could be
-            # used as a conditional driver for multiple values).  We could
+            # NOTE(leonardt): value may already be in value_to_index, in which
+            # case we update it to a new index.  This is okay and it just means
+            # that `value` occurs as more than one input (for example, it could
+            # be used as a conditional driver for multiple values).  We could
             # optimize the logic to always share the same argument, but for now
             # we just use the "last" index.
             value_to_index[value] = next(counter)

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -555,6 +555,7 @@ class ModuleVisitor:
         output_to_index = {}
 
         def _visit(value, counter, value_to_index):
+            assert value not in value_to_index
             value_to_index[value] = next(counter)
 
         counter = itertools.count()

--- a/magma/backend/mlir/magma_common.py
+++ b/magma/backend/mlir/magma_common.py
@@ -120,7 +120,7 @@ def visit_value_or_value_wrapper_by_direction(
 
     def descend(v):
         if not isinstance(v, (m_Tuple, Array)):
-            raise TypeError(value)
+            raise TypeError(v)
         pre_descend(v)
         for item in v:
             visit_value_or_value_wrapper_by_direction(

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -39,11 +39,11 @@ class MlirCompiler(Compiler):
         return "mlir"
 
     def _run_passes(self):
-        # NOTE(leonardt): We elaborate tuples before finalizing when statements 
-        # because they may cause array expansion (e.g. when we have an array of 
-        # tuples).  If we remove the flatten_all_tuples requirement, we may     
-        # finalize when earlier, but then we may still need this code path as an                                                                               
-        # option.                                                               
+        # NOTE(leonardt): We elaborate tuples before finalizing when statements
+        # because they may cause array expansion (e.g. when we have an array of
+        # tuples).  If we remove the flatten_all_tuples requirement, we may
+        # finalize when earlier, but then we may still need this code path as
+        # an option.
         if self.opts.get("flatten_all_tuples", False):
             elaborate_tuples(self.main)
         finalize_whens(self.main)

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -39,8 +39,13 @@ class MlirCompiler(Compiler):
         return "mlir"
 
     def _run_passes(self):
+        # We elaborate_tuples before finalizing when statements because they
+        # may cause array expansion (e.g. when we have an array of tuples).  If
+        # we remove the flatten_all_tuples requirement, we may finalize when
+        # earlier, but then we may still need this code path as an option
         elaborate_tuples(self.main)
         finalize_whens(self.main)
+
         insert_coreir_wires(self.main)
         insert_wrap_casts(self.main)
         wire_clocks(self.main)

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -13,6 +13,8 @@ from magma.circuit import DefineCircuitKind
 from magma.common import slice_opts
 from magma.compiler import Compiler
 from magma.passes.clock import wire_clocks
+from magma.passes.elaborate_tuples import elaborate_tuples
+from magma.passes.finalize_whens import finalize_whens
 from magma.passes.raise_logs_as_exceptions import raise_logs_as_exceptions_pass
 
 
@@ -37,6 +39,8 @@ class MlirCompiler(Compiler):
         return "mlir"
 
     def _run_passes(self):
+        elaborate_tuples(self.main)
+        finalize_whens(self.main)
         insert_coreir_wires(self.main)
         insert_wrap_casts(self.main)
         wire_clocks(self.main)

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -43,7 +43,8 @@ class MlirCompiler(Compiler):
         # may cause array expansion (e.g. when we have an array of tuples).  If
         # we remove the flatten_all_tuples requirement, we may finalize when
         # earlier, but then we may still need this code path as an option
-        elaborate_tuples(self.main)
+        if self.opts.get("flatten_all_tuples", False):
+            elaborate_tuples(self.main)
         finalize_whens(self.main)
 
         insert_coreir_wires(self.main)

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -842,6 +842,10 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
         self._io.remove(name)
         delattr(self, name)
 
+    def _rename_port(self, old, new):
+        self._io.rename(old, new)
+        setattr(self, new, self._io.inst_ports[new])
+
     def _add_port(self, name, typ):
         self._io.add(name, typ)
         setattr(self, name, self._io.inst_ports[name])

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -838,10 +838,6 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
     def _port(self, name):
         return self._io.ports[name]
 
-    def _remove_port(self, name):
-        self._io.remove(name)
-        delattr(self, name)
-
     def _rename_port(self, old, new):
         self._io.rename(old, new)
         setattr(self, new, self._io.inst_ports[new])

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -901,9 +901,6 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
             setattr(inst, k, v)
         return inst
 
-    def is_when_builder(self):
-        return False
-
 
 class DebugDefineCircuitKind(DefineCircuitKind):
     def __prepare__(name, bases, **kwargs):

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -838,6 +838,10 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
     def _port(self, name):
         return self._io.ports[name]
 
+    def _remove_port(self, name):
+        self._io.remove(name)
+        delattr(self, name)
+
     def _add_port(self, name, typ):
         self._io.add(name, typ)
         setattr(self, name, self._io.inst_ports[name])

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -901,6 +901,9 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
             setattr(inst, k, v)
         return inst
 
+    def is_when_builder(self):
+        return False
+
 
 class DebugDefineCircuitKind(DefineCircuitKind):
     def __prepare__(name, bases, **kwargs):

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -838,10 +838,6 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
     def _port(self, name):
         return self._io.ports[name]
 
-    def _rename_port(self, old, new):
-        self._io.rename(old, new)
-        setattr(self, new, self._io.inst_ports[new])
-
     def _add_port(self, name, typ):
         self._io.add(name, typ)
         setattr(self, name, self._io.inst_ports[name])

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -2,10 +2,8 @@ from typing import Optional
 
 from .t import Direction, In
 from .digital import DigitalMeta, Digital
-from .wire import wire
 from magma.bit import Bit
 from magma.array import Array
-from magma.debug import debug_wire
 from magma.tuple import Tuple
 
 

--- a/magma/debug.py
+++ b/magma/debug.py
@@ -34,3 +34,10 @@ def debug_wire(fn):
         return fn(i, o, debug_info)
     return wire
 
+
+def debug_unwire(fn):
+    def unwire(i, o=None, debug_info=None, keep_wired_when_contexts=False):
+        if get_debug_mode() and debug_info is None:
+            debug_info = get_callee_frame_info()
+        return fn(i, o, debug_info, keep_wired_when_contexts)
+    return unwire

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -124,8 +124,9 @@ class DefinitionContext(FinalizableDelegator):
         self._placer = self._placer.finalize(defn)
         for builder in self._builders:
             if builder.is_when_builder():
-                # NOTE(leonardt): We have to wait to finalize the when primitive
-                # until compilation to consider downstream circuit modifications.
+                # NOTE(leonardt): We have to wait to finalize the when
+                # primitive until compilation to consider downstream circuit
+                # modifications.
                 continue
             inst = builder.finalize()
             self._placer.place(inst)

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -123,7 +123,7 @@ class DefinitionContext(FinalizableDelegator):
     def place_instances(self, defn):
         self._placer = self._placer.finalize(defn)
         for builder in self._builders:
-            if getattr(builder, "_is_when_builder_", False):
+            if builder.is_when_builder():
                 # Wait to finalize when primitive until compile since circuit
                 # modifications may introduce changes
                 continue

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -124,8 +124,8 @@ class DefinitionContext(FinalizableDelegator):
         self._placer = self._placer.finalize(defn)
         for builder in self._builders:
             if builder.is_when_builder():
-                # Wait to finalize when primitive until compile since circuit
-                # modifications may introduce changes
+                # NOTE(leonardt): We have to wait to finalize the when primitive
+                # until compilation to consider downstream circuit modifications.
                 continue
             inst = builder.finalize()
             self._placer.place(inst)

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -123,8 +123,9 @@ class DefinitionContext(FinalizableDelegator):
     def place_instances(self, defn):
         self._placer = self._placer.finalize(defn)
         for builder in self._builders:
-            from magma.primitives.when import WhenBuilder
-            if isinstance(builder, WhenBuilder):
+            if getattr(builder, "_is_when_builder_", False):
+                # Wait to finalize when primitive until compile since circuit
+                # modifications may introduce changes
                 continue
             inst = builder.finalize()
             self._placer.place(inst)

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -1,7 +1,8 @@
 import contextlib
-import logging as py_logging
 from typing import Any, List, Mapping
 import weakref
+
+import magma as m # for is_when_builder circular import
 
 from magma.common import Stack, Finalizable, FinalizableDelegator
 from magma.logging import (
@@ -123,7 +124,7 @@ class DefinitionContext(FinalizableDelegator):
     def place_instances(self, defn):
         self._placer = self._placer.finalize(defn)
         for builder in self._builders:
-            if builder.is_when_builder():
+            if m.primitives.when.is_when_builder(builder):
                 # NOTE(leonardt): We have to wait to finalize the when
                 # primitive until compilation to consider downstream circuit
                 # modifications.

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -123,6 +123,9 @@ class DefinitionContext(FinalizableDelegator):
     def place_instances(self, defn):
         self._placer = self._placer.finalize(defn)
         for builder in self._builders:
+            from magma.primitives.when import WhenBuilder
+            if isinstance(builder, WhenBuilder):
+                continue
             inst = builder.finalize()
             self._placer.place(inst)
 

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -2,7 +2,7 @@ import contextlib
 from typing import Any, List, Mapping
 import weakref
 
-import magma as m # for is_when_builder circular import
+import magma as m  # for is_when_builder circular import
 
 from magma.common import Stack, Finalizable, FinalizableDelegator
 from magma.logging import (

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -2,14 +2,13 @@ from functools import lru_cache
 import weakref
 from abc import ABCMeta
 import hwtypes as ht
-from .t import Kind, Direction, Type, In, Out
-from .debug import debug_wire, get_callee_frame_info, debug_unwire
+from .t import Kind, Direction, Type
+from .debug import debug_wire, get_callee_frame_info
 from .compatibility import IntegerTypes
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
-from magma.ref import ArrayRef
-from magma.wire_container import Wire, WiringLog, Wireable
+from magma.wire_container import WiringLog, Wireable
 
 
 _logger = root_logger()

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -3,7 +3,7 @@ import weakref
 from abc import ABCMeta
 import hwtypes as ht
 from .t import Kind, Direction, Type, In, Out
-from .debug import debug_wire, get_callee_frame_info
+from .debug import debug_wire, get_callee_frame_info, debug_unwire
 from .compatibility import IntegerTypes
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
@@ -182,10 +182,6 @@ class Digital(Type, Wireable, metaclass=DigitalMeta):
             )
             return
         Wireable.wire(self, o, debug_info)
-
-    @debug_wire
-    def unwire(self, o=None, debug_info=None):
-        return Wireable.unwire(self, o, debug_info)
 
     def iswhole(self):
         return True

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -487,11 +487,6 @@ class IO(IOInterface):
         decl = self._decl + other._decl
         return IO(**_dict_from_decl(decl))
 
-    def remove(self, name):
-        if self._bound:
-            raise RuntimeError("Can not remove from a bound IO")
-        del self._ports[name]
-
     def add(self, name, typ):
         if self._bound:
             raise RuntimeError("Can not add to a bound IO")
@@ -559,10 +554,6 @@ class SingletonInstanceIO(IO):
         inst_ref = LazyInstRef(name=name)
         inst_port = _make_port(typ, inst_ref, flip=False)
         self._inst_ports[name] = inst_port
-
-    def remove(self, name):
-        super().remove(name)
-        del self._inst_ports[name]
 
     def __add__(self, other):
         raise NotImplementedError(f"Addition operator disallowed on "

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -492,6 +492,13 @@ class IO(IOInterface):
             raise RuntimeError("Can not remove from a bound IO")
         del self._ports[name]
 
+    def rename(self, old, new):
+        if self._bound:
+            raise RuntimeError("Can not rename in a bound IO")
+        self._ports[new] = self._ports[old]
+        self.remove(old)
+        self._ports[new].name.name = new
+
     def add(self, name, typ):
         if self._bound:
             raise RuntimeError("Can not add to a bound IO")
@@ -559,6 +566,11 @@ class SingletonInstanceIO(IO):
         inst_ref = LazyInstRef(name=name)
         inst_port = _make_port(typ, inst_ref, flip=False)
         self._inst_ports[name] = inst_port
+
+    def rename(self, old, new):
+        self._inst_ports[new] = self._inst_ports[old]
+        self._inst_ports[new].name.name = new
+        super().rename(old, new)
 
     def remove(self, name):
         super().remove(name)

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -487,6 +487,11 @@ class IO(IOInterface):
         decl = self._decl + other._decl
         return IO(**_dict_from_decl(decl))
 
+    def remove(self, name):
+        if self._bound:
+            raise RuntimeError("Can not remove from a bound IO")
+        del self._ports[name]
+
     def add(self, name, typ):
         if self._bound:
             raise RuntimeError("Can not add to a bound IO")
@@ -554,6 +559,10 @@ class SingletonInstanceIO(IO):
         inst_ref = LazyInstRef(name=name)
         inst_port = _make_port(typ, inst_ref, flip=False)
         self._inst_ports[name] = inst_port
+
+    def remove(self, name):
+        super().remove(name)
+        del self._inst_ports[name]
 
     def __add__(self, other):
         raise NotImplementedError(f"Addition operator disallowed on "

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -487,18 +487,6 @@ class IO(IOInterface):
         decl = self._decl + other._decl
         return IO(**_dict_from_decl(decl))
 
-    def remove(self, name):
-        if self._bound:
-            raise RuntimeError("Can not remove from a bound IO")
-        del self._ports[name]
-
-    def rename(self, old, new):
-        if self._bound:
-            raise RuntimeError("Can not rename in a bound IO")
-        self._ports[new] = self._ports[old]
-        self.remove(old)
-        self._ports[new].name.name = new
-
     def add(self, name, typ):
         if self._bound:
             raise RuntimeError("Can not add to a bound IO")
@@ -566,15 +554,6 @@ class SingletonInstanceIO(IO):
         inst_ref = LazyInstRef(name=name)
         inst_port = _make_port(typ, inst_ref, flip=False)
         self._inst_ports[name] = inst_port
-
-    def rename(self, old, new):
-        self._inst_ports[new] = self._inst_ports[old]
-        self._inst_ports[new].name.name = new
-        super().rename(old, new)
-
-    def remove(self, name):
-        super().remove(name)
-        del self._inst_ports[name]
 
     def __add__(self, other):
         raise NotImplementedError(f"Addition operator disallowed on "

--- a/magma/passes/clock.py
+++ b/magma/passes/clock.py
@@ -105,6 +105,8 @@ def _get_undriven_clocks_in_array(
 def get_undriven_clocks_in_value(
         value: Type, clock_type: Kind) -> Iterable[Type]:
     """Returns all undriven values of type @clock_type contained in @value."""
+    if not is_clock_or_nested_clock(type(value), (clock_type, )):
+        return
     if isinstance(value, Tuple):
         for elem in value:
             yield from get_undriven_clocks_in_value(elem, clock_type)

--- a/magma/passes/clock.py
+++ b/magma/passes/clock.py
@@ -106,6 +106,7 @@ def get_undriven_clocks_in_value(
         value: Type, clock_type: Kind) -> Iterable[Type]:
     """Returns all undriven values of type @clock_type contained in @value."""
     if not is_clock_or_nested_clock(type(value), (clock_type, )):
+        # Avoid descening into tuple/array if possible
         return
     if isinstance(value, Tuple):
         for elem in value:

--- a/magma/passes/elaborate_tuples.py
+++ b/magma/passes/elaborate_tuples.py
@@ -1,28 +1,16 @@
-from magma.array import Array
 from magma.passes.passes import DefinitionPass, pass_lambda
-from magma.tuple import Tuple
-
-
-def _is_tuple_or_nested_tuple(T):
-    if issubclass(T, Tuple):
-        return True
-    if issubclass(T, Array):
-        return _is_tuple_or_nested_tuple(T.T)
-    return False
+from magma.type_utils import contains_tuple
 
 
 def _expand(value):
-    if isinstance(value, Tuple):
-        for elem in value:
-            _expand(elem)
-    if isinstance(value, Array) and _is_tuple_or_nested_tuple(type(value)):
+    if contains_tuple(type(value)):
         for elem in value:
             _expand(elem)
 
 
 def _expand_tuple_values(values):
     for value in values:
-        if _is_tuple_or_nested_tuple(type(value)):
+        if contains_tuple(type(value)):
             _expand(value)
 
 

--- a/magma/passes/elaborate_tuples.py
+++ b/magma/passes/elaborate_tuples.py
@@ -18,19 +18,20 @@ def _expand(value):
     if isinstance(value, Array) and _is_tuple_or_nested_tuple(type(value)):
         for elem in value:
             _expand(elem)
-    return
+
+
+def _expand_tuple_values(values):
+    for value in values:
+        if _is_tuple_or_nested_tuple(type(value)):
+            _expand(value)
 
 
 class ElaborateTuplesPass(DefinitionPass):
     def __call__(self, definition):
         with definition.open():
-            for value in definition.interface.ports.values():
-                if _is_tuple_or_nested_tuple(type(value)):
-                    _expand(value)
+            _expand_tuple_values(definition.interface.ports.values())
             for instance in definition.instances:
-                for value in instance.interface.ports.values():
-                    if _is_tuple_or_nested_tuple(type(value)):
-                        _expand(value)
+                _expand_tuple_values(instance.interface.ports.values())
 
 
 elaborate_tuples = pass_lambda(ElaborateTuplesPass)

--- a/magma/passes/elaborate_tuples.py
+++ b/magma/passes/elaborate_tuples.py
@@ -1,0 +1,36 @@
+from magma.passes.passes import DefinitionPass, pass_lambda
+from magma.tuple import Tuple
+from magma.array import Array
+
+
+def _is_tuple_or_nested_tuple(T):
+    if issubclass(T, Tuple):
+        return True
+    if issubclass(T, Array):
+        return _is_tuple_or_nested_tuple(T.T)
+    return False
+
+
+def _expand(value):
+    if isinstance(value, Tuple):
+        for elem in value:
+            _expand(elem)
+    if isinstance(value, Array) and _is_tuple_or_nested_tuple(type(value)):
+        for elem in value:
+            _expand(elem)
+    return
+
+
+class ElaborateTuplesPass(DefinitionPass):
+    def __call__(self, definition):
+        with definition.open():
+            for value in definition.interface.ports.values():
+                if _is_tuple_or_nested_tuple(type(value)):
+                    _expand(value)
+            for instance in definition.instances:
+                for value in instance.interface.ports.values():
+                    if _is_tuple_or_nested_tuple(type(value)):
+                        _expand(value)
+
+
+elaborate_tuples = pass_lambda(ElaborateTuplesPass)

--- a/magma/passes/elaborate_tuples.py
+++ b/magma/passes/elaborate_tuples.py
@@ -1,6 +1,6 @@
+from magma.array import Array
 from magma.passes.passes import DefinitionPass, pass_lambda
 from magma.tuple import Tuple
-from magma.array import Array
 
 
 def _is_tuple_or_nested_tuple(T):

--- a/magma/passes/finalize_whens.py
+++ b/magma/passes/finalize_whens.py
@@ -1,0 +1,13 @@
+from magma.primitives.when import WhenBuilder
+from magma.passes.passes import DefinitionPass, pass_lambda
+
+
+class FinalizeWhens(DefinitionPass):
+    def __call__(self, definition):
+        with definition.open():
+            for builder in definition._context_._builders:
+                if isinstance(builder, WhenBuilder) and not builder._finalized:
+                    definition._context_._placer.place(builder.finalize())
+
+
+finalize_whens = pass_lambda(FinalizeWhens)

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -193,5 +193,6 @@ class WhenBuilder(CircuitBuilder):
     def block(self) -> WhenBlock:
         return self._block
 
-    def is_when_builder(self):
-        return True
+
+def is_when_builder(builder):
+    return isinstance(builder, WhenBuilder)

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -142,7 +142,12 @@ class WhenBuilder(CircuitBuilder):
             Out,
         )
 
-    def remove_drivee(self, value: Type):
+    def safe_remove_drivee(self, value: Type):
+        """
+        Removes `value`'s output port if it exists
+        """
+        if value not in self._output_to_index:
+            return
         idx = self._output_to_index[value]
         name = f"O{idx}"
         self._remove_port(name)

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -159,6 +159,7 @@ class WhenBuilder(CircuitBuilder):
 
         self._remove_port(name)
         del self._output_to_index[value]
+        del self._output_to_name[value]
 
         # Update existing outputs by subtracting one from their index and
         # renaming their port

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -142,6 +142,16 @@ class WhenBuilder(CircuitBuilder):
             Out,
         )
 
+    def remove_drivee(self, value: Type):
+        idx = self._output_to_index[value]
+        name = f"O{idx}"
+        self._remove_port(name)
+        del self._output_to_index[value]
+        for key, value in self._output_to_index.items():
+            if value > idx:
+                self._output_to_index[key] -= 1
+        self._output_counter = itertools.count(len(self._output_to_index))
+
     def add_driver(self, value: Type):
         self._generic_add(
             value,

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -150,7 +150,9 @@ class WhenBuilder(CircuitBuilder):
         for key, value in self._output_to_index.items():
             if value > idx:
                 self._output_to_index[key] -= 1
+                self._rename_port(f"O{value}", f"O{value - 1}")
         self._output_counter = itertools.count(len(self._output_to_index))
+        self._drivee_counter = itertools.count(len(self._output_to_index))
 
     def add_driver(self, value: Type):
         self._generic_add(

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -206,7 +206,6 @@ class WhenBuilder(CircuitBuilder):
         latches = find_inferred_latches(self.block)
         if latches:
             raise InferredLatchError(latches)
-        print("HELLO")
 
     @property
     def block(self) -> WhenBlock:

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -102,6 +102,7 @@ class WhenBuilder(CircuitBuilder):
         self._set_definition_attr("primitive", True)
         self._set_definition_attr(_ISWHEN_KEY, True)
         self._set_definition_attr("_builder_", self)
+        self._is_when_builder_ = True
 
     @property
     def default_drivers(self) -> Dict[Type, Type]:

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -192,3 +192,6 @@ class WhenBuilder(CircuitBuilder):
     @property
     def block(self) -> WhenBlock:
         return self._block
+
+    def is_when_builder(self):
+        return True

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -150,14 +150,22 @@ class WhenBuilder(CircuitBuilder):
             return
         idx = self._output_to_index[value]
         name = f"O{idx}"
+
         self._remove_port(name)
         del self._output_to_index[value]
+
+        # Update existing outputs by subtracting one from their index and
+        # renaming their port
         for key, value in self._output_to_index.items():
             if value > idx:
                 self._output_to_index[key] -= 1
                 self._rename_port(f"O{value}", f"O{value - 1}")
-        self._output_counter = itertools.count(len(self._output_to_index))
-        self._drivee_counter = itertools.count(len(self._output_to_index))
+
+        # Update counters so future drivee additions are consistent with the
+        # updated count
+        new_n = len(self._output_to_index)
+        self._output_counter = itertools.count(new_n)
+        self._drivee_counter = itertools.count(new_n)
 
     def add_driver(self, value: Type):
         self._generic_add(

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -148,25 +148,6 @@ class WhenBuilder(CircuitBuilder):
             Out,
         )
 
-    def safe_remove_drivee(self, value: Type):
-        """
-        Removes `value`'s output port if it exists
-        """
-        if value not in self._output_to_index:
-            return
-        name = self._output_to_name[value]
-        idx = self._output_to_index[value]
-
-        self._remove_port(name)
-        del self._output_to_index[value]
-        del self._output_to_name[value]
-
-        # Update existing outputs by subtracting one from their index and
-        # renaming their port
-        for key, value in self._output_to_index.items():
-            if value > idx:
-                self._output_to_index[key] -= 1
-
     def add_driver(self, value: Type):
         self._generic_add(
             value,

--- a/magma/protocol_type.py
+++ b/magma/protocol_type.py
@@ -1,6 +1,6 @@
 import abc
 
-from magma.debug import debug_wire
+from magma.debug import debug_wire, debug_unwire
 
 
 class MagmaProtocolMeta(type):
@@ -116,10 +116,12 @@ class MagmaProtocol(metaclass=MagmaProtocolMeta):
             other = other._get_magma_value_()
         self._get_magma_value_().wire(other, debug_info)
 
-    def unwire(self, other, debug_info=None):
+    @debug_unwire
+    def unwire(self, other, debug_info=None, keep_wired_when_contexts=False):
         if isinstance(other, MagmaProtocol):
             other = other._get_magma_value_()
-        self._get_magma_value_().unwire(other, debug_info)
+        self._get_magma_value_().unwire(other, debug_info,
+                                        keep_wired_when_contexts)
 
     def __imatmul__(self, other):
         self.wire(other)

--- a/magma/ref.py
+++ b/magma/ref.py
@@ -139,7 +139,7 @@ class LazyInstRef(InstRef):
     def inst(self):
         if self._inst is not None:
             return self._inst
-        return LazyCircuit
+        return LazyCircuit()
 
     def qualifiedname(self, sep="."):
         return super().qualifiedname(sep)
@@ -168,6 +168,11 @@ class DefnRef(NamedRef):
 
 class LazyCircuit:
     name = ""
+    debug_name = ""
+
+    @property
+    def defn(self):
+        return LazyCircuit
 
 
 class LazyDefnRef(DefnRef):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -18,7 +18,7 @@ from .common import deprecated
 from .ref import AnonRef, TupleRef
 from .t import Type, Kind, Direction
 from .compatibility import IntegerTypes
-from .debug import debug_wire, get_callee_frame_info
+from .debug import debug_wire, get_callee_frame_info, debug_unwire
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
@@ -309,15 +309,18 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
             o_elem = magma_value(o_elem)
             wire(o_elem, i_elem, debug_info)
 
-    @debug_wire
-    def unwire(self, o=None, debug_info=None):
+    @debug_unwire
+    def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         for k, t in self.items():
             if o is None:
-                t.unwire(debug_info=debug_info)
+                t.unwire(debug_info=debug_info,
+                         keep_wired_when_contexts=keep_wired_when_contexts)
             elif o[k].is_input():
-                o[k].unwire(t, debug_info=debug_info)
+                o[k].unwire(t, debug_info=debug_info,
+                            keep_wired_when_contexts=keep_wired_when_contexts)
             else:
-                t.unwire(o[k], debug_info=debug_info)
+                t.unwire(o[k], debug_info=debug_info,
+                         keep_wired_when_contexts=keep_wired_when_contexts)
 
     def driven(self):
         for t in self.ts:

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -452,9 +452,9 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
     def has_children(self):
         return True
 
-    def set_when_context(self, ctx):
+    def set_enclosing_when_context(self, ctx):
         for value in self:
-            value.set_when_context(ctx)
+            value.set_enclosing_when_context(ctx)
 
 
 def _add_properties(ns, fields):

--- a/magma/type_utils.py
+++ b/magma/type_utils.py
@@ -170,3 +170,11 @@ _TYPE_STR_SANITIZATION_MAP = {
 
 def type_to_sanitized_string(T: Kind) -> str:
     return replace_all(str(T), _TYPE_STR_SANITIZATION_MAP)
+
+
+def contains_tuple(T):
+    if issubclass(T, Tuple):
+        return True
+    if issubclass(T, Array):
+        return contains_tuple(T.T)
+    return False

--- a/magma/when.py
+++ b/magma/when.py
@@ -48,9 +48,6 @@ class _BlockBase(contextlib.AbstractContextManager):
         )
 
     def remove_conditional_wire(self, i):
-        # We use a "safe" remove pattern because multiple when contexts share
-        # the same builder and we only need to remove the drivee once but may
-        # need to update all the contexts
         self._conditional_wires = list(
             filter(lambda x: x.drivee is not i, self._conditional_wires)
         )

--- a/magma/when.py
+++ b/magma/when.py
@@ -274,6 +274,14 @@ def no_when():
     _set_curr_block(block)
 
 
+@contextlib.contextmanager
+def temp_when(temp_ctx):
+    block = _get_curr_block()
+    _set_curr_block(temp_ctx)
+    yield
+    _set_curr_block(block)
+
+
 def _get_curr_block() -> Optional[_BlockBase]:
     global _curr_block
     return _curr_block
@@ -303,7 +311,6 @@ def _reset_prev_block():
 
 
 get_curr_block = _get_curr_block
-set_curr_block = _set_curr_block
 
 
 def _reset_context():

--- a/magma/when.py
+++ b/magma/when.py
@@ -51,7 +51,6 @@ class _BlockBase(contextlib.AbstractContextManager):
         # We use a "safe" remove pattern because multiple when contexts share
         # the same builder and we only need to remove the drivee once but may
         # need to update all the contexts
-        self.root._builder.safe_remove_drivee(i)
         self._conditional_wires = list(
             filter(lambda x: x.drivee is not i, self._conditional_wires)
         )

--- a/magma/when.py
+++ b/magma/when.py
@@ -60,10 +60,10 @@ class _BlockBase(contextlib.AbstractContextManager):
         builder = self.root.builder
         if i.driven() and i not in builder.output_to_index:
             driver = i.value()
-            # TODO(leonardt): we need to skip removing wired when contexts
-            # because in this case, the driver could have been wired in a
-            # different when context
-            i._wire.unwire(driver._wire)
+            # Keep wired when contexts because in this case, the driver could
+            # have been wired in a different when context (so the default value
+            # comes from the result of a previous when context)
+            i.unwire(driver, keep_wired_when_contexts=True)
             self.root.add_default_driver(i, driver)
         self.root.builder.add_drivee(i)
         self.root.builder.add_driver(o)

--- a/magma/when.py
+++ b/magma/when.py
@@ -42,6 +42,22 @@ class _BlockBase(contextlib.AbstractContextManager):
         self._children.append(child)
         return child
 
+    def get_conditional_wires_for_drivee(self, i):
+        return list(
+            filter(lambda x: x.drivee is i, self._conditional_wires)
+        )
+
+    def get_conditional_wires_for_driver(self, o):
+        return list(
+            filter(lambda x: x.driver is o, self._conditional_wires)
+        )
+
+    def remove_conditional_wire(self, i):
+        self._conditional_wires = list(
+            filter(lambda x: x.drivee is not i, self._conditional_wires)
+        )
+        self.root.builder.remove_drivee(i)
+
     def add_conditional_wire(self, i, o):
         self._conditional_wires.append(ConditionalWire(i, o))
         builder = self.root.builder
@@ -55,6 +71,7 @@ class _BlockBase(contextlib.AbstractContextManager):
     @property
     @abc.abstractmethod
     def root(self) -> '_WhenBlock':
+
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -364,7 +381,9 @@ def _get_assignees_and_latches(ops: Iterable[_Op]) -> Tuple[Set, Set]:
         all branches.
     """
     assignees, latches = set(), set()
+    print("===")
     for op in ops:
+        print(op)
         if isinstance(op, ConditionalWire):
             assignees.add(op.drivee)
             continue
@@ -394,6 +413,8 @@ def _get_assignees_and_latches(ops: Iterable[_Op]) -> Tuple[Set, Set]:
             assignees.update(then_assignees.union(else_assignees))
             continue
         raise TypeError(op)
+    print(assignees, latches)
+    print("===")
     return assignees, latches
 
 

--- a/magma/when.py
+++ b/magma/when.py
@@ -53,10 +53,13 @@ class _BlockBase(contextlib.AbstractContextManager):
         )
 
     def remove_conditional_wire(self, i):
+        if self._parent is None:
+            # Only remove from builder once
+            # TODO: We could have the root when handle removing from children
+            self._builder.remove_drivee(i)
         self._conditional_wires = list(
             filter(lambda x: x.drivee is not i, self._conditional_wires)
         )
-        self.root.builder.remove_drivee(i)
 
     def add_conditional_wire(self, i, o):
         self._conditional_wires.append(ConditionalWire(i, o))
@@ -381,9 +384,7 @@ def _get_assignees_and_latches(ops: Iterable[_Op]) -> Tuple[Set, Set]:
         all branches.
     """
     assignees, latches = set(), set()
-    print("===")
     for op in ops:
-        print(op)
         if isinstance(op, ConditionalWire):
             assignees.add(op.drivee)
             continue
@@ -413,8 +414,6 @@ def _get_assignees_and_latches(ops: Iterable[_Op]) -> Tuple[Set, Set]:
             assignees.update(then_assignees.union(else_assignees))
             continue
         raise TypeError(op)
-    print(assignees, latches)
-    print("===")
     return assignees, latches
 
 

--- a/magma/when.py
+++ b/magma/when.py
@@ -53,10 +53,10 @@ class _BlockBase(contextlib.AbstractContextManager):
         )
 
     def remove_conditional_wire(self, i):
-        if self._parent is None:
-            # Only remove from builder once
-            # TODO: We could have the root when handle removing from children
-            self._builder.remove_drivee(i)
+        # We use a "safe" remove pattern because multiple when contexts share
+        # the same builder and we only need to remove the drivee once but may
+        # need to update all the contexts
+        self.root._builder.safe_remove_drivee(i)
         self._conditional_wires = list(
             filter(lambda x: x.drivee is not i, self._conditional_wires)
         )
@@ -74,7 +74,6 @@ class _BlockBase(contextlib.AbstractContextManager):
     @property
     @abc.abstractmethod
     def root(self) -> '_WhenBlock':
-
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/magma/when.py
+++ b/magma/when.py
@@ -61,7 +61,10 @@ class _BlockBase(contextlib.AbstractContextManager):
         builder = self.root.builder
         if i.driven() and i not in builder.output_to_index:
             driver = i.value()
-            i.unwire(driver)
+            # TODO(leonardt): we need to skip removing wired when contexts
+            # because in this case, the driver could have been wired in a
+            # different when context
+            i._wire.unwire(driver._wire)
             self.root.add_default_driver(i, driver)
         self.root.builder.add_drivee(i)
         self.root.builder.add_driver(o)

--- a/magma/when.py
+++ b/magma/when.py
@@ -47,11 +47,6 @@ class _BlockBase(contextlib.AbstractContextManager):
             filter(lambda x: x.drivee is i, self._conditional_wires)
         )
 
-    def get_conditional_wires_for_driver(self, o):
-        return list(
-            filter(lambda x: x.driver is o, self._conditional_wires)
-        )
-
     def remove_conditional_wire(self, i):
         # We use a "safe" remove pattern because multiple when contexts share
         # the same builder and we only need to remove the drivee once but may

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -170,7 +170,7 @@ class Wireable:
     def __init__(self):
         self._wire = Wire(self)
         self._enclosing_when_context = get_curr_when_block()
-        self._wired_when_context = None
+        self._wired_when_contexts = []
 
     def set_enclosing_when_context(self, ctx):
         self._enclosing_when_context = ctx
@@ -196,9 +196,10 @@ class Wireable:
         if o is not None:
             o = o._wire
         self._wire.unwire(o, debug_info)
-        if self._wired_when_context:
-            self._wired_when_context.remove_conditional_wire(self)
-        self._wired_when_context = None
+        if self._wired_when_contexts:
+            for ctx in self._wired_when_contexts:
+                ctx.remove_conditional_wire(self)
+        self._wired_when_contexts = []
 
     def _wire_impl(self, o, debug_info):
         self._wire.connect(o._wire, debug_info)
@@ -215,7 +216,7 @@ class Wireable:
             self._wire_impl(o, debug_info)
             return
         curr_when_block.add_conditional_wire(self, o)
-        self._wired_when_context = curr_when_block
+        self._wired_when_contexts.append(curr_when_block)
 
     @debug_wire
     def rewire(self, o, debug_info=None):

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -1,7 +1,7 @@
 import logging as py_logging
 
 from magma.config import config, EnvConfig
-from magma.debug import debug_wire
+from magma.debug import debug_wire, debug_unwire
 from magma.logging import root_logger, StagedLogRecord
 from magma.when import get_curr_block as get_curr_when_block
 
@@ -207,6 +207,7 @@ class Wireable:
             ctx.remove_conditional_wire(self)
         self._wired_when_contexts = []
 
+    @debug_unwire
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if o is not None:
             o = o._wire

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -207,11 +207,12 @@ class Wireable:
             ctx.remove_conditional_wire(self)
         self._wired_when_contexts = []
 
-    def unwire(self, o=None, debug_info=None):
+    def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if o is not None:
             o = o._wire
         self._wire.unwire(o, debug_info)
-        self._remove_from_wired_when_contexts()
+        if not keep_wired_when_contexts:
+            self._remove_from_wired_when_contexts()
 
     def _wire_impl(self, o, debug_info):
         self._wire.connect(o._wire, debug_info)

--- a/tests/gold/test_when_lazy_array_multiple_whens.mlir
+++ b/tests/gold/test_when_lazy_array_multiple_whens.mlir
@@ -1,0 +1,51 @@
+hw.module @test_when_lazy_array_multiple_whens(%I: i4, %S: i1) -> (O: i4) {
+    %1 = hw.constant -1 : i1
+    %0 = comb.xor %1, %S : i1
+    %2 = comb.extract %I from 0 : (i4) -> i1
+    %3 = comb.extract %I from 1 : (i4) -> i1
+    %4 = comb.extract %I from 2 : (i4) -> i1
+    %5 = comb.extract %I from 3 : (i4) -> i1
+    %10 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %13 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %10, %2 : i1
+            sv.bpassign %11, %3 : i1
+            sv.bpassign %12, %4 : i1
+            sv.bpassign %13, %5 : i1
+        } else {
+            sv.bpassign %10, %4 : i1
+            sv.bpassign %11, %5 : i1
+            sv.bpassign %12, %2 : i1
+            sv.bpassign %13, %3 : i1
+        }
+    }
+    %18 = sv.reg : !hw.inout<i1>
+    %14 = sv.read_inout %18 : !hw.inout<i1>
+    %19 = sv.reg : !hw.inout<i1>
+    %15 = sv.read_inout %19 : !hw.inout<i1>
+    %20 = sv.reg : !hw.inout<i1>
+    %16 = sv.read_inout %20 : !hw.inout<i1>
+    %21 = sv.reg : !hw.inout<i1>
+    %17 = sv.read_inout %21 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.bpassign %18, %6 : i1
+        sv.bpassign %19, %7 : i1
+        sv.bpassign %20, %8 : i1
+        sv.bpassign %21, %9 : i1
+        sv.if %0 {
+            sv.bpassign %18, %2 : i1
+            sv.bpassign %19, %3 : i1
+            sv.bpassign %20, %4 : i1
+            sv.bpassign %21, %5 : i1
+        }
+    }
+    %22 = comb.concat %17, %16, %15, %14 : i1, i1, i1, i1
+    hw.output %22 : i4
+}

--- a/tests/gold/test_when_lazy_array_multiple_whens.mlir
+++ b/tests/gold/test_when_lazy_array_multiple_whens.mlir
@@ -5,47 +5,49 @@ hw.module @test_when_lazy_array_multiple_whens(%I: i4, %S: i1) -> (O: i4) {
     %3 = comb.extract %I from 1 : (i4) -> i1
     %4 = comb.extract %I from 2 : (i4) -> i1
     %5 = comb.extract %I from 3 : (i4) -> i1
-    %10 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %10 : !hw.inout<i1>
-    %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i4>
+    %6 = sv.read_inout %11 : !hw.inout<i4>
     %12 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %7 = sv.read_inout %12 : !hw.inout<i1>
     %13 = sv.reg : !hw.inout<i1>
-    %9 = sv.read_inout %13 : !hw.inout<i1>
+    %8 = sv.read_inout %13 : !hw.inout<i1>
+    %14 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %15 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %10, %2 : i1
-            sv.bpassign %11, %3 : i1
-            sv.bpassign %12, %4 : i1
-            sv.bpassign %13, %5 : i1
-        } else {
-            sv.bpassign %10, %4 : i1
-            sv.bpassign %11, %5 : i1
             sv.bpassign %12, %2 : i1
             sv.bpassign %13, %3 : i1
+            sv.bpassign %14, %4 : i1
+            sv.bpassign %15, %5 : i1
+        } else {
+            sv.bpassign %12, %4 : i1
+            sv.bpassign %13, %5 : i1
+            sv.bpassign %14, %2 : i1
+            sv.bpassign %15, %3 : i1
         }
     }
-    %18 = sv.reg : !hw.inout<i1>
-    %14 = sv.read_inout %18 : !hw.inout<i1>
-    %19 = sv.reg : !hw.inout<i1>
-    %15 = sv.read_inout %19 : !hw.inout<i1>
     %20 = sv.reg : !hw.inout<i1>
     %16 = sv.read_inout %20 : !hw.inout<i1>
     %21 = sv.reg : !hw.inout<i1>
     %17 = sv.read_inout %21 : !hw.inout<i1>
+    %22 = sv.reg : !hw.inout<i1>
+    %18 = sv.read_inout %22 : !hw.inout<i1>
+    %23 = sv.reg : !hw.inout<i1>
+    %19 = sv.read_inout %23 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %18, %6 : i1
-        sv.bpassign %19, %7 : i1
-        sv.bpassign %20, %8 : i1
-        sv.bpassign %21, %9 : i1
+        sv.bpassign %20, %7 : i1
+        sv.bpassign %21, %8 : i1
+        sv.bpassign %22, %9 : i1
+        sv.bpassign %23, %10 : i1
         sv.if %0 {
-            sv.bpassign %18, %2 : i1
-            sv.bpassign %19, %3 : i1
-            sv.bpassign %20, %4 : i1
-            sv.bpassign %21, %5 : i1
+            sv.bpassign %20, %2 : i1
+            sv.bpassign %21, %3 : i1
+            sv.bpassign %22, %4 : i1
+            sv.bpassign %23, %5 : i1
         }
     }
-    %22 = comb.concat %17, %16, %15, %14 : i1, i1, i1, i1
-    hw.output %22 : i4
+    %24 = comb.concat %19, %18, %17, %16 : i1, i1, i1, i1
+    hw.output %24 : i4
 }

--- a/tests/gold/test_when_lazy_array_resolve.mlir
+++ b/tests/gold/test_when_lazy_array_resolve.mlir
@@ -5,19 +5,21 @@ hw.module @test_when_lazy_array_resolve(%I: i2, %S: i1) -> (O: i2) {
     %3 = comb.shru %I, %2 : i2
     %4 = comb.extract %3 from 0 : (i2) -> i1
     %5 = comb.extract %3 from 1 : (i2) -> i1
-    %8 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %8 : !hw.inout<i1>
-    %9 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %9 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i2>
+    %6 = sv.read_inout %9 : !hw.inout<i2>
+    %10 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %11 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %8, %0 : i1
-            sv.bpassign %9, %1 : i1
+            sv.bpassign %10, %0 : i1
+            sv.bpassign %11, %1 : i1
         } else {
-            sv.bpassign %8, %4 : i1
-            sv.bpassign %9, %5 : i1
+            sv.bpassign %10, %4 : i1
+            sv.bpassign %11, %5 : i1
         }
     }
-    %10 = comb.concat %7, %6 : i1, i1
-    hw.output %10 : i2
+    %12 = comb.concat %8, %7 : i1, i1
+    hw.output %12 : i2
 }

--- a/tests/gold/test_when_lazy_array_slice.mlir
+++ b/tests/gold/test_when_lazy_array_slice.mlir
@@ -1,30 +1,28 @@
 hw.module @test_when_lazy_array_slice(%S: i1) -> (O: i4) {
-    %0 = hw.constant 0 : i1
-    %1 = hw.constant 1 : i1
-    %6 = sv.reg : !hw.inout<i1>
-    %2 = sv.read_inout %6 : !hw.inout<i1>
-    %7 = sv.reg : !hw.inout<i1>
-    %3 = sv.read_inout %7 : !hw.inout<i1>
-    %8 = sv.reg : !hw.inout<i1>
-    %4 = sv.read_inout %8 : !hw.inout<i1>
-    %9 = sv.reg : !hw.inout<i1>
-    %5 = sv.read_inout %9 : !hw.inout<i1>
+    %0 = hw.constant 0 : i2
+    %1 = hw.constant 1 : i2
+    %2 = hw.constant 1 : i2
+    %3 = hw.constant 0 : i2
+    %6 = sv.reg : !hw.inout<i2>
+    %4 = sv.read_inout %6 : !hw.inout<i2>
+    %7 = sv.reg : !hw.inout<i2>
+    %5 = sv.read_inout %7 : !hw.inout<i2>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %6, %0 : i1
-            sv.bpassign %7, %0 : i1
-            sv.bpassign %8, %1 : i1
-            sv.bpassign %9, %0 : i1
+            sv.bpassign %6, %0 : i2
+            sv.bpassign %7, %1 : i2
         } else {
-            sv.bpassign %6, %1 : i1
-            sv.bpassign %7, %0 : i1
-            sv.bpassign %8, %0 : i1
-            sv.bpassign %9, %0 : i1
+            sv.bpassign %6, %2 : i2
+            sv.bpassign %7, %3 : i2
         }
     }
-    %10 = comb.concat %5, %4, %3, %2 : i1, i1, i1, i1
-    %12 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
-    sv.assign %12, %10 : i4
-    %11 = sv.read_inout %12 : !hw.inout<i4>
-    hw.output %11 : i4
+    %8 = comb.extract %4 from 0 : (i2) -> i1
+    %9 = comb.extract %4 from 1 : (i2) -> i1
+    %10 = comb.extract %5 from 0 : (i2) -> i1
+    %11 = comb.extract %5 from 1 : (i2) -> i1
+    %12 = comb.concat %11, %10, %9, %8 : i1, i1, i1, i1
+    %14 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
+    sv.assign %14, %12 : i4
+    %13 = sv.read_inout %14 : !hw.inout<i4>
+    hw.output %13 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice.mlir
+++ b/tests/gold/test_when_lazy_array_slice.mlir
@@ -5,30 +5,34 @@ hw.module @test_when_lazy_array_slice(%S: i1) -> (O: i4) {
     %3 = hw.constant 0 : i2
     %4 = hw.constant 0 : i1
     %5 = hw.constant 1 : i1
-    %10 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %10 : !hw.inout<i1>
-    %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
-    %12 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %12 : !hw.inout<i1>
-    %13 = sv.reg : !hw.inout<i1>
-    %9 = sv.read_inout %13 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i2>
+    %6 = sv.read_inout %12 : !hw.inout<i2>
+    %13 = sv.reg : !hw.inout<i2>
+    %7 = sv.read_inout %13 : !hw.inout<i2>
+    %14 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %15 : !hw.inout<i1>
+    %16 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %16 : !hw.inout<i1>
+    %17 = sv.reg : !hw.inout<i1>
+    %11 = sv.read_inout %17 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %10, %4 : i1
-            sv.bpassign %11, %4 : i1
-            sv.bpassign %12, %5 : i1
-            sv.bpassign %13, %4 : i1
+            sv.bpassign %14, %4 : i1
+            sv.bpassign %15, %4 : i1
+            sv.bpassign %16, %5 : i1
+            sv.bpassign %17, %4 : i1
         } else {
-            sv.bpassign %10, %5 : i1
-            sv.bpassign %11, %4 : i1
-            sv.bpassign %12, %4 : i1
-            sv.bpassign %13, %4 : i1
+            sv.bpassign %14, %5 : i1
+            sv.bpassign %15, %4 : i1
+            sv.bpassign %16, %4 : i1
+            sv.bpassign %17, %4 : i1
         }
     }
-    %14 = comb.concat %9, %8, %7, %6 : i1, i1, i1, i1
-    %16 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
-    sv.assign %16, %14 : i4
-    %15 = sv.read_inout %16 : !hw.inout<i4>
-    hw.output %15 : i4
+    %18 = comb.concat %11, %10, %9, %8 : i1, i1, i1, i1
+    %20 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
+    sv.assign %20, %18 : i4
+    %19 = sv.read_inout %20 : !hw.inout<i4>
+    hw.output %19 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice.mlir
+++ b/tests/gold/test_when_lazy_array_slice.mlir
@@ -3,26 +3,32 @@ hw.module @test_when_lazy_array_slice(%S: i1) -> (O: i4) {
     %1 = hw.constant 1 : i2
     %2 = hw.constant 1 : i2
     %3 = hw.constant 0 : i2
-    %6 = sv.reg : !hw.inout<i2>
-    %4 = sv.read_inout %6 : !hw.inout<i2>
-    %7 = sv.reg : !hw.inout<i2>
-    %5 = sv.read_inout %7 : !hw.inout<i2>
+    %4 = hw.constant 0 : i1
+    %5 = hw.constant 1 : i1
+    %10 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %13 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %6, %0 : i2
-            sv.bpassign %7, %1 : i2
+            sv.bpassign %10, %4 : i1
+            sv.bpassign %11, %4 : i1
+            sv.bpassign %12, %5 : i1
+            sv.bpassign %13, %4 : i1
         } else {
-            sv.bpassign %6, %2 : i2
-            sv.bpassign %7, %3 : i2
+            sv.bpassign %10, %5 : i1
+            sv.bpassign %11, %4 : i1
+            sv.bpassign %12, %4 : i1
+            sv.bpassign %13, %4 : i1
         }
     }
-    %8 = comb.extract %4 from 0 : (i2) -> i1
-    %9 = comb.extract %4 from 1 : (i2) -> i1
-    %10 = comb.extract %5 from 0 : (i2) -> i1
-    %11 = comb.extract %5 from 1 : (i2) -> i1
-    %12 = comb.concat %11, %10, %9, %8 : i1, i1, i1, i1
-    %14 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
-    sv.assign %14, %12 : i4
-    %13 = sv.read_inout %14 : !hw.inout<i4>
-    hw.output %13 : i4
+    %14 = comb.concat %9, %8, %7, %6 : i1, i1, i1, i1
+    %16 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
+    sv.assign %16, %14 : i4
+    %15 = sv.read_inout %16 : !hw.inout<i4>
+    hw.output %15 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice_driving_resolve.mlir
+++ b/tests/gold/test_when_lazy_array_slice_driving_resolve.mlir
@@ -1,0 +1,33 @@
+hw.module @test_when_lazy_array_slice_driving_resolve(%S: i1) -> (O: i4) {
+    %0 = hw.constant 1 : i1
+    %1 = hw.constant 2 : i4
+    %2 = hw.constant 4 : i4
+    %3 = hw.constant 0 : i1
+    %4 = hw.constant 1 : i1
+    %9 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %9 : !hw.inout<i1>
+    %10 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %12 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %9, %3 : i1
+            sv.bpassign %10, %4 : i1
+            sv.bpassign %11, %3 : i1
+            sv.bpassign %12, %3 : i1
+        } else {
+            sv.bpassign %9, %3 : i1
+            sv.bpassign %10, %3 : i1
+            sv.bpassign %11, %4 : i1
+            sv.bpassign %12, %3 : i1
+        }
+    }
+    %13 = comb.concat %8, %7, %6, %0 : i1, i1, i1, i1
+    %15 = sv.wire sym @test_when_lazy_array_slice_driving_resolve.x {name="x"} : !hw.inout<i4>
+    sv.assign %15, %13 : i4
+    %14 = sv.read_inout %15 : !hw.inout<i4>
+    hw.output %14 : i4
+}

--- a/tests/gold/test_when_lazy_array_slice_driving_resolve.mlir
+++ b/tests/gold/test_when_lazy_array_slice_driving_resolve.mlir
@@ -4,30 +4,32 @@ hw.module @test_when_lazy_array_slice_driving_resolve(%S: i1) -> (O: i4) {
     %2 = hw.constant 4 : i4
     %3 = hw.constant 0 : i1
     %4 = hw.constant 1 : i1
-    %9 = sv.reg : !hw.inout<i1>
-    %5 = sv.read_inout %9 : !hw.inout<i1>
-    %10 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %10 = sv.reg : !hw.inout<i4>
+    %5 = sv.read_inout %10 : !hw.inout<i4>
     %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %6 = sv.read_inout %11 : !hw.inout<i1>
     %12 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %7 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %13 : !hw.inout<i1>
+    %14 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %14 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %9, %3 : i1
-            sv.bpassign %10, %4 : i1
+            sv.bpassign %11, %3 : i1
+            sv.bpassign %12, %4 : i1
+            sv.bpassign %13, %3 : i1
+            sv.bpassign %14, %3 : i1
+        } else {
             sv.bpassign %11, %3 : i1
             sv.bpassign %12, %3 : i1
-        } else {
-            sv.bpassign %9, %3 : i1
-            sv.bpassign %10, %3 : i1
-            sv.bpassign %11, %4 : i1
-            sv.bpassign %12, %3 : i1
+            sv.bpassign %13, %4 : i1
+            sv.bpassign %14, %3 : i1
         }
     }
-    %13 = comb.concat %8, %7, %6, %0 : i1, i1, i1, i1
-    %15 = sv.wire sym @test_when_lazy_array_slice_driving_resolve.x {name="x"} : !hw.inout<i4>
-    sv.assign %15, %13 : i4
-    %14 = sv.read_inout %15 : !hw.inout<i4>
-    hw.output %14 : i4
+    %15 = comb.concat %9, %8, %7, %0 : i1, i1, i1, i1
+    %17 = sv.wire sym @test_when_lazy_array_slice_driving_resolve.x {name="x"} : !hw.inout<i4>
+    sv.assign %17, %15 : i4
+    %16 = sv.read_inout %17 : !hw.inout<i4>
+    hw.output %16 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice_driving_resolve_2.mlir
+++ b/tests/gold/test_when_lazy_array_slice_driving_resolve_2.mlir
@@ -6,30 +6,32 @@ hw.module @test_when_lazy_array_slice_driving_resolve_2(%I: i4, %S: i1) -> (O: i
     %4 = comb.extract %I from 2 : (i4) -> i1
     %5 = hw.constant 1 : i1
     %6 = comb.extract %I from 3 : (i4) -> i1
-    %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
-    %12 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i4>
+    %7 = sv.read_inout %12 : !hw.inout<i4>
     %13 = sv.reg : !hw.inout<i1>
-    %9 = sv.read_inout %13 : !hw.inout<i1>
+    %8 = sv.read_inout %13 : !hw.inout<i1>
     %14 = sv.reg : !hw.inout<i1>
-    %10 = sv.read_inout %14 : !hw.inout<i1>
+    %9 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %15 : !hw.inout<i1>
+    %16 = sv.reg : !hw.inout<i1>
+    %11 = sv.read_inout %16 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %11, %1 : i1
-            sv.bpassign %12, %3 : i1
-            sv.bpassign %13, %4 : i1
-            sv.bpassign %14, %6 : i1
+            sv.bpassign %13, %1 : i1
+            sv.bpassign %14, %3 : i1
+            sv.bpassign %15, %4 : i1
+            sv.bpassign %16, %6 : i1
         } else {
-            sv.bpassign %11, %2 : i1
-            sv.bpassign %12, %2 : i1
-            sv.bpassign %13, %5 : i1
+            sv.bpassign %13, %2 : i1
             sv.bpassign %14, %2 : i1
+            sv.bpassign %15, %5 : i1
+            sv.bpassign %16, %2 : i1
         }
     }
-    %15 = comb.concat %1, %9, %8, %7 : i1, i1, i1, i1
-    %17 = sv.wire sym @test_when_lazy_array_slice_driving_resolve_2.x {name="x"} : !hw.inout<i4>
-    sv.assign %17, %15 : i4
-    %16 = sv.read_inout %17 : !hw.inout<i4>
-    hw.output %16 : i4
+    %17 = comb.concat %1, %10, %9, %8 : i1, i1, i1, i1
+    %19 = sv.wire sym @test_when_lazy_array_slice_driving_resolve_2.x {name="x"} : !hw.inout<i4>
+    sv.assign %19, %17 : i4
+    %18 = sv.read_inout %19 : !hw.inout<i4>
+    hw.output %18 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice_driving_resolve_2.mlir
+++ b/tests/gold/test_when_lazy_array_slice_driving_resolve_2.mlir
@@ -1,0 +1,35 @@
+hw.module @test_when_lazy_array_slice_driving_resolve_2(%I: i4, %S: i1) -> (O: i4) {
+    %0 = hw.constant 4 : i4
+    %1 = comb.extract %I from 0 : (i4) -> i1
+    %2 = hw.constant 0 : i1
+    %3 = comb.extract %I from 1 : (i4) -> i1
+    %4 = comb.extract %I from 2 : (i4) -> i1
+    %5 = hw.constant 1 : i1
+    %6 = comb.extract %I from 3 : (i4) -> i1
+    %11 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %13 : !hw.inout<i1>
+    %14 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %14 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %11, %1 : i1
+            sv.bpassign %12, %3 : i1
+            sv.bpassign %13, %4 : i1
+            sv.bpassign %14, %6 : i1
+        } else {
+            sv.bpassign %11, %2 : i1
+            sv.bpassign %12, %2 : i1
+            sv.bpassign %13, %5 : i1
+            sv.bpassign %14, %2 : i1
+        }
+    }
+    %15 = comb.concat %1, %9, %8, %7 : i1, i1, i1, i1
+    %17 = sv.wire sym @test_when_lazy_array_slice_driving_resolve_2.x {name="x"} : !hw.inout<i4>
+    sv.assign %17, %15 : i4
+    %16 = sv.read_inout %17 : !hw.inout<i4>
+    hw.output %16 : i4
+}

--- a/tests/gold/test_when_lazy_array_slice_overlap.mlir
+++ b/tests/gold/test_when_lazy_array_slice_overlap.mlir
@@ -3,27 +3,29 @@ hw.module @test_when_lazy_array_slice_overlap(%I: i4, %S: i1) -> (O: i4) {
     %1 = comb.extract %I from 1 : (i4) -> i1
     %2 = comb.extract %I from 2 : (i4) -> i1
     %3 = comb.extract %I from 3 : (i4) -> i1
-    %8 = sv.reg : !hw.inout<i1>
-    %4 = sv.read_inout %8 : !hw.inout<i1>
-    %9 = sv.reg : !hw.inout<i1>
-    %5 = sv.read_inout %9 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i4>
+    %4 = sv.read_inout %9 : !hw.inout<i4>
     %10 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %5 = sv.read_inout %10 : !hw.inout<i1>
     %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %6 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %13 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %8, %0 : i1
-            sv.bpassign %9, %1 : i1
-            sv.bpassign %10, %2 : i1
-            sv.bpassign %11, %3 : i1
-        } else {
-            sv.bpassign %8, %2 : i1
-            sv.bpassign %9, %3 : i1
             sv.bpassign %10, %0 : i1
             sv.bpassign %11, %1 : i1
+            sv.bpassign %12, %2 : i1
+            sv.bpassign %13, %3 : i1
+        } else {
+            sv.bpassign %10, %2 : i1
+            sv.bpassign %11, %3 : i1
+            sv.bpassign %12, %0 : i1
+            sv.bpassign %13, %1 : i1
         }
     }
-    %12 = comb.concat %7, %6, %5, %4 : i1, i1, i1, i1
-    hw.output %12 : i4
+    %14 = comb.concat %8, %7, %6, %5 : i1, i1, i1, i1
+    hw.output %14 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice_overlap.mlir
+++ b/tests/gold/test_when_lazy_array_slice_overlap.mlir
@@ -1,0 +1,29 @@
+hw.module @test_when_lazy_array_slice_overlap(%I: i4, %S: i1) -> (O: i4) {
+    %0 = comb.extract %I from 0 : (i4) -> i1
+    %1 = comb.extract %I from 1 : (i4) -> i1
+    %2 = comb.extract %I from 2 : (i4) -> i1
+    %3 = comb.extract %I from 3 : (i4) -> i1
+    %8 = sv.reg : !hw.inout<i1>
+    %4 = sv.read_inout %8 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %9 : !hw.inout<i1>
+    %10 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %11 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %8, %0 : i1
+            sv.bpassign %9, %1 : i1
+            sv.bpassign %10, %2 : i1
+            sv.bpassign %11, %3 : i1
+        } else {
+            sv.bpassign %8, %2 : i1
+            sv.bpassign %9, %3 : i1
+            sv.bpassign %10, %0 : i1
+            sv.bpassign %11, %1 : i1
+        }
+    }
+    %12 = comb.concat %7, %6, %5, %4 : i1, i1, i1, i1
+    hw.output %12 : i4
+}

--- a/tests/gold/test_when_memory_Bits8.mlir
+++ b/tests/gold/test_when_memory_Bits8.mlir
@@ -11,189 +11,45 @@ hw.module @Memory(%RADDR: i5, %CLK: i1, %WADDR: i5, %WDATA: i8, %WE: i1) -> (RDA
     hw.output %0 : i8
 }
 hw.module @test_when_memory_Bits8(%data0: i8, %addr0: i5, %en0: i1, %data1: i8, %addr1: i5, %en1: i1, %CLK: i1) -> (out: i8) {
-    %0 = comb.extract %addr0 from 0 : (i5) -> i1
-    %1 = comb.extract %addr0 from 1 : (i5) -> i1
-    %2 = comb.extract %addr0 from 2 : (i5) -> i1
-    %3 = comb.extract %addr0 from 3 : (i5) -> i1
-    %4 = comb.extract %addr0 from 4 : (i5) -> i1
-    %5 = comb.extract %data0 from 0 : (i8) -> i1
-    %6 = comb.extract %data0 from 1 : (i8) -> i1
-    %7 = comb.extract %data0 from 2 : (i8) -> i1
-    %8 = comb.extract %data0 from 3 : (i8) -> i1
-    %9 = comb.extract %data0 from 4 : (i8) -> i1
-    %10 = comb.extract %data0 from 5 : (i8) -> i1
-    %11 = comb.extract %data0 from 6 : (i8) -> i1
-    %12 = comb.extract %data0 from 7 : (i8) -> i1
-    %13 = hw.constant 1 : i1
-    %14 = comb.extract %addr1 from 0 : (i5) -> i1
-    %15 = comb.extract %addr1 from 1 : (i5) -> i1
-    %16 = comb.extract %addr1 from 2 : (i5) -> i1
-    %17 = comb.extract %addr1 from 3 : (i5) -> i1
-    %18 = comb.extract %addr1 from 4 : (i5) -> i1
-    %24 = comb.concat %23, %22, %21, %20, %19 : i1, i1, i1, i1, i1
-    %30 = comb.concat %29, %28, %27, %26, %25 : i1, i1, i1, i1, i1
-    %39 = comb.concat %38, %37, %36, %35, %34, %33, %32, %31 : i1, i1, i1, i1, i1, i1, i1, i1
-    %41 = hw.instance "Memory_inst0" @Memory(RADDR: %24: i5, CLK: %CLK: i1, WADDR: %30: i5, WDATA: %39: i8, WE: %40: i1) -> (RDATA: i8)
-    %42 = comb.extract %41 from 0 : (i8) -> i1
-    %43 = comb.extract %41 from 1 : (i8) -> i1
-    %44 = comb.extract %41 from 2 : (i8) -> i1
-    %45 = comb.extract %41 from 3 : (i8) -> i1
-    %46 = comb.extract %41 from 4 : (i8) -> i1
-    %47 = comb.extract %41 from 5 : (i8) -> i1
-    %48 = comb.extract %41 from 6 : (i8) -> i1
-    %49 = comb.extract %41 from 7 : (i8) -> i1
-    %50 = comb.extract %data1 from 0 : (i8) -> i1
-    %51 = comb.extract %data1 from 1 : (i8) -> i1
-    %52 = comb.extract %data1 from 2 : (i8) -> i1
-    %53 = comb.extract %data1 from 3 : (i8) -> i1
-    %54 = comb.extract %data1 from 4 : (i8) -> i1
-    %55 = comb.extract %data1 from 5 : (i8) -> i1
-    %56 = comb.extract %data1 from 6 : (i8) -> i1
-    %57 = comb.extract %data1 from 7 : (i8) -> i1
-    %58 = hw.constant 0 : i1
-    %67 = sv.reg : !hw.inout<i1>
-    %25 = sv.read_inout %67 : !hw.inout<i1>
-    %68 = sv.reg : !hw.inout<i1>
-    %26 = sv.read_inout %68 : !hw.inout<i1>
-    %69 = sv.reg : !hw.inout<i1>
-    %27 = sv.read_inout %69 : !hw.inout<i1>
-    %70 = sv.reg : !hw.inout<i1>
-    %28 = sv.read_inout %70 : !hw.inout<i1>
-    %71 = sv.reg : !hw.inout<i1>
-    %29 = sv.read_inout %71 : !hw.inout<i1>
-    %72 = sv.reg : !hw.inout<i1>
-    %31 = sv.read_inout %72 : !hw.inout<i1>
-    %73 = sv.reg : !hw.inout<i1>
-    %32 = sv.read_inout %73 : !hw.inout<i1>
-    %74 = sv.reg : !hw.inout<i1>
-    %33 = sv.read_inout %74 : !hw.inout<i1>
-    %75 = sv.reg : !hw.inout<i1>
-    %34 = sv.read_inout %75 : !hw.inout<i1>
-    %76 = sv.reg : !hw.inout<i1>
-    %35 = sv.read_inout %76 : !hw.inout<i1>
-    %77 = sv.reg : !hw.inout<i1>
-    %36 = sv.read_inout %77 : !hw.inout<i1>
-    %78 = sv.reg : !hw.inout<i1>
-    %37 = sv.read_inout %78 : !hw.inout<i1>
-    %79 = sv.reg : !hw.inout<i1>
-    %38 = sv.read_inout %79 : !hw.inout<i1>
-    %80 = sv.reg : !hw.inout<i1>
-    %40 = sv.read_inout %80 : !hw.inout<i1>
-    %81 = sv.reg : !hw.inout<i1>
-    %19 = sv.read_inout %81 : !hw.inout<i1>
-    %82 = sv.reg : !hw.inout<i1>
-    %20 = sv.read_inout %82 : !hw.inout<i1>
-    %83 = sv.reg : !hw.inout<i1>
-    %21 = sv.read_inout %83 : !hw.inout<i1>
-    %84 = sv.reg : !hw.inout<i1>
-    %22 = sv.read_inout %84 : !hw.inout<i1>
-    %85 = sv.reg : !hw.inout<i1>
-    %23 = sv.read_inout %85 : !hw.inout<i1>
-    %86 = sv.reg : !hw.inout<i1>
-    %59 = sv.read_inout %86 : !hw.inout<i1>
-    %87 = sv.reg : !hw.inout<i1>
-    %60 = sv.read_inout %87 : !hw.inout<i1>
-    %88 = sv.reg : !hw.inout<i1>
-    %61 = sv.read_inout %88 : !hw.inout<i1>
-    %89 = sv.reg : !hw.inout<i1>
-    %62 = sv.read_inout %89 : !hw.inout<i1>
-    %90 = sv.reg : !hw.inout<i1>
-    %63 = sv.read_inout %90 : !hw.inout<i1>
-    %91 = sv.reg : !hw.inout<i1>
-    %64 = sv.read_inout %91 : !hw.inout<i1>
-    %92 = sv.reg : !hw.inout<i1>
-    %65 = sv.read_inout %92 : !hw.inout<i1>
-    %93 = sv.reg : !hw.inout<i1>
-    %66 = sv.read_inout %93 : !hw.inout<i1>
+    %0 = hw.constant 1 : i1
+    %5 = hw.instance "Memory_inst0" @Memory(RADDR: %1: i5, CLK: %CLK: i1, WADDR: %2: i5, WDATA: %3: i8, WE: %4: i1) -> (RDATA: i8)
+    %6 = hw.constant 255 : i8
+    %7 = hw.constant 0 : i5
+    %8 = hw.constant 0 : i8
+    %9 = hw.constant 0 : i1
+    %10 = hw.constant 0 : i5
+    %12 = sv.reg : !hw.inout<i5>
+    %2 = sv.read_inout %12 : !hw.inout<i5>
+    %13 = sv.reg : !hw.inout<i8>
+    %3 = sv.read_inout %13 : !hw.inout<i8>
+    %14 = sv.reg : !hw.inout<i1>
+    %4 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i5>
+    %1 = sv.read_inout %15 : !hw.inout<i5>
+    %16 = sv.reg : !hw.inout<i8>
+    %11 = sv.read_inout %16 : !hw.inout<i8>
     sv.alwayscomb {
-        sv.bpassign %67, %58 : i1
-        sv.bpassign %68, %58 : i1
-        sv.bpassign %69, %58 : i1
-        sv.bpassign %70, %58 : i1
-        sv.bpassign %71, %58 : i1
-        sv.bpassign %72, %58 : i1
-        sv.bpassign %73, %58 : i1
-        sv.bpassign %74, %58 : i1
-        sv.bpassign %75, %58 : i1
-        sv.bpassign %76, %58 : i1
-        sv.bpassign %77, %58 : i1
-        sv.bpassign %78, %58 : i1
-        sv.bpassign %79, %58 : i1
-        sv.bpassign %80, %58 : i1
-        sv.bpassign %81, %58 : i1
-        sv.bpassign %82, %58 : i1
-        sv.bpassign %83, %58 : i1
-        sv.bpassign %84, %58 : i1
-        sv.bpassign %85, %58 : i1
+        sv.bpassign %12, %7 : i5
+        sv.bpassign %13, %8 : i8
+        sv.bpassign %14, %9 : i1
+        sv.bpassign %15, %10 : i5
         sv.if %en0 {
-            sv.bpassign %67, %0 : i1
-            sv.bpassign %68, %1 : i1
-            sv.bpassign %69, %2 : i1
-            sv.bpassign %70, %3 : i1
-            sv.bpassign %71, %4 : i1
-            sv.bpassign %72, %5 : i1
-            sv.bpassign %73, %6 : i1
-            sv.bpassign %74, %7 : i1
-            sv.bpassign %75, %8 : i1
-            sv.bpassign %76, %9 : i1
-            sv.bpassign %77, %10 : i1
-            sv.bpassign %78, %11 : i1
-            sv.bpassign %79, %12 : i1
-            sv.bpassign %80, %13 : i1
-            sv.bpassign %81, %14 : i1
-            sv.bpassign %82, %15 : i1
-            sv.bpassign %83, %16 : i1
-            sv.bpassign %84, %17 : i1
-            sv.bpassign %85, %18 : i1
-            sv.bpassign %86, %42 : i1
-            sv.bpassign %87, %43 : i1
-            sv.bpassign %88, %44 : i1
-            sv.bpassign %89, %45 : i1
-            sv.bpassign %90, %46 : i1
-            sv.bpassign %91, %47 : i1
-            sv.bpassign %92, %48 : i1
-            sv.bpassign %93, %49 : i1
+            sv.bpassign %12, %addr0 : i5
+            sv.bpassign %13, %data0 : i8
+            sv.bpassign %14, %0 : i1
+            sv.bpassign %15, %addr1 : i5
+            sv.bpassign %16, %5 : i8
         } else {
             sv.if %en1 {
-                sv.bpassign %67, %14 : i1
-                sv.bpassign %68, %15 : i1
-                sv.bpassign %69, %16 : i1
-                sv.bpassign %70, %17 : i1
-                sv.bpassign %71, %18 : i1
-                sv.bpassign %72, %50 : i1
-                sv.bpassign %73, %51 : i1
-                sv.bpassign %74, %52 : i1
-                sv.bpassign %75, %53 : i1
-                sv.bpassign %76, %54 : i1
-                sv.bpassign %77, %55 : i1
-                sv.bpassign %78, %56 : i1
-                sv.bpassign %79, %57 : i1
-                sv.bpassign %80, %13 : i1
-                sv.bpassign %81, %0 : i1
-                sv.bpassign %82, %1 : i1
-                sv.bpassign %83, %2 : i1
-                sv.bpassign %84, %3 : i1
-                sv.bpassign %85, %4 : i1
-                sv.bpassign %86, %42 : i1
-                sv.bpassign %87, %43 : i1
-                sv.bpassign %88, %44 : i1
-                sv.bpassign %89, %45 : i1
-                sv.bpassign %90, %46 : i1
-                sv.bpassign %91, %47 : i1
-                sv.bpassign %92, %48 : i1
-                sv.bpassign %93, %49 : i1
+                sv.bpassign %12, %addr1 : i5
+                sv.bpassign %13, %data1 : i8
+                sv.bpassign %14, %0 : i1
+                sv.bpassign %15, %addr0 : i5
+                sv.bpassign %16, %5 : i8
             } else {
-                sv.bpassign %86, %13 : i1
-                sv.bpassign %87, %13 : i1
-                sv.bpassign %88, %13 : i1
-                sv.bpassign %89, %13 : i1
-                sv.bpassign %90, %13 : i1
-                sv.bpassign %91, %13 : i1
-                sv.bpassign %92, %13 : i1
-                sv.bpassign %93, %13 : i1
+                sv.bpassign %16, %6 : i8
             }
         }
     }
-    %94 = comb.concat %66, %65, %64, %63, %62, %61, %60, %59 : i1, i1, i1, i1, i1, i1, i1, i1
-    hw.output %94 : i8
+    hw.output %11 : i8
 }

--- a/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
+++ b/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
@@ -28,186 +28,55 @@ hw.module @Memory(%RADDR: i5, %CLK: i1, %WADDR: i5, %WDATA_x: i1, %WDATA_y: i7, 
     hw.output %12, %20 : i1, i7
 }
 hw.module @test_when_memory_Tuplex_Bit_y_Bits7(%data0_x: i1, %data0_y: i7, %addr0: i5, %en0: i1, %data1_x: i1, %data1_y: i7, %addr1: i5, %en1: i1, %CLK: i1) -> (out_x: i1, out_y: i7) {
-    %0 = comb.extract %addr0 from 0 : (i5) -> i1
-    %1 = comb.extract %addr0 from 1 : (i5) -> i1
-    %2 = comb.extract %addr0 from 2 : (i5) -> i1
-    %3 = comb.extract %addr0 from 3 : (i5) -> i1
-    %4 = comb.extract %addr0 from 4 : (i5) -> i1
-    %5 = comb.extract %data0_y from 0 : (i7) -> i1
-    %6 = comb.extract %data0_y from 1 : (i7) -> i1
-    %7 = comb.extract %data0_y from 2 : (i7) -> i1
-    %8 = comb.extract %data0_y from 3 : (i7) -> i1
-    %9 = comb.extract %data0_y from 4 : (i7) -> i1
-    %10 = comb.extract %data0_y from 5 : (i7) -> i1
-    %11 = comb.extract %data0_y from 6 : (i7) -> i1
-    %12 = hw.constant 1 : i1
-    %13 = comb.extract %addr1 from 0 : (i5) -> i1
-    %14 = comb.extract %addr1 from 1 : (i5) -> i1
-    %15 = comb.extract %addr1 from 2 : (i5) -> i1
-    %16 = comb.extract %addr1 from 3 : (i5) -> i1
-    %17 = comb.extract %addr1 from 4 : (i5) -> i1
-    %23 = comb.concat %22, %21, %20, %19, %18 : i1, i1, i1, i1, i1
-    %29 = comb.concat %28, %27, %26, %25, %24 : i1, i1, i1, i1, i1
-    %37 = comb.concat %36, %35, %34, %33, %32, %31, %30 : i1, i1, i1, i1, i1, i1, i1
-    %40, %41 = hw.instance "Memory_inst0" @Memory(RADDR: %23: i5, CLK: %CLK: i1, WADDR: %29: i5, WDATA_x: %38: i1, WDATA_y: %37: i7, WE: %39: i1) -> (RDATA_x: i1, RDATA_y: i7)
-    %42 = comb.extract %41 from 0 : (i7) -> i1
-    %43 = comb.extract %41 from 1 : (i7) -> i1
-    %44 = comb.extract %41 from 2 : (i7) -> i1
-    %45 = comb.extract %41 from 3 : (i7) -> i1
-    %46 = comb.extract %41 from 4 : (i7) -> i1
-    %47 = comb.extract %41 from 5 : (i7) -> i1
-    %48 = comb.extract %41 from 6 : (i7) -> i1
-    %49 = comb.extract %data1_y from 0 : (i7) -> i1
-    %50 = comb.extract %data1_y from 1 : (i7) -> i1
-    %51 = comb.extract %data1_y from 2 : (i7) -> i1
-    %52 = comb.extract %data1_y from 3 : (i7) -> i1
-    %53 = comb.extract %data1_y from 4 : (i7) -> i1
-    %54 = comb.extract %data1_y from 5 : (i7) -> i1
-    %55 = comb.extract %data1_y from 6 : (i7) -> i1
-    %56 = hw.constant 0 : i1
-    %65 = sv.reg : !hw.inout<i1>
-    %24 = sv.read_inout %65 : !hw.inout<i1>
-    %66 = sv.reg : !hw.inout<i1>
-    %25 = sv.read_inout %66 : !hw.inout<i1>
-    %67 = sv.reg : !hw.inout<i1>
-    %26 = sv.read_inout %67 : !hw.inout<i1>
-    %68 = sv.reg : !hw.inout<i1>
-    %27 = sv.read_inout %68 : !hw.inout<i1>
-    %69 = sv.reg : !hw.inout<i1>
-    %28 = sv.read_inout %69 : !hw.inout<i1>
-    %70 = sv.reg : !hw.inout<i1>
-    %38 = sv.read_inout %70 : !hw.inout<i1>
-    %71 = sv.reg : !hw.inout<i1>
-    %30 = sv.read_inout %71 : !hw.inout<i1>
-    %72 = sv.reg : !hw.inout<i1>
-    %31 = sv.read_inout %72 : !hw.inout<i1>
-    %73 = sv.reg : !hw.inout<i1>
-    %32 = sv.read_inout %73 : !hw.inout<i1>
-    %74 = sv.reg : !hw.inout<i1>
-    %33 = sv.read_inout %74 : !hw.inout<i1>
-    %75 = sv.reg : !hw.inout<i1>
-    %34 = sv.read_inout %75 : !hw.inout<i1>
-    %76 = sv.reg : !hw.inout<i1>
-    %35 = sv.read_inout %76 : !hw.inout<i1>
-    %77 = sv.reg : !hw.inout<i1>
-    %36 = sv.read_inout %77 : !hw.inout<i1>
-    %78 = sv.reg : !hw.inout<i1>
-    %39 = sv.read_inout %78 : !hw.inout<i1>
-    %79 = sv.reg : !hw.inout<i1>
-    %18 = sv.read_inout %79 : !hw.inout<i1>
-    %80 = sv.reg : !hw.inout<i1>
-    %19 = sv.read_inout %80 : !hw.inout<i1>
-    %81 = sv.reg : !hw.inout<i1>
-    %20 = sv.read_inout %81 : !hw.inout<i1>
-    %82 = sv.reg : !hw.inout<i1>
-    %21 = sv.read_inout %82 : !hw.inout<i1>
-    %83 = sv.reg : !hw.inout<i1>
-    %22 = sv.read_inout %83 : !hw.inout<i1>
-    %84 = sv.reg : !hw.inout<i1>
-    %57 = sv.read_inout %84 : !hw.inout<i1>
-    %85 = sv.reg : !hw.inout<i1>
-    %58 = sv.read_inout %85 : !hw.inout<i1>
-    %86 = sv.reg : !hw.inout<i1>
-    %59 = sv.read_inout %86 : !hw.inout<i1>
-    %87 = sv.reg : !hw.inout<i1>
-    %60 = sv.read_inout %87 : !hw.inout<i1>
-    %88 = sv.reg : !hw.inout<i1>
-    %61 = sv.read_inout %88 : !hw.inout<i1>
-    %89 = sv.reg : !hw.inout<i1>
-    %62 = sv.read_inout %89 : !hw.inout<i1>
-    %90 = sv.reg : !hw.inout<i1>
-    %63 = sv.read_inout %90 : !hw.inout<i1>
-    %91 = sv.reg : !hw.inout<i1>
-    %64 = sv.read_inout %91 : !hw.inout<i1>
+    %0 = hw.constant 1 : i1
+    %6, %7 = hw.instance "Memory_inst0" @Memory(RADDR: %1: i5, CLK: %CLK: i1, WADDR: %2: i5, WDATA_x: %3: i1, WDATA_y: %4: i7, WE: %5: i1) -> (RDATA_x: i1, RDATA_y: i7)
+    %8 = hw.constant 127 : i7
+    %9 = hw.constant 0 : i5
+    %10 = hw.constant 0 : i1
+    %11 = hw.constant 0 : i7
+    %12 = hw.constant 0 : i5
+    %15 = sv.reg : !hw.inout<i5>
+    %2 = sv.read_inout %15 : !hw.inout<i5>
+    %16 = sv.reg : !hw.inout<i1>
+    %3 = sv.read_inout %16 : !hw.inout<i1>
+    %17 = sv.reg : !hw.inout<i7>
+    %4 = sv.read_inout %17 : !hw.inout<i7>
+    %18 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %18 : !hw.inout<i1>
+    %19 = sv.reg : !hw.inout<i5>
+    %1 = sv.read_inout %19 : !hw.inout<i5>
+    %20 = sv.reg : !hw.inout<i1>
+    %13 = sv.read_inout %20 : !hw.inout<i1>
+    %21 = sv.reg : !hw.inout<i7>
+    %14 = sv.read_inout %21 : !hw.inout<i7>
     sv.alwayscomb {
-        sv.bpassign %65, %56 : i1
-        sv.bpassign %66, %56 : i1
-        sv.bpassign %67, %56 : i1
-        sv.bpassign %68, %56 : i1
-        sv.bpassign %69, %56 : i1
-        sv.bpassign %70, %56 : i1
-        sv.bpassign %71, %56 : i1
-        sv.bpassign %72, %56 : i1
-        sv.bpassign %73, %56 : i1
-        sv.bpassign %74, %56 : i1
-        sv.bpassign %75, %56 : i1
-        sv.bpassign %76, %56 : i1
-        sv.bpassign %77, %56 : i1
-        sv.bpassign %78, %56 : i1
-        sv.bpassign %79, %56 : i1
-        sv.bpassign %80, %56 : i1
-        sv.bpassign %81, %56 : i1
-        sv.bpassign %82, %56 : i1
-        sv.bpassign %83, %56 : i1
+        sv.bpassign %15, %9 : i5
+        sv.bpassign %16, %10 : i1
+        sv.bpassign %17, %11 : i7
+        sv.bpassign %18, %10 : i1
+        sv.bpassign %19, %12 : i5
         sv.if %en0 {
-            sv.bpassign %65, %0 : i1
-            sv.bpassign %66, %1 : i1
-            sv.bpassign %67, %2 : i1
-            sv.bpassign %68, %3 : i1
-            sv.bpassign %69, %4 : i1
-            sv.bpassign %70, %data0_x : i1
-            sv.bpassign %71, %5 : i1
-            sv.bpassign %72, %6 : i1
-            sv.bpassign %73, %7 : i1
-            sv.bpassign %74, %8 : i1
-            sv.bpassign %75, %9 : i1
-            sv.bpassign %76, %10 : i1
-            sv.bpassign %77, %11 : i1
-            sv.bpassign %78, %12 : i1
-            sv.bpassign %79, %13 : i1
-            sv.bpassign %80, %14 : i1
-            sv.bpassign %81, %15 : i1
-            sv.bpassign %82, %16 : i1
-            sv.bpassign %83, %17 : i1
-            sv.bpassign %84, %40 : i1
-            sv.bpassign %85, %42 : i1
-            sv.bpassign %86, %43 : i1
-            sv.bpassign %87, %44 : i1
-            sv.bpassign %88, %45 : i1
-            sv.bpassign %89, %46 : i1
-            sv.bpassign %90, %47 : i1
-            sv.bpassign %91, %48 : i1
+            sv.bpassign %15, %addr0 : i5
+            sv.bpassign %16, %data0_x : i1
+            sv.bpassign %17, %data0_y : i7
+            sv.bpassign %18, %0 : i1
+            sv.bpassign %19, %addr1 : i5
+            sv.bpassign %20, %6 : i1
+            sv.bpassign %21, %7 : i7
         } else {
             sv.if %en1 {
-                sv.bpassign %65, %13 : i1
-                sv.bpassign %66, %14 : i1
-                sv.bpassign %67, %15 : i1
-                sv.bpassign %68, %16 : i1
-                sv.bpassign %69, %17 : i1
-                sv.bpassign %70, %data1_x : i1
-                sv.bpassign %71, %49 : i1
-                sv.bpassign %72, %50 : i1
-                sv.bpassign %73, %51 : i1
-                sv.bpassign %74, %52 : i1
-                sv.bpassign %75, %53 : i1
-                sv.bpassign %76, %54 : i1
-                sv.bpassign %77, %55 : i1
-                sv.bpassign %78, %12 : i1
-                sv.bpassign %79, %0 : i1
-                sv.bpassign %80, %1 : i1
-                sv.bpassign %81, %2 : i1
-                sv.bpassign %82, %3 : i1
-                sv.bpassign %83, %4 : i1
-                sv.bpassign %84, %40 : i1
-                sv.bpassign %85, %42 : i1
-                sv.bpassign %86, %43 : i1
-                sv.bpassign %87, %44 : i1
-                sv.bpassign %88, %45 : i1
-                sv.bpassign %89, %46 : i1
-                sv.bpassign %90, %47 : i1
-                sv.bpassign %91, %48 : i1
+                sv.bpassign %15, %addr1 : i5
+                sv.bpassign %16, %data1_x : i1
+                sv.bpassign %17, %data1_y : i7
+                sv.bpassign %18, %0 : i1
+                sv.bpassign %19, %addr0 : i5
+                sv.bpassign %20, %6 : i1
+                sv.bpassign %21, %7 : i7
             } else {
-                sv.bpassign %84, %12 : i1
-                sv.bpassign %85, %12 : i1
-                sv.bpassign %86, %12 : i1
-                sv.bpassign %87, %12 : i1
-                sv.bpassign %88, %12 : i1
-                sv.bpassign %89, %12 : i1
-                sv.bpassign %90, %12 : i1
-                sv.bpassign %91, %12 : i1
+                sv.bpassign %20, %0 : i1
+                sv.bpassign %21, %8 : i7
             }
         }
     }
-    %92 = comb.concat %64, %63, %62, %61, %60, %59, %58 : i1, i1, i1, i1, i1, i1, i1
-    hw.output %57, %92 : i1, i7
+    hw.output %13, %14 : i1, i7
 }

--- a/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
+++ b/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
@@ -1,41 +1,23 @@
 hw.module @test_when_nested_Array2_AnonProductxBit_yBits2_Bit(%I_0_0_x: i1, %I_0_0_y: i2, %I_0_1_x: i1, %I_0_1_y: i2, %I_1_0_x: i1, %I_1_0_y: i2, %I_1_1_x: i1, %I_1_1_y: i2, %S: i1) -> (O_0_x: i1, O_0_y: i2, O_1_x: i1, O_1_y: i2) {
-    %0 = comb.extract %I_1_0_y from 0 : (i2) -> i1
-    %1 = comb.extract %I_0_0_y from 0 : (i2) -> i1
-    %2 = comb.extract %I_1_0_y from 1 : (i2) -> i1
-    %3 = comb.extract %I_0_0_y from 1 : (i2) -> i1
-    %4 = comb.extract %I_1_1_y from 0 : (i2) -> i1
-    %5 = comb.extract %I_0_1_y from 0 : (i2) -> i1
-    %6 = comb.extract %I_1_1_y from 1 : (i2) -> i1
-    %7 = comb.extract %I_0_1_y from 1 : (i2) -> i1
-    %14 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %14 : !hw.inout<i1>
-    %15 = sv.reg : !hw.inout<i1>
-    %9 = sv.read_inout %15 : !hw.inout<i1>
-    %16 = sv.reg : !hw.inout<i1>
-    %10 = sv.read_inout %16 : !hw.inout<i1>
-    %17 = sv.reg : !hw.inout<i1>
-    %11 = sv.read_inout %17 : !hw.inout<i1>
-    %18 = sv.reg : !hw.inout<i1>
-    %12 = sv.read_inout %18 : !hw.inout<i1>
-    %19 = sv.reg : !hw.inout<i1>
-    %13 = sv.read_inout %19 : !hw.inout<i1>
+    %4 = sv.reg : !hw.inout<i1>
+    %0 = sv.read_inout %4 : !hw.inout<i1>
+    %5 = sv.reg : !hw.inout<i2>
+    %1 = sv.read_inout %5 : !hw.inout<i2>
+    %6 = sv.reg : !hw.inout<i1>
+    %2 = sv.read_inout %6 : !hw.inout<i1>
+    %7 = sv.reg : !hw.inout<i2>
+    %3 = sv.read_inout %7 : !hw.inout<i2>
     sv.alwayscomb {
-        sv.bpassign %14, %I_1_0_x : i1
-        sv.bpassign %15, %0 : i1
-        sv.bpassign %16, %2 : i1
-        sv.bpassign %17, %I_1_1_x : i1
-        sv.bpassign %18, %4 : i1
-        sv.bpassign %19, %6 : i1
+        sv.bpassign %4, %I_1_0_x : i1
+        sv.bpassign %5, %I_1_0_y : i2
+        sv.bpassign %6, %I_1_1_x : i1
+        sv.bpassign %7, %I_1_1_y : i2
         sv.if %S {
-            sv.bpassign %14, %I_0_0_x : i1
-            sv.bpassign %15, %1 : i1
-            sv.bpassign %16, %3 : i1
-            sv.bpassign %17, %I_0_1_x : i1
-            sv.bpassign %18, %5 : i1
-            sv.bpassign %19, %7 : i1
+            sv.bpassign %4, %I_0_0_x : i1
+            sv.bpassign %5, %I_0_0_y : i2
+            sv.bpassign %6, %I_0_1_x : i1
+            sv.bpassign %7, %I_0_1_y : i2
         }
     }
-    %20 = comb.concat %10, %9 : i1, i1
-    %21 = comb.concat %13, %12 : i1, i1
-    hw.output %8, %20, %11, %21 : i1, i2, i1, i2
+    hw.output %0, %1, %2, %3 : i1, i2, i1, i2
 }

--- a/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
+++ b/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
@@ -1,27 +1,35 @@
 hw.module @test_when_nested_Array2_AnonProductxBit_yBits2_Bit(%I_0_0_x: i1, %I_0_0_y: i2, %I_0_1_x: i1, %I_0_1_y: i2, %I_1_0_x: i1, %I_1_0_y: i2, %I_1_1_x: i1, %I_1_1_y: i2, %S: i1) -> (O_0_x: i1, O_0_y: i2, O_1_x: i1, O_1_y: i2) {
-    %4 = sv.reg : !hw.inout<i1>
-    %0 = sv.read_inout %4 : !hw.inout<i1>
-    %5 = sv.reg : !hw.inout<i2>
-    %1 = sv.read_inout %5 : !hw.inout<i2>
-    %6 = sv.reg : !hw.inout<i1>
-    %2 = sv.read_inout %6 : !hw.inout<i1>
-    %7 = sv.reg : !hw.inout<i2>
-    %3 = sv.read_inout %7 : !hw.inout<i2>
+    %8 = sv.reg : !hw.inout<i1>
+    %0 = sv.read_inout %8 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i2>
+    %1 = sv.read_inout %9 : !hw.inout<i2>
+    %10 = sv.reg : !hw.inout<i1>
+    %2 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i2>
+    %3 = sv.read_inout %11 : !hw.inout<i2>
+    %12 = sv.reg : !hw.inout<i1>
+    %4 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i2>
+    %5 = sv.read_inout %13 : !hw.inout<i2>
+    %14 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i2>
+    %7 = sv.read_inout %15 : !hw.inout<i2>
     sv.alwayscomb {
-        sv.bpassign %4, %I_1_0_x : i1
-        sv.bpassign %5, %I_1_0_y : i2
-        sv.bpassign %6, %I_1_1_x : i1
-        sv.bpassign %7, %I_1_1_y : i2
-        sv.bpassign %4, %I_1_0_x : i1
-        sv.bpassign %5, %I_1_0_y : i2
-        sv.bpassign %6, %I_1_1_x : i1
-        sv.bpassign %7, %I_1_1_y : i2
+        sv.bpassign %12, %I_1_0_x : i1
+        sv.bpassign %13, %I_1_0_y : i2
+        sv.bpassign %14, %I_1_1_x : i1
+        sv.bpassign %15, %I_1_1_y : i2
+        sv.bpassign %12, %I_1_0_x : i1
+        sv.bpassign %13, %I_1_0_y : i2
+        sv.bpassign %14, %I_1_1_x : i1
+        sv.bpassign %15, %I_1_1_y : i2
         sv.if %S {
-            sv.bpassign %4, %I_0_0_x : i1
-            sv.bpassign %5, %I_0_0_y : i2
-            sv.bpassign %6, %I_0_1_x : i1
-            sv.bpassign %7, %I_0_1_y : i2
+            sv.bpassign %12, %I_0_0_x : i1
+            sv.bpassign %13, %I_0_0_y : i2
+            sv.bpassign %14, %I_0_1_x : i1
+            sv.bpassign %15, %I_0_1_y : i2
         }
     }
-    hw.output %0, %1, %2, %3 : i1, i2, i1, i2
+    hw.output %4, %5, %6, %7 : i1, i2, i1, i2
 }

--- a/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
+++ b/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
@@ -12,6 +12,10 @@ hw.module @test_when_nested_Array2_AnonProductxBit_yBits2_Bit(%I_0_0_x: i1, %I_0
         sv.bpassign %5, %I_1_0_y : i2
         sv.bpassign %6, %I_1_1_x : i1
         sv.bpassign %7, %I_1_1_y : i2
+        sv.bpassign %4, %I_1_0_x : i1
+        sv.bpassign %5, %I_1_0_y : i2
+        sv.bpassign %6, %I_1_1_x : i1
+        sv.bpassign %7, %I_1_1_y : i2
         sv.if %S {
             sv.bpassign %4, %I_0_0_x : i1
             sv.bpassign %5, %I_0_0_y : i2

--- a/tests/gold/test_when_nested_Tuplex_Bits2_y_Bit.mlir
+++ b/tests/gold/test_when_nested_Tuplex_Bits2_y_Bit.mlir
@@ -1,24 +1,15 @@
 hw.module @test_when_nested_Tuplex_Bits2_y_Bit(%I_0_x: i2, %I_0_y: i1, %I_1_x: i2, %I_1_y: i1, %S: i1) -> (O_x: i2, O_y: i1) {
-    %0 = comb.extract %I_1_x from 0 : (i2) -> i1
-    %1 = comb.extract %I_0_x from 0 : (i2) -> i1
-    %2 = comb.extract %I_1_x from 1 : (i2) -> i1
-    %3 = comb.extract %I_0_x from 1 : (i2) -> i1
-    %7 = sv.reg : !hw.inout<i1>
-    %4 = sv.read_inout %7 : !hw.inout<i1>
-    %8 = sv.reg : !hw.inout<i1>
-    %5 = sv.read_inout %8 : !hw.inout<i1>
-    %9 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %9 : !hw.inout<i1>
+    %2 = sv.reg : !hw.inout<i2>
+    %0 = sv.read_inout %2 : !hw.inout<i2>
+    %3 = sv.reg : !hw.inout<i1>
+    %1 = sv.read_inout %3 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %7, %0 : i1
-        sv.bpassign %8, %2 : i1
-        sv.bpassign %9, %I_1_y : i1
+        sv.bpassign %2, %I_1_x : i2
+        sv.bpassign %3, %I_1_y : i1
         sv.if %S {
-            sv.bpassign %7, %1 : i1
-            sv.bpassign %8, %3 : i1
-            sv.bpassign %9, %I_0_y : i1
+            sv.bpassign %2, %I_0_x : i2
+            sv.bpassign %3, %I_0_y : i1
         }
     }
-    %10 = comb.concat %5, %4 : i1, i1
-    hw.output %10, %6 : i2, i1
+    hw.output %0, %1 : i2, i1
 }

--- a/tests/gold/test_when_nested_otherwise.mlir
+++ b/tests/gold/test_when_nested_otherwise.mlir
@@ -1,31 +1,21 @@
 hw.module @test_when_nested_otherwise(%I: i2, %S: i2) -> (O: i2) {
     %1 = hw.constant -1 : i2
     %0 = comb.icmp eq %S, %1 : i2
-    %2 = comb.extract %I from 0 : (i2) -> i1
-    %3 = comb.extract %I from 1 : (i2) -> i1
-    %4 = comb.extract %S from 1 : (i2) -> i1
-    %6 = hw.constant -1 : i2
-    %5 = comb.xor %6, %I : i2
-    %7 = comb.extract %5 from 0 : (i2) -> i1
-    %8 = comb.extract %5 from 1 : (i2) -> i1
-    %11 = sv.reg : !hw.inout<i1>
-    %9 = sv.read_inout %11 : !hw.inout<i1>
-    %12 = sv.reg : !hw.inout<i1>
-    %10 = sv.read_inout %12 : !hw.inout<i1>
+    %2 = comb.extract %S from 1 : (i2) -> i1
+    %4 = hw.constant -1 : i2
+    %3 = comb.xor %4, %I : i2
+    %6 = sv.reg : !hw.inout<i2>
+    %5 = sv.read_inout %6 : !hw.inout<i2>
     sv.alwayscomb {
         sv.if %0 {
-            sv.bpassign %11, %2 : i1
-            sv.bpassign %12, %3 : i1
+            sv.bpassign %6, %I : i2
         } else {
-            sv.if %4 {
-                sv.bpassign %11, %7 : i1
-                sv.bpassign %12, %8 : i1
+            sv.if %2 {
+                sv.bpassign %6, %3 : i2
             } else {
-                sv.bpassign %11, %2 : i1
-                sv.bpassign %12, %3 : i1
+                sv.bpassign %6, %I : i2
             }
         }
     }
-    %13 = comb.concat %10, %9 : i1, i1
-    hw.output %13 : i2
+    hw.output %5 : i2
 }

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -530,7 +530,6 @@ def test_array2_driving():
 
         io.O @= y | m.zext_to(x, 8)
 
-        print(out.driving())
         for i, driving in enumerate(out.driving()):
             assert len(driving) >= 1
             assert driving[-1] is not_inst.I[i]

--- a/tests/test_type/test_array2.py
+++ b/tests/test_type/test_array2.py
@@ -509,3 +509,33 @@ def test_array2_wire_bits_temp():
             io.O[i] @= tmp[i] ^ io.I[i]
 
         tmp @= io.I
+
+
+def test_array2_driving():
+    class Foo(m.Circuit):
+        T = m.Bits[8]
+        io = m.IO(I=m.In(T), O=m.Out(T))
+        io.O @= io.I
+
+    class Top(m.Circuit):
+        T = Foo.T
+        io = m.IO(I=m.In(T), O=m.Out(T))
+        out = Foo(name="foo")(io.I)
+
+        x = out[:4] & io.I[4:]
+        and_inst = x.name.inst
+
+        y = ~out
+        not_inst = y.name.inst
+
+        io.O @= y | m.zext_to(x, 8)
+
+        print(out.driving())
+        for i, driving in enumerate(out.driving()):
+            assert len(driving) >= 1
+            assert driving[-1] is not_inst.I[i]
+            if i < 4:
+                assert len(driving) == 2
+                assert driving[0] is and_inst.I0[i]
+            else:
+                assert len(driving) == 1

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -503,7 +503,7 @@ def test_internal_instantiation_complex():
             x @= 0
 
     basename = "test_when_internal_instantiation_complex"
-    m.compile(f"build/{basename}", _Test, output="mlir")
+    m.compile(f"build/{basename}", _Test, output="mlir-verilog")
     assert check_gold(__file__, f"{basename}.mlir")
 
 
@@ -634,7 +634,7 @@ def test_when_lazy_array_resolve(caplog):
         with m.otherwise():
             io.O @= m.sint(m.uint(io.I) >> 1)
 
-    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
     assert check_gold(__file__, f"{_Test.name}.mlir")
 
 

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -534,6 +534,8 @@ def test_latch_error_simple():
         with m.when(io.S):
             io.O @= io.I[0]
 
+    m.compile("build/_Test", _Test, output="mlir")
+
 
 @_expects_error(InferredLatchError)
 def test_latch_error_elsewhen():
@@ -546,6 +548,8 @@ def test_latch_error_elsewhen():
         with m.elsewhen(io.S ^ 1):
             io.O @= 1
 
+    m.compile("build/_Test", _Test, output="mlir")
+
 
 @_expects_error(InferredLatchError)
 def test_latch_error_nested():
@@ -556,6 +560,8 @@ def test_latch_error_nested():
         with m.when(io.S[0]):
             with m.when(io.S[1]):
                 io.O @= io.I[0]
+
+    m.compile("build/_Test", _Test, output="mlir")
 
 
 def test_latch_no_error_nested():
@@ -570,6 +576,8 @@ def test_latch_no_error_nested():
         with m.otherwise():
             io.O @= 1
 
+    m.compile("build/_Test", _Test, output="mlir")
+
 
 def test_latch_no_error_nested2():
 
@@ -583,6 +591,8 @@ def test_latch_no_error_nested2():
                 io.O @= io.I[1]
         with m.otherwise():
             io.O @= 1
+
+    m.compile("build/_Test", _Test, output="mlir")
 
 
 def test_when_double_elsewhen():

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -795,3 +795,22 @@ def test_when_lazy_array_slice_overlap(caplog):
 
     m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_lazy_array_multiple_whens(caplog):
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_multiple_whens"
+        io = m.IO(I=m.In(m.Bits[4]), S=m.In(m.Bit), O=m.Out(m.Bits[4]))
+
+        with m.when(io.S):
+            io.O @= io.I
+        with m.otherwise():
+            io.O[:2] @= io.I[2:]
+            io.O[2:] @= io.I[:2]
+
+        with m.when(~io.S):
+            io.O @= io.I
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
+    assert check_gold(__file__, f"{_Test.name}.mlir")

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -777,5 +777,21 @@ def test_when_lazy_array_slice_driving_resolve_2(caplog):
         io.I[0]  # triggers driving bulk wire logic
         x[-1] @= io.I[0]  # triggers driving bulk wire logic
 
-    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_lazy_array_slice_overlap(caplog):
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_slice_overlap"
+        io = m.IO(I=m.In(m.Bits[4]), S=m.In(m.Bit), O=m.Out(m.Bits[4]))
+
+        with m.when(io.S):
+            io.O @= io.I
+        with m.otherwise():
+            io.O[:2] @= io.I[2:]
+            io.O[2:] @= io.I[:2]
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -812,5 +812,5 @@ def test_when_lazy_array_multiple_whens(caplog):
         with m.when(~io.S):
             io.O @= io.I
 
-    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -503,7 +503,7 @@ def test_internal_instantiation_complex():
             x @= 0
 
     basename = "test_when_internal_instantiation_complex"
-    m.compile(f"build/{basename}", _Test, output="mlir-verilog")
+    m.compile(f"build/{basename}", _Test, output="mlir")
     assert check_gold(__file__, f"{basename}.mlir")
 
 
@@ -644,7 +644,7 @@ def test_when_lazy_array_resolve(caplog):
         with m.otherwise():
             io.O @= m.sint(m.uint(io.I) >> 1)
 
-    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
 
 
@@ -687,7 +687,7 @@ def test_when_lazy_array_slice(caplog):
 
         io.O @= x
 
-    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
 
 

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -677,7 +677,7 @@ def test_when_lazy_array_slice(caplog):
 
         io.O @= x
 
-    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
     assert check_gold(__file__, f"{_Test.name}.mlir")
 
 


### PR DESCRIPTION
Updates the array2 logic to properly handle conditionally driven values.  The main change requires that we ensure that children are "rewired" based on the conditionally driven information of the parent.  That is, if a parent was conditional wired in various when contexts, the children need to be wired in the same when contexts using the original drivers.  This recursively invokes the elaboration process on the drivees and drivers, maintaining consistency in the when contexts (e.g. for latch detection with children and slices).  In doing this, I discovered a few code paths that could share this same resolution logic for children (_resolve_driven_bulk_wire), which simplifies some of the more complicated parts of the array code.  

One important choice was how elaboration was handled with the when build primitive.  When a value is elaborated, it is removed from the when builder outputs, and replaced with its children.  This requires us to add the ability to remove a port from a builder, something we didn't have before.  The other option was to leave the port (since it was unwired and not used), but this required adding logic in various places to be aware of this (e.g. latch detection would need to know that this wire was replaced by the child wires).  This was also a problem related to input values that are elaborated, because it threw off the indexing logic.  Related to removing a port, we also needed to rename ports.  We could choose not do this, and merely update the value_to_index dictionaries, but I thought this would be useful for debugging consistency.  Again, we could choose to special case this logic in the backend, but by adding a port removal API, the downstream backend logic can remain unchanged and just assume the ports are consistent, which requires less changes in the code.

Another decision was to have Wireable objects track their "wired_when_contexts" and updating them when they are elaborated.  Another option was to have the root when context handle the updates, which seemed like it might be cleaner since it contains the when logic to the when code objects, but that trades off the performance cost of having to traverse the entire when tree to determine which contexts a value was assigned in.  It's nominal since the user is unlikely to have an extreme amount of when statements, but it seemed simpler to just track, and update the contexts of interests (e.g. a value could have default and only be assigned in one when contexts, so using the root context could require traversing a large number of unnecessary contexts).

An elaboration pass was added for tuples so it can occur before the when finalize logic, which was also moved to the backend versus at circuit definition time.  This is for various reasons, one: the user may open and edit a definition which could require changes to the when context either from elaboration or new when statements, two: the flatten tuple logic in the backend was causing elaboration after when had been finalized, so we want to do this earlier so that we can then finalize the when statements (which was easier done as a set of two passes, rather than doing this in the backend logic)

Fixes https://github.com/phanrahan/magma/issues/1132
Fixes #1125