### PR TITLE
Prototype Sum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ prof
 
 *.sublime-*
 benchmarks/*stats
+*bind_files.list

--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -122,6 +122,7 @@ import magma.math
 from magma.when import when, elsewhen, otherwise
 from magma.value_utils import fill
 from magma.bind2 import bind2, make_bind_ports
+from magma.sum_type import Sum, match, case
 
 ################################################################################
 # BEGIN ALIASES

--- a/magma/array.py
+++ b/magma/array.py
@@ -646,11 +646,10 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
     def _get_conditional_drivee_info(self):
         conditional_wires = []
         default_drivers = []
-        wired_when_contexts = self._wired_when_contexts
-        for ctx in wired_when_contexts:
+        for ctx in self._wired_when_contexts:
             conditional_wires.append(ctx.get_conditional_wires_for_drivee(self))
             default_drivers.append(ctx._default_drivers.pop(self, None))
-        return wired_when_contexts, conditional_wires, default_drivers
+        return self._wired_when_contexts, conditional_wires, default_drivers
 
     def _rewire_conditional_children(self, wired_when_contexts,
                                      conditional_wires, default_drivers):

--- a/magma/array.py
+++ b/magma/array.py
@@ -1130,9 +1130,10 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         return True
 
     def set_enclosing_when_context(self, ctx):
-        # This code assumes set_enclosing_when_context is called when a child of a lazy
-        # value is created, so it should not have any children elaborated yet
-        # (and any future elaborations will inherit this context).
+        # This code assumes set_enclosing_when_context is called when a child
+        # of a lazy value is created, so it should not have any children
+        # elaborated yet (and any future elaborations will inherit this
+        # context).
         assert not self._ts
         assert not self._slices
         super().set_enclosing_when_context(ctx)

--- a/magma/array.py
+++ b/magma/array.py
@@ -2,32 +2,20 @@ import weakref
 from functools import reduce, lru_cache
 import operator
 from abc import ABCMeta
-<<<<<<< HEAD
 from hwtypes import BitVector, AbstractBitVector
-=======
-from hwtypes import BitVector
->>>>>>> b51fd972 (Refactor shared code between array/tuple wireable)
 from .ref import ArrayRef
 from .t import Type, Kind, Direction
 from .compatibility import IntegerTypes
 from .digital import Digital
 from .bit import Bit
 from .bitutils import int2seq
-<<<<<<< HEAD
 from .debug import debug_wire, get_callee_frame_info, debug_unwire
-=======
-from .debug import debug_wire, get_callee_frame_info
->>>>>>> b51fd972 (Refactor shared code between array/tuple wireable)
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
 from magma.operator_utils import output_only
-<<<<<<< HEAD
-from magma.wire_container import WiringLog, Wireable
-=======
 from magma.wire_container import (WiringLog, WireableWithChildren,
                                   wireable_with_children_wrapper)
->>>>>>> b51fd972 (Refactor shared code between array/tuple wireable)
 from magma.protocol_type import MagmaProtocol
 from magma.when import no_when, temp_when
 
@@ -735,12 +723,17 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
 >>>>>>> b51fd972 (Refactor shared code between array/tuple wireable)
     def _make_t(self, index):
         if issubclass(self.T, MagmaProtocol):
+<<<<<<< HEAD
             value = self.T._to_magma_()(name=ArrayRef(self, index))
             value.set_enclosing_when_context(self._enclosing_when_context)
             return self.T._from_magma_value_(value)
         value = self.T(name=ArrayRef(self, index))
         value.set_enclosing_when_context(self._enclosing_when_context)
         return value
+=======
+            return self.T._from_magma_ref_(ArrayRef(self, index))
+        return self.T(name=ArrayRef(self, index))
+>>>>>>> 9165165c (Use from ref in array)
 
     def _resolve_slice_children(self, start, stop, slice_value):
         for i in range(start, stop):

--- a/magma/array.py
+++ b/magma/array.py
@@ -14,7 +14,7 @@ from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
 from magma.operator_utils import output_only
-from magma.wire_container import (WiringLog, WireableWithChildren,
+from magma.wire_container import (WiringLog, AggregateWireable,
                                   aggregate_wireable_method)
 from magma.protocol_type import MagmaProtocol
 from magma.when import no_when, temp_when
@@ -358,9 +358,9 @@ def _is_slice_child(child):
     return isinstance(child, Array) and child._is_slice()
 
 
-class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
+class Array(Type, AggregateWireable, metaclass=ArrayMeta):
     """
-    WireableWithChildren class allows Array values to be "bulk wired" like a
+    AggregateWireable class allows Array values to be "bulk wired" like a
     Digital value
 
     The `self._ts` attribute contains a lazily constructed mapping from index
@@ -372,7 +372,7 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
     child objects and populating the corresponding entries in the `._ts`
     dictionary of both the slice object the parent array object.
 
-    A large portion of the Array logic for the WireableWithChildren interface
+    A large portion of the Array logic for the AggregateWireable interface
     must dispatch on `self._ts` and `self._slices` to see if the Array has been
     expanded (requiring the logic to be implemented recursively over the
     children), otherwise the logic will treat the Array as a "bulk wired"
@@ -382,7 +382,7 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
     def __init__(self, *args, **kwargs):
         # Pass name= kwarg to Type constructor
         Type.__init__(self, **kwargs)
-        WireableWithChildren.__init__(self)
+        AggregateWireable.__init__(self)
         if args:
             # If args is not empty, that means this array is being constructed
             # with existing values, so populate the `_ts` dictionary eagerly
@@ -618,7 +618,7 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
             self._wire_children(o, debug_info)
         else:
             # Perform a bulk wire
-            WireableWithChildren.wire(self, o, debug_info)
+            AggregateWireable.wire(self, o, debug_info)
 
     @debug_unwire
     @aggregate_wireable_method
@@ -754,7 +754,7 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
         if not value._wire.driven():
             return
         driver = value._wire.value()
-        WireableWithChildren.unwire(value, driver)
+        AggregateWireable.unwire(value, driver)
         for i in range(start, stop):
             self._ts[i] @= driver[i - start]
 >>>>>>> b51fd972 (Refactor shared code between array/tuple wireable)

--- a/magma/array.py
+++ b/magma/array.py
@@ -627,7 +627,7 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
     @aggregate_wireable_method
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if not self._has_elaborated_children():
-            return WireableWithChildren.unwire(self, o, debug_info)
+            return AggregateWireable.unwire(self, o, debug_info)
         for i, child in self._enumerate_children():
             o_i = None if o is None else o[i]
             child.unwire(o_i, debug_info=debug_info,
@@ -683,7 +683,7 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
         # Save conditional wire info before unwire happens
         info = self._get_conditional_drivee_info()
 
-        Wireable.unwire(self, value)
+        AggregateWireable.unwire(self, value)
 
         self._rewire_conditional_children(*info)
 
@@ -697,7 +697,7 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
         # Else, was not wired in a when context, so children should not be
         # wired in a when context
         with no_when():
-            Wireable.unwire(self, value)
+            AggregateWireable.unwire(self, value)
 
             for i, child in self._enumerate_children():
                 child.wire(value[i])

--- a/magma/array.py
+++ b/magma/array.py
@@ -719,6 +719,10 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
     def _resolve_driving_bulk_wire(self):
         driving = self._wire.driving()
         for drivee in driving:
+            # Force drivee to resolve by triggering the
+            # _resolve_driven_bulk_wire logic which occurs when referencing a
+            # child which begins the elaboration process.  Using this pattern
+            # avoids having to duplicate the logic for driving/driven
             drivee[0]
         return
 

--- a/magma/array.py
+++ b/magma/array.py
@@ -9,7 +9,7 @@ from .compatibility import IntegerTypes
 from .digital import Digital
 from .bit import Bit
 from .bitutils import int2seq
-from .debug import debug_wire, get_callee_frame_info
+from .debug import debug_wire, get_callee_frame_info, debug_unwire
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
@@ -622,14 +622,15 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
             # Perform a bulk wire
             Wireable.wire(self, o, debug_info)
 
-    @debug_wire
-    def unwire(self, o=None, debug_info=None):
+    @debug_unwire
+    def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if self._has_elaborated_children():
             for i, child in self._enumerate_children():
                 o_i = None if o is None else o[i]
-                child.unwire(o_i, debug_info=debug_info)
+                child.unwire(o_i, debug_info=debug_info,
+                             keep_wired_when_contexts=keep_wired_when_contexts)
         else:
-            Wireable.unwire(self, o, debug_info)
+            Wireable.unwire(self, o, debug_info, keep_wired_when_contexts)
 
     def iswhole(self):
         if self._has_elaborated_children():

--- a/magma/array.py
+++ b/magma/array.py
@@ -649,11 +649,7 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         wired_when_contexts = self._wired_when_contexts
         for ctx in wired_when_contexts:
             conditional_wires.append(ctx.get_conditional_wires_for_drivee(self))
-            if self in ctx._default_drivers:
-                default_drivers.append(ctx._default_drivers[self])
-                del ctx._default_drivers[self]
-            else:
-                default_drivers.append(None)
+            default_drivers.append(ctx._default_drivers.pop(self, None))
         return wired_when_contexts, conditional_wires, default_drivers
 
     def _rewire_conditional_children(self, wired_when_contexts,

--- a/magma/array.py
+++ b/magma/array.py
@@ -722,21 +722,14 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
         if self._wire.driving():
             self._resolve_driving_bulk_wire()
 
-=======
->>>>>>> b51fd972 (Refactor shared code between array/tuple wireable)
     def _make_t(self, index):
         if issubclass(self.T, MagmaProtocol):
-<<<<<<< HEAD
             value = self.T._to_magma_()(name=ArrayRef(self, index))
             value.set_enclosing_when_context(self._enclosing_when_context)
             return self.T._from_magma_value_(value)
         value = self.T(name=ArrayRef(self, index))
         value.set_enclosing_when_context(self._enclosing_when_context)
         return value
-=======
-            return self.T._from_magma_ref_(ArrayRef(self, index))
-        return self.T(name=ArrayRef(self, index))
->>>>>>> 9165165c (Use from ref in array)
 
     def _resolve_slice_children(self, start, stop, slice_value):
         for i in range(start, stop):
@@ -750,17 +743,8 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
         # When we encounter an overlapping slice that is already bulk driven,
         # we ensure the corresponding children are updated to their current
         # values
-<<<<<<< HEAD
         if value._wire.driven():
             value._resolve_driven_bulk_wire()
-=======
-        if not value._wire.driven():
-            return
-        driver = value._wire.value()
-        AggregateWireable.unwire(value, driver)
-        for i in range(start, stop):
-            self._ts[i] @= driver[i - start]
->>>>>>> b51fd972 (Refactor shared code between array/tuple wireable)
 
     def _remove_slice(self, key):
         """

--- a/magma/array.py
+++ b/magma/array.py
@@ -632,6 +632,7 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
             # Perform a bulk wire
             WireableWithChildren.wire(self, o, debug_info)
 
+    @wireable_with_children_wrapper
     @debug_unwire
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if not self._has_elaborated_children():
@@ -1020,21 +1021,16 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
             return None
         return _trace_child
 
+    @wireable_with_children_wrapper
     def trace(self, skip_self=True):
-        if self._has_elaborated_children():
-            result = self._collect_children(self._make_trace_child(skip_self))
-            return result
-        return WireableWithChildren.trace(self)
+        return self._collect_children(self._make_trace_child(skip_self))
 
+    @wireable_with_children_wrapper
     def driven(self):
-        if not self._has_elaborated_children():
-            return WireableWithChildren.driven(self)
-        for _, child in self._enumerate_children():
-            if child is None:
-                return False
-            if not child.driven():
-                return False
-        return True
+        return all(
+            child is not None and child.driven()
+            for _, child in self._enumerate_children()
+        )
 
     def _is_slice(self):
         return (isinstance(self.name, ArrayRef) and

--- a/magma/array.py
+++ b/magma/array.py
@@ -632,8 +632,8 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
             # Perform a bulk wire
             WireableWithChildren.wire(self, o, debug_info)
 
-    @wireable_with_children_wrapper
     @debug_unwire
+    @wireable_with_children_wrapper
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if not self._has_elaborated_children():
             return WireableWithChildren.unwire(self, o, debug_info)

--- a/magma/array.py
+++ b/magma/array.py
@@ -15,7 +15,7 @@ from .protocol_type import magma_type, magma_value
 
 from magma.operator_utils import output_only
 from magma.wire_container import (WiringLog, WireableWithChildren,
-                                  wireable_with_children_wrapper)
+                                  aggregate_wireable_method)
 from magma.protocol_type import MagmaProtocol
 from magma.when import no_when, temp_when
 
@@ -534,11 +534,11 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
             return False
         return True
 
-    @wireable_with_children_wrapper
+    @aggregate_wireable_method
     def driving(self):
         return [t.driving() for t in self]
 
-    @wireable_with_children_wrapper
+    @aggregate_wireable_method
     def wired(self):
         return all(t.wired() for t in self)
 
@@ -621,7 +621,7 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
             WireableWithChildren.wire(self, o, debug_info)
 
     @debug_unwire
-    @wireable_with_children_wrapper
+    @aggregate_wireable_method
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if not self._has_elaborated_children():
             return WireableWithChildren.unwire(self, o, debug_info)
@@ -984,7 +984,7 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
     def _has_elaborated_children(self):
         return bool(self._ts) or bool(self._slices)
 
-    @wireable_with_children_wrapper
+    @aggregate_wireable_method
     def value(self):
         return self._collect_children(lambda x: x.value())
 
@@ -1013,11 +1013,11 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
             return None
         return _trace_child
 
-    @wireable_with_children_wrapper
+    @aggregate_wireable_method
     def trace(self, skip_self=True):
         return self._collect_children(self._make_trace_child(skip_self))
 
-    @wireable_with_children_wrapper
+    @aggregate_wireable_method
     def driven(self):
         return all(
             child is not None and child.driven()

--- a/magma/array.py
+++ b/magma/array.py
@@ -14,10 +14,13 @@ from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
 from magma.operator_utils import output_only
-from magma.wire_container import (WiringLog, AggregateWireable,
-                                  aggregate_wireable_method)
 from magma.protocol_type import MagmaProtocol
 from magma.when import no_when, temp_when
+from magma.wire_container import (
+    WiringLog,
+    AggregateWireable,
+    aggregate_wireable_method
+)
 
 
 _logger = root_logger()

--- a/magma/array.py
+++ b/magma/array.py
@@ -991,10 +991,9 @@ class Array(Type, WireableWithChildren, metaclass=ArrayMeta):
     def _has_elaborated_children(self):
         return bool(self._ts) or bool(self._slices)
 
+    @wireable_with_children_wrapper
     def value(self):
-        if self._has_elaborated_children():
-            return self._collect_children(lambda x: x.value())
-        return super().value()
+        return self._collect_children(lambda x: x.value())
 
     def _make_trace_child(self, skip_self):
         def _trace_child(t):

--- a/magma/array.py
+++ b/magma/array.py
@@ -641,15 +641,6 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         return False
 
     def _get_conditional_drivee_info(self):
-        conditional_wires = []
-        default_drivers = []
-        for ctx in self._wired_when_contexts:
-            conditional_wires.append(ctx.get_conditional_wires_for_drivee(self))
-            default_drivers.append(ctx._default_drivers.pop(self, None))
-        return self._wired_when_contexts, conditional_wires, default_drivers
-
-    def _rewire_conditional_children(self, wired_when_contexts,
-                                     conditional_wires, default_drivers):
         """
         * wired_when_contexts: list of contexts in which this value appears as
                                conditionally driven.
@@ -661,6 +652,15 @@ class Array(Type, Wireable, metaclass=ArrayMeta):
         * default_drivers: for each ctx in `wired_when_contexts`, contains the
                            default driver (if it exists) for `self`.
         """
+        conditional_wires = []
+        default_drivers = []
+        for ctx in self._wired_when_contexts:
+            conditional_wires.append(ctx.get_conditional_wires_for_drivee(self))
+            default_drivers.append(ctx._default_drivers.pop(self, None))
+        return self._wired_when_contexts, conditional_wires, default_drivers
+
+    def _rewire_conditional_children(self, wired_when_contexts,
+                                     conditional_wires, default_drivers):
         for i, child in self._enumerate_children():
             for ctx, wires, default_driver in zip(wired_when_contexts,
                                                   conditional_wires,

--- a/magma/backend/coreir/insert_coreir_wires.py
+++ b/magma/backend/coreir/insert_coreir_wires.py
@@ -61,13 +61,7 @@ class InsertCoreIRWires(DefinitionPass):
 
         # Could be already wired for fanout cases
         if not wire_input.driven():
-            if isinstance(wire_input, Array):
-                for d, w in zip(driver, wire_input):
-                    # Could have wired up child elements already
-                    if not w.driven():
-                        w @= d
-            else:
-                wire_input @= driver
+            wire_input @= driver
         if (isinstance(value, _ClockType) and
                 not isinstance(wire_output, type(value))):
             # This mean it was cast by the user (e.g. m.clock(value)), so we

--- a/magma/backend/mlir/build_magma_graph.py
+++ b/magma/backend/mlir/build_magma_graph.py
@@ -79,7 +79,6 @@ class ModuleContext:
 
 def _visit_driver(
         ctx: ModuleContext, value: Type, driver: Type, module: ModuleLike):
-    print(value, driver)
     if driver.const():
         if isinstance(driver, Digital):
             as_bool = _const_digital_to_bool(driver)
@@ -107,7 +106,6 @@ def _visit_driver(
             T = type(driver)
             creator = MagmaArrayCreateOp(T)
             for i, element in enumerate(driver):
-                print(value[i].trace().debug_name, type(element.name))
                 creator_input = getattr(creator, f"I{i}")
                 _visit_driver(ctx, creator_input, element, creator)
             info = dict(src=creator.O, dst=value)
@@ -158,7 +156,6 @@ def _visit_driver(
 
 def _visit_input(ctx: ModuleContext, value: Type, module: ModuleLike):
     driver = value.trace()
-    print(value, driver)
     if driver is None:
         raise UnconnectedPortException(value)
     _visit_driver(ctx, value, driver, module)
@@ -178,10 +175,8 @@ def _visit_inputs(
 def build_magma_graph(
         ckt: DefineCircuitKind,
         opts: BuildMagmaGrahOpts = BuildMagmaGrahOpts()) -> Graph:
-    print(ckt)
     ctx = ModuleContext(Graph(), opts)
     _visit_inputs(ctx, ckt, opts.flatten_all_tuples)
     for inst in ckt.instances:
-        print(inst)
         _visit_inputs(ctx, inst, opts.flatten_all_tuples)
     return ctx.graph

--- a/magma/backend/mlir/build_magma_graph.py
+++ b/magma/backend/mlir/build_magma_graph.py
@@ -92,7 +92,6 @@ def _visit_driver(
             ctx.graph.add_edge(const, module, info=info)
             return
     ref = driver.name
-    assert not isinstance(ref, LazyInstRef) or ref._inst, ref
     if isinstance(ref, InstRef):
         info = dict(src=driver, dst=value)
         ctx.graph.add_edge(ref.inst, module, info=info)

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -560,7 +560,7 @@ class ModuleVisitor:
             # `value` occurs as more than one input (for example, it could be
             # used as a conditional driver for multiple values).  We could
             # optimize the logic to always share the same argument, but for now
-            # we just use the "last" index
+            # we just use the "last" index.
             value_to_index[value] = next(counter)
 
         counter = itertools.count()

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -54,6 +54,7 @@ from magma.primitives.mux import Mux
 from magma.primitives.register import Register
 from magma.primitives.when import iswhen
 from magma.primitives.xmr import XMRSink, XMRSource
+from magma.protocol_type import MagmaProtocol, MagmaProtocolMeta, magma_value
 from magma.t import Kind, Type
 from magma.tuple import TupleMeta, Tuple as m_Tuple
 from magma.value_utils import make_selector
@@ -1145,6 +1146,7 @@ class HardwareModule:
         return self._value_map[port]
 
     def get_or_make_mapped_value(self, port: Type, **kwargs) -> MlirValue:
+        port = magma_value(port)
         try:
             return self._value_map[port]
         except KeyError:
@@ -1153,6 +1155,7 @@ class HardwareModule:
         return value
 
     def set_mapped_value(self, port: Type, value: MlirValue):
+        port = magma_value(port)
         if port in self._value_map:
             raise ValueError(f"Port {port} already mapped")
         self._value_map[port] = value
@@ -1160,6 +1163,11 @@ class HardwareModule:
     def new_value(
             self, value_or_type: Union[Type, Kind, MlirType],
             **kwargs) -> MlirValue:
+        if isinstance(value_or_type, MagmaProtocol):
+            value_or_type = value_or_type._get_magma_value_()
+        if isinstance(value_or_type, MagmaProtocolMeta):
+            value_or_type = value_or_type._to_magma_()
+
         if isinstance(value_or_type, Type):
             mlir_type = magma_type_to_mlir_type(type(value_or_type))
         elif isinstance(value_or_type, Kind):

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -555,7 +555,12 @@ class ModuleVisitor:
         output_to_index = {}
 
         def _visit(value, counter, value_to_index):
-            assert value not in value_to_index
+            # NOTE: value may already be in value_to_index, in which case we
+            # update it to a new index.  This is okay and it just means that
+            # `value` occurs as more than one input (for example, it could be
+            # used as a conditional driver for multiple values).  We could
+            # optimize the logic to always share the same argument, but for now
+            # we just use the "last" index
             value_to_index[value] = next(counter)
 
         counter = itertools.count()

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -555,6 +555,7 @@ class ModuleVisitor:
         output_to_index = {}
 
         def _visit(value, counter, value_to_index):
+            assert value not in value_to_index
             value_to_index[value] = next(counter)
 
         counter = itertools.count()

--- a/magma/backend/mlir/magma_common.py
+++ b/magma/backend/mlir/magma_common.py
@@ -6,6 +6,7 @@ from magma.backend.mlir.common import make_unique_name
 from magma.backend.mlir.graph_lib import Graph
 from magma.circuit import Circuit, DefineCircuitKind
 from magma.common import replace_all, Stack, SimpleCounter
+from magma.protocol_type import MagmaProtocol, MagmaProtocolMeta, magma_value
 from magma.ref import Ref, ArrayRef, TupleRef
 from magma.t import Kind, Type
 from magma.tuple import TupleMeta, Tuple as m_Tuple
@@ -35,6 +36,10 @@ def contains_tuple(T: Kind):
 
 
 def value_or_type_to_string(value_or_type: Union[Type, Kind]):
+    if isinstance(value_or_type, MagmaProtocol):
+        value_or_type = value_or_type._get_magma_value_()
+    if isinstance(value_or_type, MagmaProtocolMeta):
+        value_or_type = value_or_type._to_magma_()
     if isinstance(value_or_type, Type):
         s = value_or_type.name.qualifiedname("_")
     else:
@@ -113,6 +118,8 @@ def visit_value_or_value_wrapper_by_direction(
         input_visitor: Callable[[Type], Any],
         output_visitor: Callable[[Type], Any],
         **kwargs):
+
+    value_or_value_wrapper = magma_value(value_or_value_wrapper)
 
     pre_descend = kwargs.get("pre_descend", lambda _: None)
     post_descend = kwargs.get("post_descend", lambda _: None)

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -39,8 +39,13 @@ class MlirCompiler(Compiler):
         return "mlir"
 
     def _run_passes(self):
+        # We elaborate_tuples before finalizing when statements because they
+        # may cause array expansion (e.g. when we have an array of tuples).  If
+        # we remove the flatten_all_tuples requirement, we may finalize when
+        # earlier, but then we may still need this code path as an option
         elaborate_tuples(self.main)
         finalize_whens(self.main)
+
         insert_coreir_wires(self.main)
         insert_wrap_casts(self.main)
         wire_clocks(self.main)

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -43,7 +43,8 @@ class MlirCompiler(Compiler):
         # may cause array expansion (e.g. when we have an array of tuples).  If
         # we remove the flatten_all_tuples requirement, we may finalize when
         # earlier, but then we may still need this code path as an option
-        elaborate_tuples(self.main)
+        if self.opts.get("flatten_all_tuples", False):
+            elaborate_tuples(self.main)
         finalize_whens(self.main)
 
         insert_coreir_wires(self.main)

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -838,10 +838,6 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
     def _port(self, name):
         return self._io.ports[name]
 
-    def _remove_port(self, name):
-        self._io.remove(name)
-        delattr(self, name)
-
     def _rename_port(self, old, new):
         self._io.rename(old, new)
         setattr(self, new, self._io.inst_ports[new])

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -838,10 +838,6 @@ class CircuitBuilder(metaclass=_CircuitBuilderMeta):
     def _port(self, name):
         return self._io.ports[name]
 
-    def _rename_port(self, old, new):
-        self._io.rename(old, new)
-        setattr(self, new, self._io.inst_ports[new])
-
     def _add_port(self, name, typ):
         self._io.add(name, typ)
         setattr(self, name, self._io.inst_ports[name])

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -2,10 +2,8 @@ from typing import Optional
 
 from .t import Direction, In
 from .digital import DigitalMeta, Digital
-from .wire import wire
 from magma.bit import Bit
 from magma.array import Array
-from magma.debug import debug_wire
 from magma.tuple import Tuple
 
 

--- a/magma/debug.py
+++ b/magma/debug.py
@@ -34,3 +34,10 @@ def debug_wire(fn):
         return fn(i, o, debug_info)
     return wire
 
+
+def debug_unwire(fn):
+    def unwire(i, o=None, debug_info=None, keep_wired_when_contexts=False):
+        if get_debug_mode() and debug_info is None:
+            debug_info = get_callee_frame_info()
+        return fn(i, o, debug_info, keep_wired_when_contexts)
+    return unwire

--- a/magma/definition_context.py
+++ b/magma/definition_context.py
@@ -123,8 +123,9 @@ class DefinitionContext(FinalizableDelegator):
     def place_instances(self, defn):
         self._placer = self._placer.finalize(defn)
         for builder in self._builders:
-            from magma.primitives.when import WhenBuilder
-            if isinstance(builder, WhenBuilder):
+            if getattr(builder, "_is_when_builder_", False):
+                # Wait to finalize when primitive until compile since circuit
+                # modifications may introduce changes
                 continue
             inst = builder.finalize()
             self._placer.place(inst)

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -3,7 +3,7 @@ import weakref
 from abc import ABCMeta
 import hwtypes as ht
 from .t import Kind, Direction, Type, In, Out
-from .debug import debug_wire, get_callee_frame_info
+from .debug import debug_wire, get_callee_frame_info, debug_unwire
 from .compatibility import IntegerTypes
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
@@ -182,10 +182,6 @@ class Digital(Type, Wireable, metaclass=DigitalMeta):
             )
             return
         Wireable.wire(self, o, debug_info)
-
-    @debug_wire
-    def unwire(self, o=None, debug_info=None):
-        return Wireable.unwire(self, o, debug_info)
 
     def iswhole(self):
         return True

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -487,11 +487,6 @@ class IO(IOInterface):
         decl = self._decl + other._decl
         return IO(**_dict_from_decl(decl))
 
-    def remove(self, name):
-        if self._bound:
-            raise RuntimeError("Can not remove from a bound IO")
-        del self._ports[name]
-
     def add(self, name, typ):
         if self._bound:
             raise RuntimeError("Can not add to a bound IO")
@@ -559,10 +554,6 @@ class SingletonInstanceIO(IO):
         inst_ref = LazyInstRef(name=name)
         inst_port = _make_port(typ, inst_ref, flip=False)
         self._inst_ports[name] = inst_port
-
-    def remove(self, name):
-        super().remove(name)
-        del self._inst_ports[name]
 
     def __add__(self, other):
         raise NotImplementedError(f"Addition operator disallowed on "

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -487,6 +487,11 @@ class IO(IOInterface):
         decl = self._decl + other._decl
         return IO(**_dict_from_decl(decl))
 
+    def remove(self, name):
+        if self._bound:
+            raise RuntimeError("Can not remove from a bound IO")
+        del self._ports[name]
+
     def add(self, name, typ):
         if self._bound:
             raise RuntimeError("Can not add to a bound IO")
@@ -554,6 +559,10 @@ class SingletonInstanceIO(IO):
         inst_ref = LazyInstRef(name=name)
         inst_port = _make_port(typ, inst_ref, flip=False)
         self._inst_ports[name] = inst_port
+
+    def remove(self, name):
+        super().remove(name)
+        del self._inst_ports[name]
 
     def __add__(self, other):
         raise NotImplementedError(f"Addition operator disallowed on "

--- a/magma/interface.py
+++ b/magma/interface.py
@@ -487,18 +487,6 @@ class IO(IOInterface):
         decl = self._decl + other._decl
         return IO(**_dict_from_decl(decl))
 
-    def remove(self, name):
-        if self._bound:
-            raise RuntimeError("Can not remove from a bound IO")
-        del self._ports[name]
-
-    def rename(self, old, new):
-        if self._bound:
-            raise RuntimeError("Can not rename in a bound IO")
-        self._ports[new] = self._ports[old]
-        self.remove(old)
-        self._ports[new].name.name = new
-
     def add(self, name, typ):
         if self._bound:
             raise RuntimeError("Can not add to a bound IO")
@@ -566,15 +554,6 @@ class SingletonInstanceIO(IO):
         inst_ref = LazyInstRef(name=name)
         inst_port = _make_port(typ, inst_ref, flip=False)
         self._inst_ports[name] = inst_port
-
-    def rename(self, old, new):
-        self._inst_ports[new] = self._inst_ports[old]
-        self._inst_ports[new].name.name = new
-        super().rename(old, new)
-
-    def remove(self, name):
-        super().remove(name)
-        del self._inst_ports[name]
 
     def __add__(self, other):
         raise NotImplementedError(f"Addition operator disallowed on "

--- a/magma/passes/clock.py
+++ b/magma/passes/clock.py
@@ -106,6 +106,7 @@ def get_undriven_clocks_in_value(
         value: Type, clock_type: Kind) -> Iterable[Type]:
     """Returns all undriven values of type @clock_type contained in @value."""
     if not is_clock_or_nested_clock(type(value), (clock_type, )):
+        # Avoid descening into tuple/array if possible
         return
     if isinstance(value, Tuple):
         for elem in value:

--- a/magma/passes/elaborate_tuples.py
+++ b/magma/passes/elaborate_tuples.py
@@ -18,19 +18,20 @@ def _expand(value):
     if isinstance(value, Array) and _is_tuple_or_nested_tuple(type(value)):
         for elem in value:
             _expand(elem)
-    return
+
+
+def _expand_tuple_values(values):
+    for value in values:
+        if _is_tuple_or_nested_tuple(type(value)):
+            _expand(value)
 
 
 class ElaborateTuplesPass(DefinitionPass):
     def __call__(self, definition):
         with definition.open():
-            for value in definition.interface.ports.values():
-                if _is_tuple_or_nested_tuple(type(value)):
-                    _expand(value)
+            _expand_tuple_values(definition.interface.ports.values())
             for instance in definition.instances:
-                for value in instance.interface.ports.values():
-                    if _is_tuple_or_nested_tuple(type(value)):
-                        _expand(value)
+                _expand_tuple_values(instance.interface.ports.values())
 
 
 elaborate_tuples = pass_lambda(ElaborateTuplesPass)

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -142,7 +142,12 @@ class WhenBuilder(CircuitBuilder):
             Out,
         )
 
-    def remove_drivee(self, value: Type):
+    def safe_remove_drivee(self, value: Type):
+        """
+        Removes `value`'s output port if it exists
+        """
+        if value not in self._output_to_index:
+            return
         idx = self._output_to_index[value]
         name = f"O{idx}"
         self._remove_port(name)

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -159,6 +159,7 @@ class WhenBuilder(CircuitBuilder):
 
         self._remove_port(name)
         del self._output_to_index[value]
+        del self._output_to_name[value]
 
         # Update existing outputs by subtracting one from their index and
         # renaming their port

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -206,7 +206,6 @@ class WhenBuilder(CircuitBuilder):
         latches = find_inferred_latches(self.block)
         if latches:
             raise InferredLatchError(latches)
-        print("HELLO")
 
     @property
     def block(self) -> WhenBlock:

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -102,6 +102,7 @@ class WhenBuilder(CircuitBuilder):
         self._set_definition_attr("primitive", True)
         self._set_definition_attr(_ISWHEN_KEY, True)
         self._set_definition_attr("_builder_", self)
+        self._is_when_builder_ = True
 
     @property
     def default_drivers(self) -> Dict[Type, Type]:

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -150,14 +150,22 @@ class WhenBuilder(CircuitBuilder):
             return
         idx = self._output_to_index[value]
         name = f"O{idx}"
+
         self._remove_port(name)
         del self._output_to_index[value]
+
+        # Update existing outputs by subtracting one from their index and
+        # renaming their port
         for key, value in self._output_to_index.items():
             if value > idx:
                 self._output_to_index[key] -= 1
                 self._rename_port(f"O{value}", f"O{value - 1}")
-        self._output_counter = itertools.count(len(self._output_to_index))
-        self._drivee_counter = itertools.count(len(self._output_to_index))
+
+        # Update counters so future drivee additions are consistent with the
+        # updated count
+        new_n = len(self._output_to_index)
+        self._output_counter = itertools.count(new_n)
+        self._drivee_counter = itertools.count(new_n)
 
     def add_driver(self, value: Type):
         self._generic_add(

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -148,25 +148,6 @@ class WhenBuilder(CircuitBuilder):
             Out,
         )
 
-    def safe_remove_drivee(self, value: Type):
-        """
-        Removes `value`'s output port if it exists
-        """
-        if value not in self._output_to_index:
-            return
-        name = self._output_to_name[value]
-        idx = self._output_to_index[value]
-
-        self._remove_port(name)
-        del self._output_to_index[value]
-        del self._output_to_name[value]
-
-        # Update existing outputs by subtracting one from their index and
-        # renaming their port
-        for key, value in self._output_to_index.items():
-            if value > idx:
-                self._output_to_index[key] -= 1
-
     def add_driver(self, value: Type):
         self._generic_add(
             value,

--- a/magma/protocol_type.py
+++ b/magma/protocol_type.py
@@ -1,6 +1,6 @@
 import abc
 
-from magma.debug import debug_wire
+from magma.debug import debug_wire, debug_unwire
 
 
 class MagmaProtocolMeta(type):
@@ -116,10 +116,12 @@ class MagmaProtocol(metaclass=MagmaProtocolMeta):
             other = other._get_magma_value_()
         self._get_magma_value_().wire(other, debug_info)
 
-    def unwire(self, other, debug_info=None):
+    @debug_unwire
+    def unwire(self, other, debug_info=None, keep_wired_when_contexts=False):
         if isinstance(other, MagmaProtocol):
             other = other._get_magma_value_()
-        self._get_magma_value_().unwire(other, debug_info)
+        self._get_magma_value_().unwire(other, debug_info,
+                                        keep_wired_when_contexts)
 
     def __imatmul__(self, other):
         self.wire(other)

--- a/magma/protocol_type.py
+++ b/magma/protocol_type.py
@@ -29,7 +29,7 @@ class MagmaProtocolMeta(type):
         # To create an instance from a value.
         raise NotImplementedError()
 
-    def _from_magma_ref(cls, ref: 'Ref'):
+    def _from_magma_ref_(cls, ref: 'Ref'):
         return cls._from_magma_value_(cls._to_magma_()(name=ref))
 
     def _is_oriented_magma_(cls, direction):

--- a/magma/protocol_type.py
+++ b/magma/protocol_type.py
@@ -29,6 +29,9 @@ class MagmaProtocolMeta(type):
         # To create an instance from a value.
         raise NotImplementedError()
 
+    def _from_magma_ref(cls, ref: 'Ref'):
+        return cls._from_magma_value_(cls._to_magma_()(name=ref))
+
     def _is_oriented_magma_(cls, direction):
         return cls._to_magma_().is_oriented(direction)
 

--- a/magma/protocol_type.py
+++ b/magma/protocol_type.py
@@ -136,6 +136,9 @@ class MagmaProtocol(metaclass=MagmaProtocolMeta):
     def const(self):
         return self._get_magma_value_().const()
 
+    def set_enclosing_when_context(self, ctx):
+        self._get_magma_value_().set_enclosing_when_context(ctx)
+
 
 def magma_type(T):
     if issubclass(T, MagmaProtocol):

--- a/magma/sum_type.py
+++ b/magma/sum_type.py
@@ -64,7 +64,7 @@ class Sum(MagmaProtocol, metaclass=SumMeta):
 
         self._tag_map = {}  # map from T to int id value
         for T in self._magma_Ts_.values():
-            # For now, tags map to index in _magma_Ts_ order
+            # For now, tags map to index in _magma_Ts_ order.
             self._tag_map[T.undirected_t] = len(self._tag_map)
 
         self._match_active = False  # must be True to use case
@@ -111,7 +111,7 @@ class Sum(MagmaProtocol, metaclass=SumMeta):
         return self._val
 
     def check_tag(self, T):
-        # Used for when condition in a specific case
+        # Used for when condition in a specific case.
         return self._val.tag == self._tag_map[T]
 
     def __invert__(self):

--- a/magma/sum_type.py
+++ b/magma/sum_type.py
@@ -1,0 +1,210 @@
+from typing import Optional
+
+from magma.bits import Bits
+from magma.bitutils import clog2
+from magma.common import Stack
+from magma.protocol_type import MagmaProtocol, MagmaProtocolMeta
+from magma.t import Type, Direction, Kind
+from magma.tuple import AnonProduct
+from magma.conversions import from_bits, as_bits, zext_to
+from magma.when import when, elsewhen, otherwise
+
+
+class SumMeta(MagmaProtocolMeta):
+    def _to_magma_(cls):
+        return cls._magma_T_
+
+    def _qualify_magma_(cls, direction: Direction):
+        dct = {k: v.qualify(direction)
+               for k, v in cls._magma_Ts_.items()}
+        return type(cls)(cls.__name__, (cls, ), dct)
+
+    def _flip_magma_(cls):
+        dct = {k: v.flip()
+               for k, v in cls._magma_Ts_.items()}
+        return type(cls)(cls.__name__, (cls, ), dct)
+
+    def _from_magma_value_(cls, val: Type):
+        return cls(val)
+
+    def __new__(mcs, name, bases, namespace):
+        data_len = 0
+        Ts = {}
+        # TODO: How to handle mixed direction type?
+        is_input, is_output = True, True
+
+        for key, value in namespace.items():
+            if isinstance(value, Kind):
+                data_len = max(data_len, value.flat_length())
+                Ts[key] = value
+                is_input &= value.is_input()
+                is_output &= value.is_output()
+        if len(Ts):
+            assert data_len > 0, "Expected non zero length data"
+
+            tag_len = clog2(len(Ts))
+            T = AnonProduct[
+                {"tag": Bits[tag_len], "data": Bits[data_len]}
+            ]
+            if is_input:
+                T = T.qualify(Direction.In)
+            elif is_output:
+                T = T.qualify(Direction.Out)
+            namespace['_magma_T_'] = T
+            namespace['_magma_Ts_'] = Ts
+
+        return type.__new__(mcs, name, bases, namespace)
+
+
+class Sum(MagmaProtocol, metaclass=SumMeta):
+    def __init__(self, val: Optional[Type] = None):
+        if val is None:
+            val = self._magma_T_()
+        self._val = val
+
+        self._tag_map = {}  # map from T to int id value
+        for T in self._magma_Ts_.values():
+            # For now, tags map to index in _magma_Ts_ order
+            self._tag_map[T.undirected_t] = len(self._tag_map)
+
+        self._match_active = False  # must be True to use case
+        self._active_case = None  # tracks current case type
+        self._activated_cases = []  # tracks prev activated cases
+
+    @property
+    def match_active(self):
+        return self._match_active
+
+    @match_active.setter
+    def match_active(self, value):
+        self._match_active = value
+
+    @property
+    def activated_cases(self):
+        return self._activated_cases
+
+    @property
+    def num_tags(self):
+        return len(self._tag_map)
+
+    def activate_case(self, T):
+        if self._active_case is not None:
+            raise TypeError("Cannot have more than one active case")
+        if T in self._activated_cases:
+            raise TypeError(f"Cannot call case({T}) twice")
+        if T.undirected_t not in self._tag_map:
+            raise TypeError(f"Unexpected case type {T}")
+
+        self._active_case = T
+        self._activated_cases.append(T)
+
+    def deactivate_case(self):
+        last_T = self._active_case
+        self._active_case = None
+        return last_T
+
+    def _get_magma_value_(self):
+        if self._active_case:
+            # Interpret base on active case T
+            T = self._active_case.undirected_t
+            return from_bits(T, self._val.data[:T.flat_length()])
+        return self._val
+
+    def check_tag(self, T):
+        # Used for when condition in a specific case
+        return self._val.tag == self._tag_map[T]
+
+    def __invert__(self):
+        return ~self._get_magma_value_()
+
+    def __xor__(self, other):
+        return self._get_magma_value_() ^ other
+
+    def __and__(self, other):
+        return self._get_magma_value_() & other
+
+    # TODO: define all operators (can we metaprogram delegator to
+    # self._get_magma_value_()?)
+
+    def wire(self, other):
+        if self._active_case:
+            self._get_magma_value_().wire(other)
+            return
+        T = type(other).undirected_t
+        if T not in self._tag_map:
+            raise TypeError(f"Cannot wire {other} to {self}")
+        self._val.tag @= self._tag_map[T]
+        self._val.data @= zext_to(as_bits(other), len(self._val.data))
+
+
+_MATCH_STACK = Stack()
+
+
+def reset_match_context():
+    _MATCH_STACK.clear()
+
+
+class MatchContext:
+    """
+    Marks a value of type Sum to be inside an active match context, enabling
+    the use of case statements.
+    """
+
+    def __init__(self, value):
+        self._value = value
+        _MATCH_STACK.push(self)
+
+    @property
+    def value(self):
+        return self._value
+
+    def __enter__(self):
+        self._value.match_active = True
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        assert self._value.match_active, "Should not have been deactivated"
+        assert _MATCH_STACK.pop() is self
+        self._value.match_active = False
+
+
+match = MatchContext
+
+
+class CaseContext:
+    """
+    Reinterprets a value of type Sum as a specific variant indicated by the
+    case statement argument and resets the value when the context is exited
+    """
+
+    def __init__(self, T):
+        try:
+            value = _MATCH_STACK.peek().value
+        except IndexError:
+            raise TypeError("Case used outside of match statement")
+        assert value.match_active
+
+        self._value = value
+        self._T = T
+        # Use elsewhen/otherwise to avoid latch detect issues
+        # TODO(leonardt/sum): Enforce that this isn't interleaved with other
+        # when/case statements
+        if len(self._value.activated_cases) == self._value.num_tags - 1:
+            self._when_ctx = otherwise()
+        elif self._value.activated_cases:
+            self._when_ctx = elsewhen(value.check_tag(T))
+        else:
+            self._when_ctx = when(value.check_tag(T))
+
+    def __enter__(self):
+        self._value.activate_case(self._T)
+        self._when_ctx.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        last_T = self._value.deactivate_case()
+        assert last_T is self._T, "Got wrong expected activate case"
+        self._when_ctx.__exit__(exc_type, exc_value, exc_tb)
+
+
+case = CaseContext

--- a/magma/sum_type.py
+++ b/magma/sum_type.py
@@ -30,7 +30,7 @@ class SumMeta(MagmaProtocolMeta):
     def __new__(mcs, name, bases, namespace):
         data_len = 0
         Ts = {}
-        # TODO: How to handle mixed direction type?
+        # TODO(leonardt/sum): How to handle mixed direction type?
         is_input, is_output = True, True
 
         for key, value in namespace.items():
@@ -123,7 +123,7 @@ class Sum(MagmaProtocol, metaclass=SumMeta):
     def __and__(self, other):
         return self._get_magma_value_() & other
 
-    # TODO: define all operators (can we metaprogram delegator to
+    # TODO(leonardt/sum): define all operators (can we metaprogram delegator to
     # self._get_magma_value_()?)
 
     def wire(self, other):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -194,7 +194,7 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
         WireableWithChildren.__init__(self)
 
         self._ts = {}
-        if len(largs) > 0:
+        if largs:
             assert len(largs) == len(self)
             for i, (k, t, T) in enumerate(zip(self.keys(),
                                               largs,

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -18,7 +18,7 @@ from .common import deprecated
 from .ref import AnonRef, TupleRef
 from .t import Type, Kind, Direction
 from .compatibility import IntegerTypes
-from .debug import debug_wire, get_callee_frame_info
+from .debug import debug_wire, get_callee_frame_info, debug_unwire
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
@@ -309,15 +309,18 @@ class Tuple(Type, Tuple_, metaclass=TupleKind):
             o_elem = magma_value(o_elem)
             wire(o_elem, i_elem, debug_info)
 
-    @debug_wire
-    def unwire(self, o=None, debug_info=None):
+    @debug_unwire
+    def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         for k, t in self.items():
             if o is None:
-                t.unwire(debug_info=debug_info)
+                t.unwire(debug_info=debug_info,
+                         keep_wired_when_contexts=keep_wired_when_contexts)
             elif o[k].is_input():
-                o[k].unwire(t, debug_info=debug_info)
+                o[k].unwire(t, debug_info=debug_info,
+                            keep_wired_when_contexts=keep_wired_when_contexts)
             else:
-                t.unwire(o[k], debug_info=debug_info)
+                t.unwire(o[k], debug_info=debug_info,
+                         keep_wired_when_contexts=keep_wired_when_contexts)
 
     def driven(self):
         for t in self.ts:

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -257,7 +257,7 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
 
     def _make_t(self, idx):
         T = self.types()[idx]
-        ref = TupleRef(self, self._keys_list()[idx])
+        ref = TupleRef(self, self._keys_list[idx])
         if issubclass(T, MagmaProtocol):
             return T._from_magma_value_(T._to_magma_()(name=ref))
         return T(name=ref)

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -341,7 +341,8 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
     @aggregate_wireable_method
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if not self._has_elaborated_children():
-            return Wireable.unwire(self, o, debug_info)
+            return AggregateWireableWireable.unwire(self, o, debug_info,
+                                                    keep_wired_when_contexts)
 
         for k, t in self.items():
             if o is None:

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -259,7 +259,7 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
         T = self.types()[idx]
         ref = TupleRef(self, self._keys_list[idx])
         if issubclass(T, MagmaProtocol):
-            return T._from_magma_value_(T._to_magma_()(name=ref))
+            return T._from_magma_ref_(ref)
         return T(name=ref)
 
     def _has_elaborated_children(self):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -20,7 +20,7 @@ from .debug import debug_wire, get_callee_frame_info, debug_unwire
 from .logging import root_logger
 from .protocol_type import magma_type, magma_value
 
-from magma.wire_container import (WiringLog, WireableWithChildren,
+from magma.wire_container import (WiringLog, AggregateWireable,
                                   aggregate_wireable_method)
 from magma.wire import wire
 from magma.protocol_type import MagmaProtocol
@@ -187,11 +187,11 @@ class TupleKind(TupleMeta, Kind):
     __hash__ = TupleMeta.__hash__
 
 
-class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
+class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
     def __init__(self, *largs, **kwargs):
 
         Type.__init__(self, **kwargs)
-        WireableWithChildren.__init__(self)
+        AggregateWireable.__init__(self)
 
         self._ts = {}
         if largs:
@@ -332,7 +332,7 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
                 o_elem = magma_value(o_elem)
                 wire(o_elem, self_elem, debug_info)
         else:
-            WireableWithChildren.wire(self, o, debug_info)
+            AggregateWireable.wire(self, o, debug_info)
 
     @debug_unwire
     @aggregate_wireable_method

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -190,7 +190,7 @@ class TupleKind(TupleMeta, Kind):
 class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
     def __init__(self, *largs, **kwargs):
 
-        Type.__init__(self, **kwargs)  # name=
+        Type.__init__(self, **kwargs)
         WireableWithChildren.__init__(self)
 
         self.ts = {}

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -193,7 +193,7 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
         Type.__init__(self, **kwargs)
         WireableWithChildren.__init__(self)
 
-        self.ts = {}
+        self._ts = {}
         if len(largs) > 0:
             assert len(largs) == len(self)
             for i, (k, t, T) in enumerate(zip(self.keys(),
@@ -201,7 +201,7 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
                                               self.types())):
                 if isinstance(t, (IntegerTypes, BitVector, Bit)):
                     t = T(t)
-                self.ts[i] = t
+                self._ts[i] = t
                 if not isinstance(self, AnonProduct):
                     setattr(self, k, t)
 
@@ -261,7 +261,7 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
         return T(name=ref)
 
     def _has_elaborated_children(self):
-        return bool(self.ts)
+        return bool(self._ts)
 
     def _enumerate_children(self):
         return self.items()
@@ -274,10 +274,14 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
                 raise KeyError(key) from None
         if not isinstance(key, int):
             raise KeyError(key)
-        if key not in self.ts:
-            self.ts[key] = self._make_t(key)
+        if key not in self._ts:
+            self._ts[key] = self._make_t(key)
             self._resolve_bulk_wire()
-        return self.ts[key]
+        return self._ts[key]
+
+    @property
+    def ts(self):
+        return [self[k] for k in self.keys()]
 
     def __setitem__(self, key, val):
         old = self[key]

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -440,11 +440,7 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
         return sum([t.flatten() for t in self], [])
 
     def const(self):
-        for t in self:
-            if not t.const():
-                return False
-
-        return True
+        return all(t.const() for t in self)
 
     @classmethod
     def types(cls):

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -259,8 +259,11 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
         T = self.types()[idx]
         ref = TupleRef(self, self._keys_list[idx])
         if issubclass(T, MagmaProtocol):
-            return T._from_magma_ref_(ref)
-        return T(name=ref)
+            value = T._from_magma_ref_(ref)
+        else:
+            value = T(name=ref)
+        value.set_enclosing_when_context(self._enclosing_when_context)
+        return value
 
     def _has_elaborated_children(self):
         return bool(self._ts)

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -328,8 +328,8 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
         else:
             WireableWithChildren.wire(self, o, debug_info)
 
-    @wireable_with_children_wrapper
     @debug_unwire
+    @wireable_with_children_wrapper
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if not self._has_elaborated_children():
             return Wireable.unwire(self, o, debug_info)

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -205,6 +205,8 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
                 if not isinstance(self, AnonProduct):
                     setattr(self, k, t)
 
+        self._keys_list = list(self.keys())
+
     def __getattr__(self, key):
         if not isinstance(self, AnonProduct) and key in self.keys():
             # On demand setattr for lazy children
@@ -253,9 +255,9 @@ class Tuple(Type, Tuple_, WireableWithChildren, metaclass=TupleKind):
         kts = ['{}={}'.format(k, v) for k, v in zip(self.keys(), ts)]
         return 'tuple(dict({})'.format(', '.join(kts))
 
-    def _make_t(self, key):
-        T = self.types()[key]
-        ref = TupleRef(self, list(self.keys())[key])
+    def _make_t(self, idx):
+        T = self.types()[idx]
+        ref = TupleRef(self, self._keys_list()[idx])
         if issubclass(T, MagmaProtocol):
             return T._from_magma_value_(T._to_magma_()(name=ref))
         return T(name=ref)

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -359,7 +359,6 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
     def wired(self):
         return all(t.wired() for t in self)
 
-    # test whether the values refer a whole tuple
     @staticmethod
     def _iswhole(ts, keys):
 

--- a/magma/when.py
+++ b/magma/when.py
@@ -48,9 +48,6 @@ class _BlockBase(contextlib.AbstractContextManager):
         )
 
     def remove_conditional_wire(self, i):
-        # We use a "safe" remove pattern because multiple when contexts share
-        # the same builder and we only need to remove the drivee once but may
-        # need to update all the contexts
         self._conditional_wires = list(
             filter(lambda x: x.drivee is not i, self._conditional_wires)
         )

--- a/magma/when.py
+++ b/magma/when.py
@@ -274,6 +274,14 @@ def no_when():
     _set_curr_block(block)
 
 
+@contextlib.contextmanager
+def temp_when(temp_ctx):
+    block = _get_curr_block()
+    _set_curr_block(temp_ctx)
+    yield
+    _set_curr_block(block)
+
+
 def _get_curr_block() -> Optional[_BlockBase]:
     global _curr_block
     return _curr_block
@@ -303,7 +311,6 @@ def _reset_prev_block():
 
 
 get_curr_block = _get_curr_block
-set_curr_block = _set_curr_block
 
 
 def _reset_context():

--- a/magma/when.py
+++ b/magma/when.py
@@ -51,7 +51,6 @@ class _BlockBase(contextlib.AbstractContextManager):
         # We use a "safe" remove pattern because multiple when contexts share
         # the same builder and we only need to remove the drivee once but may
         # need to update all the contexts
-        self.root._builder.safe_remove_drivee(i)
         self._conditional_wires = list(
             filter(lambda x: x.drivee is not i, self._conditional_wires)
         )

--- a/magma/when.py
+++ b/magma/when.py
@@ -60,10 +60,10 @@ class _BlockBase(contextlib.AbstractContextManager):
         builder = self.root.builder
         if i.driven() and i not in builder.output_to_index:
             driver = i.value()
-            # TODO(leonardt): we need to skip removing wired when contexts
-            # because in this case, the driver could have been wired in a
-            # different when context
-            i._wire.unwire(driver._wire)
+            # Keep wired when contexts because in this case, the driver could
+            # have been wired in a different when context (so the default value
+            # comes from the result of a previous when context)
+            i.unwire(driver, keep_wired_when_contexts=True)
             self.root.add_default_driver(i, driver)
         self.root.builder.add_drivee(i)
         self.root.builder.add_driver(o)

--- a/magma/when.py
+++ b/magma/when.py
@@ -53,10 +53,10 @@ class _BlockBase(contextlib.AbstractContextManager):
         )
 
     def remove_conditional_wire(self, i):
-        if self._parent is None:
-            # Only remove from builder once
-            # TODO: We could have the root when handle removing from children
-            self._builder.remove_drivee(i)
+        # We use a "safe" remove pattern because multiple when contexts share
+        # the same builder and we only need to remove the drivee once but may
+        # need to update all the contexts
+        self.root._builder.safe_remove_drivee(i)
         self._conditional_wires = list(
             filter(lambda x: x.drivee is not i, self._conditional_wires)
         )
@@ -74,7 +74,6 @@ class _BlockBase(contextlib.AbstractContextManager):
     @property
     @abc.abstractmethod
     def root(self) -> '_WhenBlock':
-
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/magma/when.py
+++ b/magma/when.py
@@ -61,7 +61,10 @@ class _BlockBase(contextlib.AbstractContextManager):
         builder = self.root.builder
         if i.driven() and i not in builder.output_to_index:
             driver = i.value()
-            i.unwire(driver)
+            # TODO(leonardt): we need to skip removing wired when contexts
+            # because in this case, the driver could have been wired in a
+            # different when context
+            i._wire.unwire(driver._wire)
             self.root.add_default_driver(i, driver)
         self.root.builder.add_drivee(i)
         self.root.builder.add_driver(o)

--- a/magma/when.py
+++ b/magma/when.py
@@ -47,11 +47,6 @@ class _BlockBase(contextlib.AbstractContextManager):
             filter(lambda x: x.drivee is i, self._conditional_wires)
         )
 
-    def get_conditional_wires_for_driver(self, o):
-        return list(
-            filter(lambda x: x.driver is o, self._conditional_wires)
-        )
-
     def remove_conditional_wire(self, i):
         # We use a "safe" remove pattern because multiple when contexts share
         # the same builder and we only need to remove the drivee once but may

--- a/magma/when.py
+++ b/magma/when.py
@@ -311,6 +311,7 @@ def _reset_prev_block():
 
 
 get_curr_block = _get_curr_block
+WhenBlock = _WhenBlock
 
 
 def _reset_context():

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -1,3 +1,4 @@
+import functools
 import logging as py_logging
 
 from magma.config import config, EnvConfig
@@ -279,10 +280,13 @@ class WireableWithChildren(Wireable):
             self._resolve_driving_bulk_wire()
 
 
-def wireable_with_children_wrapper(fn):
+def aggregate_wireable_method(fn):
+
+    @functools.wraps(fn)
     def wrapper(self, *args, **kwargs):
         if self._has_elaborated_children():
             return fn(self, *args, **kwargs)
         wireable_fn = getattr(WireableWithChildren, fn.__name__)
         return wireable_fn(self, *args, **kwargs)
+
     return wrapper

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -256,9 +256,9 @@ class WireableWithChildren(Wireable):
 
     def _resolve_driving_bulk_wire(self):
         driving = self._wire.driving()
-        # NOTE: we need to remove drivees before doing the recursive wiring of
-        # the children or else we'll trigger _resolve_bulk_wire when iterating
-        # over the children
+        # NOTE(leonardt): we need to remove drivees before doing the recursive
+        # wiring of the children or else we'll trigger _resolve_bulk_wire when
+        # iterating over the children
         for drivee in driving:
             # Remove bulk wire since children will now track the wiring
             Wireable.unwire(drivee, self)

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -246,11 +246,11 @@ class WireableWithChildren(Wireable):
         raise NotImplementedError()
 
     def _resolve_driven_bulk_wire(self):
-        # Remove bulk wire since children will now track the wiring
+        # Remove bulk wire since children will now track the wiring.
         value = self._wire.value()
         Wireable.unwire(self, value)
 
-        # Update children
+        # Update children.
         for i, child in self._enumerate_children():
             child.wire(value[i])
 
@@ -258,13 +258,13 @@ class WireableWithChildren(Wireable):
         driving = self._wire.driving()
         # NOTE(leonardt): we need to remove drivees before doing the recursive
         # wiring of the children or else we'll trigger _resolve_bulk_wire when
-        # iterating over the children
+        # iterating over the children.
         for drivee in driving:
-            # Remove bulk wire since children will now track the wiring
+            # Remove bulk wire since children will now track the wiring.
             Wireable.unwire(drivee, self)
 
         for drivee in driving:
-            # Update children
+            # Update children.
             for i, child in self._enumerate_children():
                 drivee[i].wire(child)
 

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -1,7 +1,7 @@
 import logging as py_logging
 
 from magma.config import config, EnvConfig
-from magma.debug import debug_wire
+from magma.debug import debug_wire, debug_unwire
 from magma.logging import root_logger, StagedLogRecord
 from magma.when import get_curr_block as get_curr_when_block
 
@@ -207,6 +207,7 @@ class Wireable:
             ctx.remove_conditional_wire(self)
         self._wired_when_contexts = []
 
+    @debug_unwire
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if o is not None:
             o = o._wire

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -207,11 +207,12 @@ class Wireable:
             ctx.remove_conditional_wire(self)
         self._wired_when_contexts = []
 
-    def unwire(self, o=None, debug_info=None):
+    def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
         if o is not None:
             o = o._wire
         self._wire.unwire(o, debug_info)
-        self._remove_from_wired_when_contexts()
+        if not keep_wired_when_contexts:
+            self._remove_from_wired_when_contexts()
 
     def _wire_impl(self, o, debug_info):
         self._wire.connect(o._wire, debug_info)

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -128,8 +128,9 @@ class Wire:
             return self._driver.trace(skip_self=False)
         if not skip_self and (self._bit.is_output() or self._bit.is_inout()):
             return self._bit
-        if (not skip_self and self._bit.has_children() and
-                self._bit.driven()):
+        if (
+            not skip_self and self._bit.has_children() and self._bit.driven()
+        ):
             # Driven non-bulk, so trace children
             return self._bit.trace(skip_self=False)
         return None

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -127,9 +127,9 @@ class Wire:
             return self._driver.trace(skip_self=False)
         if not skip_self and (self._bit.is_output() or self._bit.is_inout()):
             return self._bit
-        if not skip_self and self._bit.has_children():
-            # Could be an Array driven non-bulk, so check if children can be
-            # traced
+        if (not skip_self and self._bit.has_children() and
+                self._bit.driven()):
+            # Driven non-bulk, so trace children
             return self._bit.trace(skip_self=False)
         return None
 

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -240,7 +240,7 @@ class Wireable:
         self.wire(o, debug_info=debug_info)
 
 
-class WireableWithChildren(Wireable):
+class AggregateWireable(Wireable):
     def _has_elaborated_children(self):
         raise NotImplementedError()
 
@@ -287,7 +287,7 @@ def aggregate_wireable_method(fn):
     def wrapper(self, *args, **kwargs):
         if self._has_elaborated_children():
             return fn(self, *args, **kwargs)
-        wireable_fn = getattr(WireableWithChildren, fn.__name__)
+        wireable_fn = getattr(AggregateWireable, fn.__name__)
         return wireable_fn(self, *args, **kwargs)
 
     return wrapper

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -1,3 +1,4 @@
+import abc
 import functools
 import logging as py_logging
 
@@ -241,9 +242,11 @@ class Wireable:
 
 
 class AggregateWireable(Wireable):
+    @abc.abstractmethod
     def _has_elaborated_children(self):
         raise NotImplementedError()
 
+    @abc.abstractmethod
     def _enumerate_children(self):
         raise NotImplementedError()
 

--- a/tests/gold/test_when_lazy_array_multiple_whens.mlir
+++ b/tests/gold/test_when_lazy_array_multiple_whens.mlir
@@ -1,0 +1,51 @@
+hw.module @test_when_lazy_array_multiple_whens(%I: i4, %S: i1) -> (O: i4) {
+    %1 = hw.constant -1 : i1
+    %0 = comb.xor %1, %S : i1
+    %2 = comb.extract %I from 0 : (i4) -> i1
+    %3 = comb.extract %I from 1 : (i4) -> i1
+    %4 = comb.extract %I from 2 : (i4) -> i1
+    %5 = comb.extract %I from 3 : (i4) -> i1
+    %10 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %13 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %10, %2 : i1
+            sv.bpassign %11, %3 : i1
+            sv.bpassign %12, %4 : i1
+            sv.bpassign %13, %5 : i1
+        } else {
+            sv.bpassign %10, %4 : i1
+            sv.bpassign %11, %5 : i1
+            sv.bpassign %12, %2 : i1
+            sv.bpassign %13, %3 : i1
+        }
+    }
+    %18 = sv.reg : !hw.inout<i1>
+    %14 = sv.read_inout %18 : !hw.inout<i1>
+    %19 = sv.reg : !hw.inout<i1>
+    %15 = sv.read_inout %19 : !hw.inout<i1>
+    %20 = sv.reg : !hw.inout<i1>
+    %16 = sv.read_inout %20 : !hw.inout<i1>
+    %21 = sv.reg : !hw.inout<i1>
+    %17 = sv.read_inout %21 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.bpassign %18, %6 : i1
+        sv.bpassign %19, %7 : i1
+        sv.bpassign %20, %8 : i1
+        sv.bpassign %21, %9 : i1
+        sv.if %0 {
+            sv.bpassign %18, %2 : i1
+            sv.bpassign %19, %3 : i1
+            sv.bpassign %20, %4 : i1
+            sv.bpassign %21, %5 : i1
+        }
+    }
+    %22 = comb.concat %17, %16, %15, %14 : i1, i1, i1, i1
+    hw.output %22 : i4
+}

--- a/tests/gold/test_when_lazy_array_multiple_whens.mlir
+++ b/tests/gold/test_when_lazy_array_multiple_whens.mlir
@@ -5,47 +5,49 @@ hw.module @test_when_lazy_array_multiple_whens(%I: i4, %S: i1) -> (O: i4) {
     %3 = comb.extract %I from 1 : (i4) -> i1
     %4 = comb.extract %I from 2 : (i4) -> i1
     %5 = comb.extract %I from 3 : (i4) -> i1
-    %10 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %10 : !hw.inout<i1>
-    %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i4>
+    %6 = sv.read_inout %11 : !hw.inout<i4>
     %12 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %7 = sv.read_inout %12 : !hw.inout<i1>
     %13 = sv.reg : !hw.inout<i1>
-    %9 = sv.read_inout %13 : !hw.inout<i1>
+    %8 = sv.read_inout %13 : !hw.inout<i1>
+    %14 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %15 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %10, %2 : i1
-            sv.bpassign %11, %3 : i1
-            sv.bpassign %12, %4 : i1
-            sv.bpassign %13, %5 : i1
-        } else {
-            sv.bpassign %10, %4 : i1
-            sv.bpassign %11, %5 : i1
             sv.bpassign %12, %2 : i1
             sv.bpassign %13, %3 : i1
+            sv.bpassign %14, %4 : i1
+            sv.bpassign %15, %5 : i1
+        } else {
+            sv.bpassign %12, %4 : i1
+            sv.bpassign %13, %5 : i1
+            sv.bpassign %14, %2 : i1
+            sv.bpassign %15, %3 : i1
         }
     }
-    %18 = sv.reg : !hw.inout<i1>
-    %14 = sv.read_inout %18 : !hw.inout<i1>
-    %19 = sv.reg : !hw.inout<i1>
-    %15 = sv.read_inout %19 : !hw.inout<i1>
     %20 = sv.reg : !hw.inout<i1>
     %16 = sv.read_inout %20 : !hw.inout<i1>
     %21 = sv.reg : !hw.inout<i1>
     %17 = sv.read_inout %21 : !hw.inout<i1>
+    %22 = sv.reg : !hw.inout<i1>
+    %18 = sv.read_inout %22 : !hw.inout<i1>
+    %23 = sv.reg : !hw.inout<i1>
+    %19 = sv.read_inout %23 : !hw.inout<i1>
     sv.alwayscomb {
-        sv.bpassign %18, %6 : i1
-        sv.bpassign %19, %7 : i1
-        sv.bpassign %20, %8 : i1
-        sv.bpassign %21, %9 : i1
+        sv.bpassign %20, %7 : i1
+        sv.bpassign %21, %8 : i1
+        sv.bpassign %22, %9 : i1
+        sv.bpassign %23, %10 : i1
         sv.if %0 {
-            sv.bpassign %18, %2 : i1
-            sv.bpassign %19, %3 : i1
-            sv.bpassign %20, %4 : i1
-            sv.bpassign %21, %5 : i1
+            sv.bpassign %20, %2 : i1
+            sv.bpassign %21, %3 : i1
+            sv.bpassign %22, %4 : i1
+            sv.bpassign %23, %5 : i1
         }
     }
-    %22 = comb.concat %17, %16, %15, %14 : i1, i1, i1, i1
-    hw.output %22 : i4
+    %24 = comb.concat %19, %18, %17, %16 : i1, i1, i1, i1
+    hw.output %24 : i4
 }

--- a/tests/gold/test_when_lazy_array_resolve.mlir
+++ b/tests/gold/test_when_lazy_array_resolve.mlir
@@ -5,19 +5,21 @@ hw.module @test_when_lazy_array_resolve(%I: i2, %S: i1) -> (O: i2) {
     %3 = comb.shru %I, %2 : i2
     %4 = comb.extract %3 from 0 : (i2) -> i1
     %5 = comb.extract %3 from 1 : (i2) -> i1
-    %8 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %8 : !hw.inout<i1>
-    %9 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %9 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i2>
+    %6 = sv.read_inout %9 : !hw.inout<i2>
+    %10 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %11 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %8, %0 : i1
-            sv.bpassign %9, %1 : i1
+            sv.bpassign %10, %0 : i1
+            sv.bpassign %11, %1 : i1
         } else {
-            sv.bpassign %8, %4 : i1
-            sv.bpassign %9, %5 : i1
+            sv.bpassign %10, %4 : i1
+            sv.bpassign %11, %5 : i1
         }
     }
-    %10 = comb.concat %7, %6 : i1, i1
-    hw.output %10 : i2
+    %12 = comb.concat %8, %7 : i1, i1
+    hw.output %12 : i2
 }

--- a/tests/gold/test_when_lazy_array_slice.mlir
+++ b/tests/gold/test_when_lazy_array_slice.mlir
@@ -5,30 +5,34 @@ hw.module @test_when_lazy_array_slice(%S: i1) -> (O: i4) {
     %3 = hw.constant 0 : i2
     %4 = hw.constant 0 : i1
     %5 = hw.constant 1 : i1
-    %10 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %10 : !hw.inout<i1>
-    %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
-    %12 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %12 : !hw.inout<i1>
-    %13 = sv.reg : !hw.inout<i1>
-    %9 = sv.read_inout %13 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i2>
+    %6 = sv.read_inout %12 : !hw.inout<i2>
+    %13 = sv.reg : !hw.inout<i2>
+    %7 = sv.read_inout %13 : !hw.inout<i2>
+    %14 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %15 : !hw.inout<i1>
+    %16 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %16 : !hw.inout<i1>
+    %17 = sv.reg : !hw.inout<i1>
+    %11 = sv.read_inout %17 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %10, %4 : i1
-            sv.bpassign %11, %4 : i1
-            sv.bpassign %12, %5 : i1
-            sv.bpassign %13, %4 : i1
+            sv.bpassign %14, %4 : i1
+            sv.bpassign %15, %4 : i1
+            sv.bpassign %16, %5 : i1
+            sv.bpassign %17, %4 : i1
         } else {
-            sv.bpassign %10, %5 : i1
-            sv.bpassign %11, %4 : i1
-            sv.bpassign %12, %4 : i1
-            sv.bpassign %13, %4 : i1
+            sv.bpassign %14, %5 : i1
+            sv.bpassign %15, %4 : i1
+            sv.bpassign %16, %4 : i1
+            sv.bpassign %17, %4 : i1
         }
     }
-    %14 = comb.concat %9, %8, %7, %6 : i1, i1, i1, i1
-    %16 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
-    sv.assign %16, %14 : i4
-    %15 = sv.read_inout %16 : !hw.inout<i4>
-    hw.output %15 : i4
+    %18 = comb.concat %11, %10, %9, %8 : i1, i1, i1, i1
+    %20 = sv.wire sym @test_when_lazy_array_slice.x {name="x"} : !hw.inout<i4>
+    sv.assign %20, %18 : i4
+    %19 = sv.read_inout %20 : !hw.inout<i4>
+    hw.output %19 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice_driving_resolve.mlir
+++ b/tests/gold/test_when_lazy_array_slice_driving_resolve.mlir
@@ -1,0 +1,33 @@
+hw.module @test_when_lazy_array_slice_driving_resolve(%S: i1) -> (O: i4) {
+    %0 = hw.constant 1 : i1
+    %1 = hw.constant 2 : i4
+    %2 = hw.constant 4 : i4
+    %3 = hw.constant 0 : i1
+    %4 = hw.constant 1 : i1
+    %9 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %9 : !hw.inout<i1>
+    %10 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %12 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %9, %3 : i1
+            sv.bpassign %10, %4 : i1
+            sv.bpassign %11, %3 : i1
+            sv.bpassign %12, %3 : i1
+        } else {
+            sv.bpassign %9, %3 : i1
+            sv.bpassign %10, %3 : i1
+            sv.bpassign %11, %4 : i1
+            sv.bpassign %12, %3 : i1
+        }
+    }
+    %13 = comb.concat %8, %7, %6, %0 : i1, i1, i1, i1
+    %15 = sv.wire sym @test_when_lazy_array_slice_driving_resolve.x {name="x"} : !hw.inout<i4>
+    sv.assign %15, %13 : i4
+    %14 = sv.read_inout %15 : !hw.inout<i4>
+    hw.output %14 : i4
+}

--- a/tests/gold/test_when_lazy_array_slice_driving_resolve.mlir
+++ b/tests/gold/test_when_lazy_array_slice_driving_resolve.mlir
@@ -4,30 +4,32 @@ hw.module @test_when_lazy_array_slice_driving_resolve(%S: i1) -> (O: i4) {
     %2 = hw.constant 4 : i4
     %3 = hw.constant 0 : i1
     %4 = hw.constant 1 : i1
-    %9 = sv.reg : !hw.inout<i1>
-    %5 = sv.read_inout %9 : !hw.inout<i1>
-    %10 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %10 = sv.reg : !hw.inout<i4>
+    %5 = sv.read_inout %10 : !hw.inout<i4>
     %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %6 = sv.read_inout %11 : !hw.inout<i1>
     %12 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %7 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %13 : !hw.inout<i1>
+    %14 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %14 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %9, %3 : i1
-            sv.bpassign %10, %4 : i1
+            sv.bpassign %11, %3 : i1
+            sv.bpassign %12, %4 : i1
+            sv.bpassign %13, %3 : i1
+            sv.bpassign %14, %3 : i1
+        } else {
             sv.bpassign %11, %3 : i1
             sv.bpassign %12, %3 : i1
-        } else {
-            sv.bpassign %9, %3 : i1
-            sv.bpassign %10, %3 : i1
-            sv.bpassign %11, %4 : i1
-            sv.bpassign %12, %3 : i1
+            sv.bpassign %13, %4 : i1
+            sv.bpassign %14, %3 : i1
         }
     }
-    %13 = comb.concat %8, %7, %6, %0 : i1, i1, i1, i1
-    %15 = sv.wire sym @test_when_lazy_array_slice_driving_resolve.x {name="x"} : !hw.inout<i4>
-    sv.assign %15, %13 : i4
-    %14 = sv.read_inout %15 : !hw.inout<i4>
-    hw.output %14 : i4
+    %15 = comb.concat %9, %8, %7, %0 : i1, i1, i1, i1
+    %17 = sv.wire sym @test_when_lazy_array_slice_driving_resolve.x {name="x"} : !hw.inout<i4>
+    sv.assign %17, %15 : i4
+    %16 = sv.read_inout %17 : !hw.inout<i4>
+    hw.output %16 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice_driving_resolve_2.mlir
+++ b/tests/gold/test_when_lazy_array_slice_driving_resolve_2.mlir
@@ -6,30 +6,32 @@ hw.module @test_when_lazy_array_slice_driving_resolve_2(%I: i4, %S: i1) -> (O: i
     %4 = comb.extract %I from 2 : (i4) -> i1
     %5 = hw.constant 1 : i1
     %6 = comb.extract %I from 3 : (i4) -> i1
-    %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
-    %12 = sv.reg : !hw.inout<i1>
-    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i4>
+    %7 = sv.read_inout %12 : !hw.inout<i4>
     %13 = sv.reg : !hw.inout<i1>
-    %9 = sv.read_inout %13 : !hw.inout<i1>
+    %8 = sv.read_inout %13 : !hw.inout<i1>
     %14 = sv.reg : !hw.inout<i1>
-    %10 = sv.read_inout %14 : !hw.inout<i1>
+    %9 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %15 : !hw.inout<i1>
+    %16 = sv.reg : !hw.inout<i1>
+    %11 = sv.read_inout %16 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %11, %1 : i1
-            sv.bpassign %12, %3 : i1
-            sv.bpassign %13, %4 : i1
-            sv.bpassign %14, %6 : i1
+            sv.bpassign %13, %1 : i1
+            sv.bpassign %14, %3 : i1
+            sv.bpassign %15, %4 : i1
+            sv.bpassign %16, %6 : i1
         } else {
-            sv.bpassign %11, %2 : i1
-            sv.bpassign %12, %2 : i1
-            sv.bpassign %13, %5 : i1
+            sv.bpassign %13, %2 : i1
             sv.bpassign %14, %2 : i1
+            sv.bpassign %15, %5 : i1
+            sv.bpassign %16, %2 : i1
         }
     }
-    %15 = comb.concat %1, %9, %8, %7 : i1, i1, i1, i1
-    %17 = sv.wire sym @test_when_lazy_array_slice_driving_resolve_2.x {name="x"} : !hw.inout<i4>
-    sv.assign %17, %15 : i4
-    %16 = sv.read_inout %17 : !hw.inout<i4>
-    hw.output %16 : i4
+    %17 = comb.concat %1, %10, %9, %8 : i1, i1, i1, i1
+    %19 = sv.wire sym @test_when_lazy_array_slice_driving_resolve_2.x {name="x"} : !hw.inout<i4>
+    sv.assign %19, %17 : i4
+    %18 = sv.read_inout %19 : !hw.inout<i4>
+    hw.output %18 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice_driving_resolve_2.mlir
+++ b/tests/gold/test_when_lazy_array_slice_driving_resolve_2.mlir
@@ -1,0 +1,35 @@
+hw.module @test_when_lazy_array_slice_driving_resolve_2(%I: i4, %S: i1) -> (O: i4) {
+    %0 = hw.constant 4 : i4
+    %1 = comb.extract %I from 0 : (i4) -> i1
+    %2 = hw.constant 0 : i1
+    %3 = comb.extract %I from 1 : (i4) -> i1
+    %4 = comb.extract %I from 2 : (i4) -> i1
+    %5 = hw.constant 1 : i1
+    %6 = comb.extract %I from 3 : (i4) -> i1
+    %11 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i1>
+    %9 = sv.read_inout %13 : !hw.inout<i1>
+    %14 = sv.reg : !hw.inout<i1>
+    %10 = sv.read_inout %14 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %11, %1 : i1
+            sv.bpassign %12, %3 : i1
+            sv.bpassign %13, %4 : i1
+            sv.bpassign %14, %6 : i1
+        } else {
+            sv.bpassign %11, %2 : i1
+            sv.bpassign %12, %2 : i1
+            sv.bpassign %13, %5 : i1
+            sv.bpassign %14, %2 : i1
+        }
+    }
+    %15 = comb.concat %1, %9, %8, %7 : i1, i1, i1, i1
+    %17 = sv.wire sym @test_when_lazy_array_slice_driving_resolve_2.x {name="x"} : !hw.inout<i4>
+    sv.assign %17, %15 : i4
+    %16 = sv.read_inout %17 : !hw.inout<i4>
+    hw.output %16 : i4
+}

--- a/tests/gold/test_when_lazy_array_slice_overlap.mlir
+++ b/tests/gold/test_when_lazy_array_slice_overlap.mlir
@@ -3,27 +3,29 @@ hw.module @test_when_lazy_array_slice_overlap(%I: i4, %S: i1) -> (O: i4) {
     %1 = comb.extract %I from 1 : (i4) -> i1
     %2 = comb.extract %I from 2 : (i4) -> i1
     %3 = comb.extract %I from 3 : (i4) -> i1
-    %8 = sv.reg : !hw.inout<i1>
-    %4 = sv.read_inout %8 : !hw.inout<i1>
-    %9 = sv.reg : !hw.inout<i1>
-    %5 = sv.read_inout %9 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i4>
+    %4 = sv.read_inout %9 : !hw.inout<i4>
     %10 = sv.reg : !hw.inout<i1>
-    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %5 = sv.read_inout %10 : !hw.inout<i1>
     %11 = sv.reg : !hw.inout<i1>
-    %7 = sv.read_inout %11 : !hw.inout<i1>
+    %6 = sv.read_inout %11 : !hw.inout<i1>
+    %12 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i1>
+    %8 = sv.read_inout %13 : !hw.inout<i1>
     sv.alwayscomb {
         sv.if %S {
-            sv.bpassign %8, %0 : i1
-            sv.bpassign %9, %1 : i1
-            sv.bpassign %10, %2 : i1
-            sv.bpassign %11, %3 : i1
-        } else {
-            sv.bpassign %8, %2 : i1
-            sv.bpassign %9, %3 : i1
             sv.bpassign %10, %0 : i1
             sv.bpassign %11, %1 : i1
+            sv.bpassign %12, %2 : i1
+            sv.bpassign %13, %3 : i1
+        } else {
+            sv.bpassign %10, %2 : i1
+            sv.bpassign %11, %3 : i1
+            sv.bpassign %12, %0 : i1
+            sv.bpassign %13, %1 : i1
         }
     }
-    %12 = comb.concat %7, %6, %5, %4 : i1, i1, i1, i1
-    hw.output %12 : i4
+    %14 = comb.concat %8, %7, %6, %5 : i1, i1, i1, i1
+    hw.output %14 : i4
 }

--- a/tests/gold/test_when_lazy_array_slice_overlap.mlir
+++ b/tests/gold/test_when_lazy_array_slice_overlap.mlir
@@ -1,0 +1,29 @@
+hw.module @test_when_lazy_array_slice_overlap(%I: i4, %S: i1) -> (O: i4) {
+    %0 = comb.extract %I from 0 : (i4) -> i1
+    %1 = comb.extract %I from 1 : (i4) -> i1
+    %2 = comb.extract %I from 2 : (i4) -> i1
+    %3 = comb.extract %I from 3 : (i4) -> i1
+    %8 = sv.reg : !hw.inout<i1>
+    %4 = sv.read_inout %8 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %9 : !hw.inout<i1>
+    %10 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i1>
+    %7 = sv.read_inout %11 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %S {
+            sv.bpassign %8, %0 : i1
+            sv.bpassign %9, %1 : i1
+            sv.bpassign %10, %2 : i1
+            sv.bpassign %11, %3 : i1
+        } else {
+            sv.bpassign %8, %2 : i1
+            sv.bpassign %9, %3 : i1
+            sv.bpassign %10, %0 : i1
+            sv.bpassign %11, %1 : i1
+        }
+    }
+    %12 = comb.concat %7, %6, %5, %4 : i1, i1, i1, i1
+    hw.output %12 : i4
+}

--- a/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
+++ b/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
@@ -34,49 +34,61 @@ hw.module @test_when_memory_Tuplex_Bit_y_Bits7(%data0_x: i1, %data0_y: i7, %addr
     %9 = hw.constant 0 : i5
     %10 = hw.constant 0 : i1
     %11 = hw.constant 0 : i7
-    %12 = hw.constant 0 : i5
-    %15 = sv.reg : !hw.inout<i5>
-    %2 = sv.read_inout %15 : !hw.inout<i5>
-    %16 = sv.reg : !hw.inout<i1>
-    %3 = sv.read_inout %16 : !hw.inout<i1>
-    %17 = sv.reg : !hw.inout<i7>
-    %4 = sv.read_inout %17 : !hw.inout<i7>
-    %18 = sv.reg : !hw.inout<i1>
-    %5 = sv.read_inout %18 : !hw.inout<i1>
-    %19 = sv.reg : !hw.inout<i5>
-    %1 = sv.read_inout %19 : !hw.inout<i5>
-    %20 = sv.reg : !hw.inout<i1>
-    %13 = sv.read_inout %20 : !hw.inout<i1>
-    %21 = sv.reg : !hw.inout<i7>
-    %14 = sv.read_inout %21 : !hw.inout<i7>
+    %12 = hw.constant 0 : i1
+    %13 = hw.constant 0 : i5
+    %14 = hw.constant 0 : i7
+    %21 = sv.reg : !hw.inout<i5>
+    %2 = sv.read_inout %21 : !hw.inout<i5>
+    %22 = sv.reg : !hw.inout<i1>
+    %15 = sv.read_inout %22 : !hw.inout<i1>
+    %23 = sv.reg : !hw.inout<i7>
+    %16 = sv.read_inout %23 : !hw.inout<i7>
+    %24 = sv.reg : !hw.inout<i1>
+    %5 = sv.read_inout %24 : !hw.inout<i1>
+    %25 = sv.reg : !hw.inout<i5>
+    %1 = sv.read_inout %25 : !hw.inout<i5>
+    %26 = sv.reg : !hw.inout<i1>
+    %17 = sv.read_inout %26 : !hw.inout<i1>
+    %27 = sv.reg : !hw.inout<i7>
+    %18 = sv.read_inout %27 : !hw.inout<i7>
+    %28 = sv.reg : !hw.inout<i1>
+    %19 = sv.read_inout %28 : !hw.inout<i1>
+    %29 = sv.reg : !hw.inout<i7>
+    %20 = sv.read_inout %29 : !hw.inout<i7>
+    %30 = sv.reg : !hw.inout<i1>
+    %3 = sv.read_inout %30 : !hw.inout<i1>
+    %31 = sv.reg : !hw.inout<i7>
+    %4 = sv.read_inout %31 : !hw.inout<i7>
     sv.alwayscomb {
-        sv.bpassign %15, %9 : i5
-        sv.bpassign %16, %10 : i1
-        sv.bpassign %17, %11 : i7
-        sv.bpassign %18, %10 : i1
-        sv.bpassign %19, %12 : i5
+        sv.bpassign %21, %9 : i5
+        sv.bpassign %30, %12 : i1
+        sv.bpassign %31, %11 : i7
+        sv.bpassign %24, %12 : i1
+        sv.bpassign %25, %13 : i5
+        sv.bpassign %30, %12 : i1
+        sv.bpassign %31, %14 : i7
         sv.if %en0 {
-            sv.bpassign %15, %addr0 : i5
-            sv.bpassign %16, %data0_x : i1
-            sv.bpassign %17, %data0_y : i7
-            sv.bpassign %18, %0 : i1
-            sv.bpassign %19, %addr1 : i5
-            sv.bpassign %20, %6 : i1
-            sv.bpassign %21, %7 : i7
+            sv.bpassign %21, %addr0 : i5
+            sv.bpassign %24, %0 : i1
+            sv.bpassign %25, %addr1 : i5
+            sv.bpassign %28, %6 : i1
+            sv.bpassign %29, %7 : i7
+            sv.bpassign %30, %data0_x : i1
+            sv.bpassign %31, %data0_y : i7
         } else {
             sv.if %en1 {
-                sv.bpassign %15, %addr1 : i5
-                sv.bpassign %16, %data1_x : i1
-                sv.bpassign %17, %data1_y : i7
-                sv.bpassign %18, %0 : i1
-                sv.bpassign %19, %addr0 : i5
-                sv.bpassign %20, %6 : i1
-                sv.bpassign %21, %7 : i7
+                sv.bpassign %21, %addr1 : i5
+                sv.bpassign %24, %0 : i1
+                sv.bpassign %25, %addr0 : i5
+                sv.bpassign %28, %6 : i1
+                sv.bpassign %29, %7 : i7
+                sv.bpassign %30, %data1_x : i1
+                sv.bpassign %31, %data1_y : i7
             } else {
-                sv.bpassign %20, %0 : i1
-                sv.bpassign %21, %8 : i7
+                sv.bpassign %28, %0 : i1
+                sv.bpassign %29, %8 : i7
             }
         }
     }
-    hw.output %13, %14 : i1, i7
+    hw.output %19, %20 : i1, i7
 }

--- a/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
+++ b/tests/gold/test_when_nested_Array2_AnonProductxBit_yBits2_Bit.mlir
@@ -1,27 +1,35 @@
 hw.module @test_when_nested_Array2_AnonProductxBit_yBits2_Bit(%I_0_0_x: i1, %I_0_0_y: i2, %I_0_1_x: i1, %I_0_1_y: i2, %I_1_0_x: i1, %I_1_0_y: i2, %I_1_1_x: i1, %I_1_1_y: i2, %S: i1) -> (O_0_x: i1, O_0_y: i2, O_1_x: i1, O_1_y: i2) {
-    %4 = sv.reg : !hw.inout<i1>
-    %0 = sv.read_inout %4 : !hw.inout<i1>
-    %5 = sv.reg : !hw.inout<i2>
-    %1 = sv.read_inout %5 : !hw.inout<i2>
-    %6 = sv.reg : !hw.inout<i1>
-    %2 = sv.read_inout %6 : !hw.inout<i1>
-    %7 = sv.reg : !hw.inout<i2>
-    %3 = sv.read_inout %7 : !hw.inout<i2>
+    %8 = sv.reg : !hw.inout<i1>
+    %0 = sv.read_inout %8 : !hw.inout<i1>
+    %9 = sv.reg : !hw.inout<i2>
+    %1 = sv.read_inout %9 : !hw.inout<i2>
+    %10 = sv.reg : !hw.inout<i1>
+    %2 = sv.read_inout %10 : !hw.inout<i1>
+    %11 = sv.reg : !hw.inout<i2>
+    %3 = sv.read_inout %11 : !hw.inout<i2>
+    %12 = sv.reg : !hw.inout<i1>
+    %4 = sv.read_inout %12 : !hw.inout<i1>
+    %13 = sv.reg : !hw.inout<i2>
+    %5 = sv.read_inout %13 : !hw.inout<i2>
+    %14 = sv.reg : !hw.inout<i1>
+    %6 = sv.read_inout %14 : !hw.inout<i1>
+    %15 = sv.reg : !hw.inout<i2>
+    %7 = sv.read_inout %15 : !hw.inout<i2>
     sv.alwayscomb {
-        sv.bpassign %4, %I_1_0_x : i1
-        sv.bpassign %5, %I_1_0_y : i2
-        sv.bpassign %6, %I_1_1_x : i1
-        sv.bpassign %7, %I_1_1_y : i2
-        sv.bpassign %4, %I_1_0_x : i1
-        sv.bpassign %5, %I_1_0_y : i2
-        sv.bpassign %6, %I_1_1_x : i1
-        sv.bpassign %7, %I_1_1_y : i2
+        sv.bpassign %12, %I_1_0_x : i1
+        sv.bpassign %13, %I_1_0_y : i2
+        sv.bpassign %14, %I_1_1_x : i1
+        sv.bpassign %15, %I_1_1_y : i2
+        sv.bpassign %12, %I_1_0_x : i1
+        sv.bpassign %13, %I_1_0_y : i2
+        sv.bpassign %14, %I_1_1_x : i1
+        sv.bpassign %15, %I_1_1_y : i2
         sv.if %S {
-            sv.bpassign %4, %I_0_0_x : i1
-            sv.bpassign %5, %I_0_0_y : i2
-            sv.bpassign %6, %I_0_1_x : i1
-            sv.bpassign %7, %I_0_1_y : i2
+            sv.bpassign %12, %I_0_0_x : i1
+            sv.bpassign %13, %I_0_0_y : i2
+            sv.bpassign %14, %I_0_1_x : i1
+            sv.bpassign %15, %I_0_1_y : i2
         }
     }
-    hw.output %0, %1, %2, %3 : i1, i2, i1, i2
+    hw.output %4, %5, %6, %7 : i1, i2, i1, i2
 }

--- a/tests/test_syntax/test_to_verilog.py
+++ b/tests/test_syntax/test_to_verilog.py
@@ -10,8 +10,6 @@ import pytest
 pytest.skip("Kratos failure", allow_module_level=True)
 
 
-pytest.skip("error in kratos")
-
 class SimpleALU(m.Circuit):
     io = m.IO(a=m.In(m.UInt[16]), b=m.In(m.UInt[16]),
               c=m.Out(m.UInt[16]), config_=m.In(m.Bits[2]))

--- a/tests/test_syntax/test_to_verilog.py
+++ b/tests/test_syntax/test_to_verilog.py
@@ -1,3 +1,4 @@
+import pytest
 import magma as m
 from magma.testing import check_files_equal
 import hwtypes
@@ -29,6 +30,7 @@ class SimpleALU(m.Circuit):
     io.c <= execute_alu(io.a, io.b, io.config_)
 
 
+@pytest.skip("error in kratos")
 def test_simple_alu():
     inst_to_defn_map = m.syntax.build_kratos_debug_info(SimpleALU, is_top=True)
     assert "SimpleALU.execute_alu_inst0" in inst_to_defn_map

--- a/tests/test_syntax/test_to_verilog.py
+++ b/tests/test_syntax/test_to_verilog.py
@@ -10,6 +10,8 @@ import pytest
 pytest.skip("Kratos failure", allow_module_level=True)
 
 
+pytest.skip("error in kratos")
+
 class SimpleALU(m.Circuit):
     io = m.IO(a=m.In(m.UInt[16]), b=m.In(m.UInt[16]),
               c=m.Out(m.UInt[16]), config_=m.In(m.Bits[2]))
@@ -30,7 +32,6 @@ class SimpleALU(m.Circuit):
     io.c <= execute_alu(io.a, io.b, io.config_)
 
 
-@pytest.skip("error in kratos")
 def test_simple_alu():
     inst_to_defn_map = m.syntax.build_kratos_debug_info(SimpleALU, is_top=True)
     assert "SimpleALU.execute_alu_inst0" in inst_to_defn_map

--- a/tests/test_type/gold/test_sum_basic.mlir
+++ b/tests/test_type/gold/test_sum_basic.mlir
@@ -1,0 +1,68 @@
+hw.module @Foo(%I0_tag: i1, %I0_data: i2, %I1: i2) -> (O0_tag: i1, O0_data: i2, O1: i2, O2_tag: i1, O2_data: i2) {
+    %0 = hw.constant 0 : i1
+    %1 = comb.icmp eq %I0_tag, %0 : i1
+    %2 = hw.constant 0 : i1
+    %3 = comb.extract %I0_data from 0 : (i2) -> i1
+    %5 = hw.constant -1 : i1
+    %4 = comb.xor %5, %3 : i1
+    %6 = hw.constant 0 : i1
+    %7 = hw.constant 0 : i1
+    %8 = comb.extract %I1 from 1 : (i2) -> i1
+    %9 = comb.extract %I1 from 0 : (i2) -> i1
+    %10 = comb.xor %8, %9 : i1
+    %11 = hw.constant 1 : i1
+    %12 = hw.constant 3 : i2
+    %13 = comb.xor %I0_data, %12 : i2
+    %14 = comb.extract %13 from 0 : (i2) -> i1
+    %15 = comb.extract %13 from 1 : (i2) -> i1
+    %16 = hw.constant 1 : i2
+    %17 = comb.and %I0_data, %16 : i2
+    %18 = comb.extract %17 from 0 : (i2) -> i1
+    %19 = comb.extract %17 from 1 : (i2) -> i1
+    %20 = hw.constant 1 : i1
+    %21 = hw.constant 2 : i2
+    %22 = comb.or %I1, %21 : i2
+    %23 = comb.extract %22 from 0 : (i2) -> i1
+    %24 = comb.extract %22 from 1 : (i2) -> i1
+    %33 = sv.reg : !hw.inout<i1>
+    %25 = sv.read_inout %33 : !hw.inout<i1>
+    %34 = sv.reg : !hw.inout<i1>
+    %26 = sv.read_inout %34 : !hw.inout<i1>
+    %35 = sv.reg : !hw.inout<i1>
+    %27 = sv.read_inout %35 : !hw.inout<i1>
+    %36 = sv.reg : !hw.inout<i1>
+    %28 = sv.read_inout %36 : !hw.inout<i1>
+    %37 = sv.reg : !hw.inout<i1>
+    %29 = sv.read_inout %37 : !hw.inout<i1>
+    %38 = sv.reg : !hw.inout<i1>
+    %30 = sv.read_inout %38 : !hw.inout<i1>
+    %39 = sv.reg : !hw.inout<i1>
+    %31 = sv.read_inout %39 : !hw.inout<i1>
+    %40 = sv.reg : !hw.inout<i1>
+    %32 = sv.read_inout %40 : !hw.inout<i1>
+    sv.alwayscomb {
+        sv.if %1 {
+            sv.bpassign %33, %2 : i1
+            sv.bpassign %34, %4 : i1
+            sv.bpassign %35, %6 : i1
+            sv.bpassign %36, %3 : i1
+            sv.bpassign %37, %6 : i1
+            sv.bpassign %38, %7 : i1
+            sv.bpassign %39, %10 : i1
+            sv.bpassign %40, %6 : i1
+        } else {
+            sv.bpassign %33, %11 : i1
+            sv.bpassign %34, %14 : i1
+            sv.bpassign %35, %15 : i1
+            sv.bpassign %36, %18 : i1
+            sv.bpassign %37, %19 : i1
+            sv.bpassign %38, %20 : i1
+            sv.bpassign %39, %23 : i1
+            sv.bpassign %40, %24 : i1
+        }
+    }
+    %41 = comb.concat %27, %26 : i1, i1
+    %42 = comb.concat %29, %28 : i1, i1
+    %43 = comb.concat %32, %31 : i1, i1
+    hw.output %25, %41, %42, %30, %43 : i1, i2, i2, i1, i2
+}

--- a/tests/test_type/test_sum.py
+++ b/tests/test_type/test_sum.py
@@ -1,0 +1,32 @@
+import magma as m
+from magma.testing.utils import check_gold
+
+
+def test_sum_basic():
+    class T(m.Sum):
+        x = m.Bit
+        y = m.Bits[2]
+
+    class Foo(m.Circuit):
+        io = m.IO(
+            I0=m.In(T),
+            I1=m.In(m.Bits[2]),
+            O0=m.Out(T),
+            O1=m.Out(m.Bits[2]),
+            O2=m.Out(T)
+        )
+        with m.match(io.I0):
+            with m.case(T.x):
+                io.O0 @= ~io.I0               # sum  @= sum
+                io.O1 @= m.bits(io.I0, 2)     # bits @= sum
+                io.O2 @= io.I1[1] ^ io.I1[0]  # sum  @= bits
+            with m.case(T.y):
+                io.O0 @= io.I0 ^ 0b11  # sum  @= sum
+                io.O1 @= io.I0 & 0b01  # bits @= sum
+                io.O2 @= io.I1 | 0b10  # sum  @= bits
+
+    m.compile("build/test_sum_basic", Foo, output="mlir",
+              flatten_all_tuples=True)
+    assert check_gold(__file__, "test_sum_basic.mlir")
+
+    # TODO: fault support for sum

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -166,7 +166,7 @@ def test_wire():
     assert t1.value() is t0
     assert t0.value() is t1
 
-    assert t0.driving() == dict(x=[t1.x], y=[t1.y])
+    assert t0.driving() == [t1]
 
     b0 = t0.x
     b1 = t1.x

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -795,3 +795,22 @@ def test_when_lazy_array_slice_overlap(caplog):
 
     m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_lazy_array_multiple_whens(caplog):
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_multiple_whens"
+        io = m.IO(I=m.In(m.Bits[4]), S=m.In(m.Bit), O=m.Out(m.Bits[4]))
+
+        with m.when(io.S):
+            io.O @= io.I
+        with m.otherwise():
+            io.O[:2] @= io.I[2:]
+            io.O[2:] @= io.I[:2]
+
+        with m.when(~io.S):
+            io.O @= io.I
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
+    assert check_gold(__file__, f"{_Test.name}.mlir")

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -777,5 +777,21 @@ def test_when_lazy_array_slice_driving_resolve_2(caplog):
         io.I[0]  # triggers driving bulk wire logic
         x[-1] @= io.I[0]  # triggers driving bulk wire logic
 
-    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_lazy_array_slice_overlap(caplog):
+
+    class _Test(m.Circuit):
+        name = "test_when_lazy_array_slice_overlap"
+        io = m.IO(I=m.In(m.Bits[4]), S=m.In(m.Bit), O=m.Out(m.Bits[4]))
+
+        with m.when(io.S):
+            io.O @= io.I
+        with m.otherwise():
+            io.O[:2] @= io.I[2:]
+            io.O[2:] @= io.I[:2]
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -812,5 +812,5 @@ def test_when_lazy_array_multiple_whens(caplog):
         with m.when(~io.S):
             io.O @= io.I
 
-    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")

--- a/tests/test_wire/test_unwire.py
+++ b/tests/test_wire/test_unwire.py
@@ -40,10 +40,4 @@ def test_unwire_undriven(T, func, caplog):
 >>     lambda x, y: x.unwire(), lambda x, y: m.unwire(x)\
 """  # noqa
 
-    if T is Ts[2]:
-        # Tuple recurses by default
-        # TODO: Update this when we finish Tuple2
-        for i in range(len(T)):
-            assert has_warning(caplog, make_expcted_log(f"Foo[{i}]"))
-    else:
-        assert has_warning(caplog, make_expcted_log("Foo"))
+    assert has_warning(caplog, make_expcted_log("Foo"))


### PR DESCRIPTION
Checking in a prototype implementation of the sum type, this isn't quite ready for widespread use, but I would like to it to be in the CI flow since it depends on the when logic.  Also, I think it's been sufficiently pushed through to get a review on the overall architecture and make some early decisions, e.g.:
(1) match, case context manager patterns (dispatching to when)
(2) stateful interpretation of the sum value based on the active context (the alternative is to use a named reference, e.g. `io.I.x`, to retrieve the interpreted value, but we'd still want to check the active context to verify that it's a legal reference, so if we're maintaining that state anyways it seems useful to the user to just have it interpreted correctly for them
