### PR TITLE
[Types] Fix non-terminating recursion in bulk wiring logic

### DIFF
--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -319,15 +319,6 @@ class AggregateWireable(Wireable):
             for i, child in self._enumerate_children():
                 child.wire(value[i])
 
-    def _resolve_driving_bulk_wire(self):
-        driving = self._wire.driving()
-        for drivee in driving:
-            # Force drivee to resolve by triggering the
-            # _resolve_driven_bulk_wire logic which occurs when referencing a
-            # child which begins the elaboration process.  Using this pattern
-            # avoids having to duplicate the logic for driving/driven
-            next(iter(drivee))
-
     def _resolve_bulk_wire(self):
         """
         If a child reference is made, we "expand" a bulk wire into the

--- a/tests/test_aggregate_wireable.py
+++ b/tests/test_aggregate_wireable.py
@@ -16,3 +16,24 @@ def test_aggregate_wireable_unwire(T):
         assert io.O.value() is io.I
         io.O.unwire(io.I)
         assert io.O.value() is None
+
+
+@pytest.mark.skip("Slow test should only be run if needed")
+def test_aggregate_wireable_recursion_error():
+    class T(m.Product):
+        x = m.Array[2, m.Bits[8]]
+        y = m.Bit
+
+    class Foo(m.Circuit):
+        T = m.Array[1024, m.Bits[8]]
+        io = m.IO(I=m.In(T), O=m.Out(T), S=m.In(m.Bit))
+        x = io.I
+        for i in range(256):
+            prev = x
+            x = T(name=f"asdf{i}")
+            x @= prev
+        io.O @= x
+
+    repr(Foo)
+
+    m.compile("build/Foo", Foo, output="mlir-verilog")


### PR DESCRIPTION
For sufficiently complex wirings (e.g. long chains or large flattened types with multi level fan out chains) the recursive wire resolution logic would hit a RecursionError.  We can avoid this using an iteration approach:
(1) trace to the source value, initialize a worklist (2) until worklist is empty, for each item add the values it is driving
    to the worklist, then resolve the value

Note, to avoid loops in the resolve logic, we mark a values with a flag noting whether they should be resolved.  By default, all values should be resolved, but once they are being resolved, they shouldn't resolve again.  This avoids ping ponging between the resolution logic of two values when wiring up the children.