### PR TITLE
[Primitives] Add default=None for list_lookup

### DIFF
--- a/magma/primitives/mux.py
+++ b/magma/primitives/mux.py
@@ -185,15 +185,18 @@ def dict_lookup(dict_, select, default=0):
     return output
 
 
-def list_lookup(list_, select, default=0):
+def list_lookup(list_, select, default=None):
     """
     Use `select` as an index into `list` (similar to a case statement)
 
     `default` is used when `select` does not match any of the indices (e.g.
-    when the select width is longer than the list) and has a default value of
-    0.
+    when the select width is longer than the list).  If it is `None`, the last
+    element of the list will be used.
     """
     output = default
-    for i, elem in enumerate(list_):
-        output = mux([output, elem], i == select)
+    if default is None:
+        output = list_[-1]
+        list_ = list_[:-1]
+    for i in range(len(list_) - 1, -1, -1):
+        output = mux([output, list_[i]], i == select)
     return output

--- a/magma/primitives/mux.py
+++ b/magma/primitives/mux.py
@@ -197,6 +197,8 @@ def list_lookup(list_, select, default=None):
     if default is None:
         output = list_[-1]
         list_ = list_[:-1]
+    # We chain the muxes in reverse order so that the emitted Verilog is in
+    # forward order.
     for i in range(len(list_) - 1, -1, -1):
         output = mux([output, list_[i]], i == select)
     return output

--- a/tests/test_primitives/gold/test_mux_list_lookup_default_none.mlir
+++ b/tests/test_primitives/gold/test_mux_list_lookup_default_none.mlir
@@ -1,0 +1,14 @@
+hw.module @test_mux_list_lookup_default_none(%S: i2) -> (O: i5) {
+    %0 = hw.constant 2 : i5
+    %1 = hw.constant 1 : i5
+    %2 = hw.constant 1 : i2
+    %3 = comb.icmp eq %S, %2 : i2
+    %5 = hw.array_create %1, %0 : i5
+    %4 = hw.array_get %5[%3] : !hw.array<2xi5>
+    %6 = hw.constant 0 : i5
+    %7 = hw.constant 0 : i2
+    %8 = comb.icmp eq %S, %7 : i2
+    %10 = hw.array_create %6, %4 : i5
+    %9 = hw.array_get %10[%8] : !hw.array<2xi5>
+    hw.output %9 : i5
+}


### PR DESCRIPTION
Rather than use an explicit default value as the standard pattern, it makes more sense to use the final element of the list since we're buildling a mux tree anyways.  The existing explicit "default" value pattern might still be useful to emulate a certain "else" pattern that's different than the last element.

In adding this, I noticed the mux tree was being built forwards, which made the generated code a bit convoluted for this default case, so I reversed the tree instead to make it look more natural in the generated code.