### PR TITLE
[MLIR] Finalize whens last

### DIFF
--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -45,7 +45,6 @@ class MlirCompiler(Compiler):
         insert_coreir_wires(self.main)
         insert_wrap_casts(self.main)
         wire_clocks(self.main)
-
         # NOTE(leonardt): finalizing whens must happen after any
         # passes that modify the circuit.  This is because passes
         # could introduce more conditional logic, or they could

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -39,18 +39,19 @@ class MlirCompiler(Compiler):
         return "mlir"
 
     def _run_passes(self):
-        # NOTE(leonardt): We elaborate tuples before finalizing when statements
-        # because they may cause array expansion (e.g. when we have an array of
-        # tuples).  If we remove the flatten_all_tuples requirement, we may
-        # finalize when earlier, but then we may still need this code path as
-        # an option.
         if self.opts.get("flatten_all_tuples", False):
             elaborate_tuples(self.main)
-        finalize_whens(self.main)
 
         insert_coreir_wires(self.main)
         insert_wrap_casts(self.main)
         wire_clocks(self.main)
+
+        # NOTE(leonardt): finalizing whens must happen after any
+        # passes that modify the circuit.  This is because passes
+        # could introduce more conditional logic, or they could
+        # trigger elaboration on values used in existing coditiona
+        # logic (which modifies the when builder)
+        finalize_whens(self.main)
         raise_logs_as_exceptions_pass(self.main)
 
     def compile(self):

--- a/tests/test_backend/test_mlir/build/.gitignore
+++ b/tests/test_backend/test_mlir/build/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+*

--- a/tests/test_backend/test_mlir/examples.py
+++ b/tests/test_backend/test_mlir/examples.py
@@ -535,3 +535,15 @@ class simple_array_slice(m.Circuit):
     T = m.Bits[8]
     io = m.IO(a=m.In(m.Array[12, T]), y=m.Out(m.Array[4, T]))
     io.y @= io.a[:4]
+
+
+class complex_when_lazy_tuple(m.Circuit):
+    T = m.Tuple[m.Bit, m.Bits[8]]
+    io = m.IO(I0=m.In(T), I1=m.In(T), S=m.In(m.Bit), O=m.Out(T))
+    x = T(name="x")
+    with m.when(io.S):
+        x @= io.I0
+    with m.otherwise():
+        x @= io.I1
+
+    io.O @= x

--- a/tests/test_backend/test_mlir/test_mlir_compiler.py
+++ b/tests/test_backend/test_mlir/test_mlir_compiler.py
@@ -1,0 +1,17 @@
+import magma as m
+
+
+def test_mlir_compiler_finalize_when_order():
+    T = m.Tuple[m.Bit, m.Bits[8]]
+
+    class Foo(m.Circuit):
+        io = m.IO(I0=m.In(T), I1=m.In(T), S=m.In(m.Bit), O=m.Out(T))
+        x = T(name="x")
+        with m.when(io.S):
+            x @= io.I0
+        with m.otherwise():
+            x @= io.I1
+
+        io.O @= x
+
+    m.compile("build/Foo", Foo, output="mlir")

--- a/tests/test_backend/test_mlir/test_mlir_compiler.py
+++ b/tests/test_backend/test_mlir/test_mlir_compiler.py
@@ -3,5 +3,8 @@ from examples import complex_when_lazy_tuple
 
 
 def test_mlir_compiler_finalize_when_order():
-    m.compile("build/complex_when_lazy_tuple", complex_when_lazy_tuple,
-              output="mlir")
+    m.compile(
+        "build/complex_when_lazy_tuple",
+        complex_when_lazy_tuple,
+        output="mlir",
+    )

--- a/tests/test_backend/test_mlir/test_mlir_compiler.py
+++ b/tests/test_backend/test_mlir/test_mlir_compiler.py
@@ -1,4 +1,5 @@
 import magma as m
+
 from examples import complex_when_lazy_tuple
 
 

--- a/tests/test_backend/test_mlir/test_mlir_compiler.py
+++ b/tests/test_backend/test_mlir/test_mlir_compiler.py
@@ -1,11 +1,13 @@
+import tempfile
 import magma as m
 
 from examples import complex_when_lazy_tuple
 
 
 def test_mlir_compiler_finalize_when_order():
-    m.compile(
-        "build/complex_when_lazy_tuple",
-        complex_when_lazy_tuple,
-        output="mlir",
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        m.compile(
+            f"{tmpdir}/complex_when_lazy_tuple",
+            complex_when_lazy_tuple,
+            output="mlir",
+        )

--- a/tests/test_backend/test_mlir/test_mlir_compiler.py
+++ b/tests/test_backend/test_mlir/test_mlir_compiler.py
@@ -1,17 +1,7 @@
 import magma as m
+from examples import complex_when_lazy_tuple
 
 
 def test_mlir_compiler_finalize_when_order():
-    T = m.Tuple[m.Bit, m.Bits[8]]
-
-    class Foo(m.Circuit):
-        io = m.IO(I0=m.In(T), I1=m.In(T), S=m.In(m.Bit), O=m.Out(T))
-        x = T(name="x")
-        with m.when(io.S):
-            x @= io.I0
-        with m.otherwise():
-            x @= io.I1
-
-        io.O @= x
-
-    m.compile("build/Foo", Foo, output="mlir")
+    m.compile("build/complex_when_lazy_tuple", complex_when_lazy_tuple,
+              output="mlir")

--- a/tests/test_backend/test_mlir/test_utils.py
+++ b/tests/test_backend/test_mlir/test_utils.py
@@ -181,7 +181,7 @@ def get_local_examples() -> List[DefineCircuitKind]:
         examples.simple_memory_wrapper,
         examples.simple_undriven_instances,
         examples.simple_neg,
-        examples.simple_array_slice,
+        examples.simple_array_slice
     ]
 
 

--- a/tests/test_backend/test_mlir/test_utils.py
+++ b/tests/test_backend/test_mlir/test_utils.py
@@ -181,7 +181,7 @@ def get_local_examples() -> List[DefineCircuitKind]:
         examples.simple_memory_wrapper,
         examples.simple_undriven_instances,
         examples.simple_neg,
-        examples.simple_array_slice
+        examples.simple_array_slice,
     ]
 
 

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -485,7 +485,7 @@ def test_internal_instantiation():
     assert check_gold(__file__, f"{basename}.mlir")
 
 
-@pytest.mark.skip("There's a bug in this test")
+@pytest.mark.skip("Test does not pass due to when issue (#1156)")
 def test_internal_instantiation_complex():
 
     class _Test(m.Circuit):

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -485,6 +485,7 @@ def test_internal_instantiation():
     assert check_gold(__file__, f"{basename}.mlir")
 
 
+@pytest.mark.skip("There's a bug in this test")
 def test_internal_instantiation_complex():
 
     class _Test(m.Circuit):


### PR DESCRIPTION
Then when finalize must occur after any passes that modify the circuit

e.g. `insert_coreir_wires` could flatten a value used in the conditional logic, which then requires updating the when builder instance