### PR TITLE
[Types] Use AggregateWireable API to avoid elaboration

### DIFF
--- a/magma/array.py
+++ b/magma/array.py
@@ -606,8 +606,8 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
 
     def _should_wire_children(self, o):
         return (
-            self._has_elaborated_children() or
-            o._has_elaborated_children() or
+            self.has_elaborated_children() or
+            o.has_elaborated_children() or
             self.T.is_mixed()
         )
 
@@ -635,12 +635,12 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
                          keep_wired_when_contexts=keep_wired_when_contexts)
 
     def iswhole(self):
-        if self._has_elaborated_children():
+        if self.has_elaborated_children():
             return Array._iswhole(self._collect_children(lambda x: x))
         return True
 
     def const(self):
-        if self._has_elaborated_children():
+        if self.has_elaborated_children():
             return all(child.const()
                        for _, child in self._enumerate_children())
         return False
@@ -846,7 +846,7 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
         return ts
 
     def __repr__(self):
-        if self.name.anon() and self._has_elaborated_children():
+        if self.name.anon() and self.has_elaborated_children():
             t_strs = ', '.join(repr(t) for t in self.ts)
             return f'array([{t_strs}])'
         return Type.__repr__(self)
@@ -890,7 +890,7 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
 
         return T
 
-    def _has_elaborated_children(self):
+    def has_elaborated_children(self):
         return bool(self._ts) or bool(self._slices)
 
     @aggregate_wireable_method

--- a/magma/array.py
+++ b/magma/array.py
@@ -626,7 +626,7 @@ class Array(Type, AggregateWireable, metaclass=ArrayMeta):
     @debug_unwire
     @aggregate_wireable_method
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
-        if not self._has_elaborated_children():
+        if not self.has_elaborated_children():
             return AggregateWireable.unwire(self, o, debug_info,
                                             keep_wired_when_contexts)
         for i, child in self._enumerate_children():

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -266,7 +266,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
         value.set_enclosing_when_context(self._enclosing_when_context)
         return value
 
-    def _has_elaborated_children(self):
+    def has_elaborated_children(self):
         return bool(self._ts)
 
     def _enumerate_children(self):
@@ -330,8 +330,8 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
             )
             return
         if (self.is_mixed() or
-                self._has_elaborated_children() or
-                o._has_elaborated_children()):
+                self.has_elaborated_children() or
+                o.has_elaborated_children()):
             for self_elem, o_elem in zip(self, o):
                 self_elem = magma_value(self_elem)
                 o_elem = magma_value(o_elem)

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -342,7 +342,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
     @debug_unwire
     @aggregate_wireable_method
     def unwire(self, o=None, debug_info=None, keep_wired_when_contexts=False):
-        if not self._has_elaborated_children():
+        if not self.has_elaborated_children():
             return AggregateWireable.unwire(self, o, debug_info,
                                             keep_wired_when_contexts)
 

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -247,7 +247,7 @@ class Wireable:
 
 class AggregateWireable(Wireable):
     @abc.abstractmethod
-    def _has_elaborated_children(self):
+    def has_elaborated_children(self):
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -336,7 +336,7 @@ def aggregate_wireable_method(fn):
 
     @functools.wraps(fn)
     def wrapper(self, *args, **kwargs):
-        if self._has_elaborated_children():
+        if self.has_elaborated_children():
             return fn(self, *args, **kwargs)
         wireable_fn = getattr(AggregateWireable, fn.__name__)
         return wireable_fn(self, *args, **kwargs)

--- a/tests/test_smart/test_smart_bits.py
+++ b/tests/test_smart/test_smart_bits.py
@@ -71,6 +71,7 @@ def test_binop():
             O3=m.Out(m.UInt[16]))
         O1 = m.UInt[8]()
         O1 @= op(m.zext_to(io.I0, 12), io.I1)[:8]
+        O1[0]  # force elaboration for repr test
         io.O1 @= O1
         io.O2 @= op(m.zext_to(io.I0, 12), io.I1)
         io.O3 @= op(m.zext_to(io.I0, 16), m.zext_to(io.I1, 16))
@@ -162,6 +163,7 @@ def test_rshift():
             O3=m.Out(m.UInt[16]))
         O1 = m.UInt[4]()
         O1 @= (io.I0 >> m.zext_to(io.I1, 8))[:4]
+        O1[0]  # force elaboration for repr test
         io.O1 @= O1
         io.O2 @= m.zext_to(io.I0 >> m.zext_to(io.I1, 8), 8)
         O3 = m.UInt[16]()
@@ -227,6 +229,7 @@ def test_unary():
             O2=m.Out(m.UInt[16]))
         O1 = m.UInt[4]()
         O1 @= op(io.I0)[:4]
+        O1[0]  # force elaboration for repr test
         io.O1 @= O1
         io.O2 @= op(m.zext_to(io.I0, 16))
 


### PR DESCRIPTION
Some cases in the repr and insert_wrap_casts logic were unnecessarily expanding arrays.  This updates the logic to avoid elaboration when possible, also updating it to use the AggregateWireable API.

Some of the smart_bits tests relied on this elaboration for checking the repr of two circutis, so some code has been added there to force elaboration so the repr works.