### PR TITLE
[Types] Fix rebase bug in aggregate wireables

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -626,9 +626,6 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
     @debug_unwire
     @aggregate_wireable_method
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
-        if not self._has_elaborated_children():
-            return AggregateWireable.unwire(self, o, debug_info,
-                                            keep_wired_when_contexts)
         for i, child in self._enumerate_children():
             o_i = None if o is None else o[i]
             child.unwire(o_i, debug_info=debug_info,

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -342,9 +342,16 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
     @debug_unwire
     @aggregate_wireable_method
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
-        if not self._has_elaborated_children():
-            return AggregateWireable.unwire(self, o, debug_info,
-                                            keep_wired_when_contexts)
+        for k, t in self.items():
+            if o is None:
+                t.unwire(debug_info=debug_info,
+                         keep_wired_when_contexts=keep_wired_when_contexts)
+            elif o[k].is_input():
+                o[k].unwire(t, debug_info=debug_info,
+                            keep_wired_when_contexts=keep_wired_when_contexts)
+            else:
+                t.unwire(o[k], debug_info=debug_info,
+                         keep_wired_when_contexts=keep_wired_when_contexts)
 
     @aggregate_wireable_method
     def driven(self):

--- a/tests/test_aggregate_wireable.py
+++ b/tests/test_aggregate_wireable.py
@@ -1,0 +1,18 @@
+import pytest
+import magma as m
+
+
+@pytest.mark.parametrize('T', [m.Bits[8], m.Tuple[m.Bit, m.Bits[8]]])
+def test_aggregate_wireable_unwire(T):
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(T), O=m.Out(T))
+        io.O @= io.I
+        assert io.O.value() is io.I
+        io.O.unwire(io.I)
+        assert io.O.value() is None
+
+        io.O @= io.I
+        io.O[0]  # Trigger elaboration
+        assert io.O.value() is io.I
+        io.O.unwire(io.I)
+        assert io.O.value() is None


### PR DESCRIPTION
I chose the wrong changes for these functions when rebasing the tuple2 code.  With the aggregate_wireable_method decorator, they only need to implement the logic for when children are elaborated (the decorator calls the aggregate method if the has_elaborated_children check fails). This didn't trigger a CI bug because when unwire fails, it just raises a warning (e.g. driving an already driven value) that occurs silently in the passing tests.  Adds a test to cover this case.