### PR TITLE
[When] Support clock enable registers

### DIFF
--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -185,6 +185,7 @@ class Register(Generator2):
                            has_async_resetn=has_async_resetn,
                            has_reset=has_reset,
                            has_resetn=has_resetn)
+        self.ce_name = CE_name
         if init is None:
             init = 0
 

--- a/tests/gold/test_when_reg_ce.mlir
+++ b/tests/gold/test_when_reg_ce.mlir
@@ -1,0 +1,30 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @test_when_reg_ce(%I: i8, %CE: i1, %CLK: i1) -> (O: i8) {
+        %0 = hw.constant 1 : i1
+        %1 = hw.constant 0 : i1
+        %5 = sv.reg : !hw.inout<i8>
+        %3 = sv.read_inout %5 : !hw.inout<i8>
+        %6 = sv.reg : !hw.inout<i1>
+        %4 = sv.read_inout %6 : !hw.inout<i1>
+        sv.alwayscomb {
+            sv.bpassign %5, %2 : i8
+            sv.bpassign %6, %1 : i1
+            sv.if %CE {
+                sv.bpassign %5, %I : i8
+                sv.bpassign %6, %0 : i1
+            }
+        }
+        %7 = sv.reg {name = "Register_inst0"} : !hw.inout<i8>
+        sv.alwaysff(posedge %CLK) {
+            sv.if %4 {
+                sv.passign %7, %3 : i8
+            }
+        }
+        %8 = hw.constant 0 : i8
+        sv.initial {
+            sv.bpassign %7, %8 : i8
+        }
+        %2 = sv.read_inout %7 : !hw.inout<i8>
+        hw.output %2 : i8
+    }
+}

--- a/tests/gold/test_when_reg_ce_multiple.mlir
+++ b/tests/gold/test_when_reg_ce_multiple.mlir
@@ -1,0 +1,39 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @test_when_reg_ce_multiple(%I: i8, %CE: i2, %CLK: i1) -> (O: i8) {
+        %0 = comb.extract %CE from 0 : (i2) -> i1
+        %1 = hw.constant 1 : i1
+        %2 = comb.extract %CE from 1 : (i2) -> i1
+        %4 = hw.constant -1 : i8
+        %3 = comb.xor %4, %I : i8
+        %5 = hw.constant 0 : i1
+        %9 = sv.reg : !hw.inout<i8>
+        %7 = sv.read_inout %9 : !hw.inout<i8>
+        %10 = sv.reg : !hw.inout<i1>
+        %8 = sv.read_inout %10 : !hw.inout<i1>
+        sv.alwayscomb {
+            sv.bpassign %9, %6 : i8
+            sv.bpassign %10, %5 : i1
+            sv.if %0 {
+                sv.bpassign %9, %I : i8
+                sv.bpassign %10, %1 : i1
+            } else {
+                sv.if %2 {
+                    sv.bpassign %9, %3 : i8
+                    sv.bpassign %10, %1 : i1
+                }
+            }
+        }
+        %11 = sv.reg {name = "Register_inst0"} : !hw.inout<i8>
+        sv.alwaysff(posedge %CLK) {
+            sv.if %8 {
+                sv.passign %11, %7 : i8
+            }
+        }
+        %12 = hw.constant 0 : i8
+        sv.initial {
+            sv.bpassign %11, %12 : i8
+        }
+        %6 = sv.read_inout %11 : !hw.inout<i8>
+        hw.output %6 : i8
+    }
+}

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -814,3 +814,36 @@ def test_when_lazy_array_multiple_whens(caplog):
 
     m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_reg_ce():
+    class _Test(m.Circuit):
+        name = "test_when_reg_ce"
+        io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8]),
+                  CE=m.In(m.Bit))
+
+        x = m.Register(m.Bits[8], has_enable=True)()
+        with m.when(io.CE):
+            x.I @= io.I
+        io.O @= x.O
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_when_reg_ce_multiple():
+    class _Test(m.Circuit):
+        name = "test_when_reg_ce_multiple"
+        io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8]),
+                  CE=m.In(m.Bits[2]))
+
+        x = m.Register(m.Bits[8], has_enable=True)()
+        with m.when(io.CE[0]):
+            x.I @= io.I
+        with m.elsewhen(io.CE[1]):
+            x.I @= ~io.I
+
+        io.O @= x.O
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")


### PR DESCRIPTION
Some important choices detailed in the comments.

General architecture: when exiting a when block, we check the conditional wires to see if any correspond to driving a register input, if one is found, we check the register to see if it has an enable port, if so, we wire the enable to one.  In the backend, we extend the register default value logic to include enable ports with a default of False.

There's a few considerations made here:
* The enable logic assumes the user does not explicitly wire enable, and if so the the builtin behavior will override the user choice.  If the user explicitly wires the enable to False inside the when, then this doesn't really make sense because they are wiring a conditional value but they don't want it to update? If the user explicitly wires to True, that's unnecessary since magma will do it, and the warning will indicate that they shouldn't do an explicit wiring, promoting a preferred idiom (no explicit enables inside whens).
* The current pattern assumes the interface of the magma builtin primitive Register (i.e. one input, and one optional enable), in the future we should consider making this interface more general so we can support user defined registers that implement the current interface for providing default update values.