### PR TITLE
[CompileGuard] Avoid name collision in port logic

### DIFF
--- a/magma/compile_guard.py
+++ b/magma/compile_guard.py
@@ -54,8 +54,7 @@ class _Grouper(GrouperBase):
         if T in self._clock_types:
             return  # only add at most one port for each clock type
         self._clock_types.add(T)
-        name = str(port.name)
-        self._builder.add_port(In(T), name=name)
+        self._builder.add_port(In(T))
 
 
 class _CompileGuardBuilder(CircuitBuilder):

--- a/tests/gold/test_compile_guard_anon_driven_internal.mlir
+++ b/tests/gold/test_compile_guard_anon_driven_internal.mlir
@@ -1,12 +1,12 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
-    hw.module @COND_compile_guard(%CLK: i1) -> () {
+    hw.module @COND_compile_guard(%port_0: i1) -> () {
         %1 = sv.wire sym @COND_compile_guard.corebit_undriven_inst0 : !hw.inout<i1>
         %0 = sv.read_inout %1 : !hw.inout<i1>
         %3 = sv.wire sym @COND_compile_guard.x {name="x"} : !hw.inout<i1>
         sv.assign %3, %0 : i1
         %2 = sv.read_inout %3 : !hw.inout<i1>
         %5 = sv.reg {name = "Register_inst0"} : !hw.inout<i1>
-        sv.alwaysff(posedge %CLK) {
+        sv.alwaysff(posedge %port_0) {
             sv.passign %5, %2 : i1
         }
         %6 = hw.constant 0 : i1
@@ -17,7 +17,7 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
     }
     hw.module @_Top(%I: i1, %CLK: i1) -> (O: i1) {
         sv.ifdef "COND" {
-            hw.instance "COND_compile_guard" @COND_compile_guard(CLK: %CLK: i1) -> ()
+            hw.instance "COND_compile_guard" @COND_compile_guard(port_0: %CLK: i1) -> ()
         }
         hw.output %I : i1
     }

--- a/tests/gold/test_compile_guard_anon_driver_driven.v
+++ b/tests/gold/test_compile_guard_anon_driver_driven.v
@@ -36,13 +36,13 @@ endmodule
 
 module A (
     input port_0,
-    input CLK
+    input port_1
 );
 wire Register_inst0_O;
 Register Register_inst0 (
     .I(port_0),
     .O(Register_inst0_O),
-    .CLK(CLK)
+    .CLK(port_1)
 );
 endmodule
 
@@ -53,7 +53,7 @@ module _Top (
 `ifdef COND
 A A (
     .port_0(I),
-    .CLK(CLK)
+    .port_1(CLK)
 );
 `endif
 endmodule

--- a/tests/gold/test_compile_guard_anon_driver_nested_type.v
+++ b/tests/gold/test_compile_guard_anon_driver_nested_type.v
@@ -164,7 +164,7 @@ module A (
     input port_97,
     input port_98,
     input port_99,
-    input CLK
+    input port_100
 );
 wire [9:0] Register_inst0_O_0_x;
 wire [9:0] Register_inst0_O_1_x;
@@ -197,7 +197,7 @@ assign Register_inst0_I_8_x = {port_89,port_88,port_87,port_86,port_85,port_84,p
 wire [9:0] Register_inst0_I_9_x;
 assign Register_inst0_I_9_x = {port_99,port_98,port_97,port_96,port_95,port_94,port_93,port_92,port_91,port_90};
 Register Register_inst0 (
-    .CLK(CLK),
+    .CLK(port_100),
     .I_0_x(Register_inst0_I_0_x),
     .I_1_x(Register_inst0_I_1_x),
     .I_2_x(Register_inst0_I_2_x),
@@ -327,7 +327,7 @@ A A (
     .port_97(I),
     .port_98(I),
     .port_99(I),
-    .CLK(CLK)
+    .port_100(CLK)
 );
 `endif
 endmodule

--- a/tests/gold/test_compile_guard_array.json
+++ b/tests/gold/test_compile_guard_array.json
@@ -5,7 +5,7 @@
       "COND_compile_guard":{
         "type":["Record",[
           ["port_0","BitIn"],
-          ["CLK",["Named","coreir.clkIn"]]
+          ["port_1",["Named","coreir.clkIn"]]
         ]],
         "instances":{
           "Register_inst0":{
@@ -13,7 +13,7 @@
           }
         },
         "connections":[
-          ["self.CLK","Register_inst0.CLK"],
+          ["self.port_1","Register_inst0.CLK"],
           ["self.port_0","Register_inst0.I"]
         ]
       },
@@ -49,8 +49,8 @@
           }
         },
         "connections":[
-          ["self.CLK","COND_compile_guard.CLK"],
           ["self.I.0","COND_compile_guard.port_0"],
+          ["self.CLK","COND_compile_guard.port_1"],
           ["self.O","self.I.1"]
         ]
       }

--- a/tests/gold/test_compile_guard_assert.json
+++ b/tests/gold/test_compile_guard_assert.json
@@ -5,8 +5,8 @@
       "ASSERT_ON_compile_guard":{
         "type":["Record",[
           ["port_0","BitIn"],
-          ["CLK",["Named","coreir.clkIn"]],
-          ["port_1",["Array",4,"BitIn"]]
+          ["port_1",["Named","coreir.clkIn"]],
+          ["port_2",["Array",4,"BitIn"]]
         ]],
         "instances":{
           "ASSERT_ON_compile_guard_inline_verilog_inst_0":{
@@ -55,7 +55,7 @@
         "connections":[
           ["_FAULT_ASSERT_WIRE_0.out","ASSERT_ON_compile_guard_inline_verilog_inst_0.__magma_inline_value_0"],
           ["self.port_0","Register_inst0.CE"],
-          ["self.CLK","Register_inst0.CLK"],
+          ["self.port_1","Register_inst0.CLK"],
           ["magma_UInt_2_add_inst0.out","Register_inst0.I"],
           ["magma_UInt_2_add_inst0.in0","Register_inst0.O"],
           ["magma_UInt_2_eq_inst0.in0","Register_inst0.O"],
@@ -66,7 +66,7 @@
           ["magma_UInt_2_eq_inst0.out","magma_Bit_not_inst0.in"],
           ["magma_Bit_or_inst0.in0","magma_Bit_not_inst0.out"],
           ["magma_Bits_4_eq_inst0.out","magma_Bit_or_inst0.in1"],
-          ["self.port_1","magma_Bits_4_eq_inst0.in0"]
+          ["self.port_2","magma_Bits_4_eq_inst0.in0"]
         ]
       },
       "ASSERT_ON_compile_guard_inline_verilog_0":{
@@ -164,9 +164,9 @@
           }
         },
         "connections":[
-          ["self.CLK","ASSERT_ON_compile_guard.CLK"],
           ["self.I.valid","ASSERT_ON_compile_guard.port_0"],
-          ["Register_inst0.O","ASSERT_ON_compile_guard.port_1"],
+          ["self.CLK","ASSERT_ON_compile_guard.port_1"],
+          ["Register_inst0.O","ASSERT_ON_compile_guard.port_2"],
           ["self.CLK","Register_inst0.CLK"],
           ["self.I.data","Register_inst0.I"],
           ["self.O","Register_inst0.O"]

--- a/tests/gold/test_compile_guard_basic.json
+++ b/tests/gold/test_compile_guard_basic.json
@@ -5,7 +5,7 @@
       "COND_compile_guard":{
         "type":["Record",[
           ["port_0","BitIn"],
-          ["CLK",["Named","coreir.clkIn"]]
+          ["port_1",["Named","coreir.clkIn"]]
         ]],
         "instances":{
           "Register_inst0":{
@@ -13,7 +13,7 @@
           }
         },
         "connections":[
-          ["self.CLK","Register_inst0.CLK"],
+          ["self.port_1","Register_inst0.CLK"],
           ["self.port_0","Register_inst0.I"]
         ]
       },
@@ -49,8 +49,8 @@
           }
         },
         "connections":[
-          ["self.CLK","COND_compile_guard.CLK"],
           ["self.I","COND_compile_guard.port_0"],
+          ["self.CLK","COND_compile_guard.port_1"],
           ["self.O","self.I"]
         ]
       }

--- a/tests/gold/test_compile_guard_basic_undefined.json
+++ b/tests/gold/test_compile_guard_basic_undefined.json
@@ -5,7 +5,7 @@
       "COND_compile_guard":{
         "type":["Record",[
           ["port_0","BitIn"],
-          ["CLK",["Named","coreir.clkIn"]]
+          ["port_1",["Named","coreir.clkIn"]]
         ]],
         "instances":{
           "Register_inst0":{
@@ -13,7 +13,7 @@
           }
         },
         "connections":[
-          ["self.CLK","Register_inst0.CLK"],
+          ["self.port_1","Register_inst0.CLK"],
           ["self.port_0","Register_inst0.I"]
         ]
       },
@@ -49,8 +49,8 @@
           }
         },
         "connections":[
-          ["self.CLK","COND_compile_guard.CLK"],
           ["self.I","COND_compile_guard.port_0"],
+          ["self.CLK","COND_compile_guard.port_1"],
           ["self.O","self.I"]
         ]
       }

--- a/tests/gold/test_compile_guard_basic_vcc.json
+++ b/tests/gold/test_compile_guard_basic_vcc.json
@@ -4,8 +4,8 @@
     "modules":{
       "CompileGuardCircuit_0":{
         "type":["Record",[
-          ["CLK",["Named","coreir.clkIn"]],
-          ["port_0","BitIn"]
+          ["port_0",["Named","coreir.clkIn"]],
+          ["port_1","BitIn"]
         ]],
         "instances":{
           "Register_inst0":{
@@ -20,10 +20,10 @@
           }
         },
         "connections":[
-          ["self.CLK","Register_inst0.CLK"],
+          ["self.port_0","Register_inst0.CLK"],
           ["magma_Bit_xor_inst0.out","Register_inst0.I"],
           ["magma_Bit_xor_inst0.in1","bit_const_1_None.out"],
-          ["self.port_0","magma_Bit_xor_inst0.in0"]
+          ["self.port_1","magma_Bit_xor_inst0.in0"]
         ]
       },
       "Register":{
@@ -58,8 +58,8 @@
           }
         },
         "connections":[
-          ["self.CLK","CompileGuardCircuit_0.CLK"],
-          ["self.I","CompileGuardCircuit_0.port_0"],
+          ["self.CLK","CompileGuardCircuit_0.port_0"],
+          ["self.I","CompileGuardCircuit_0.port_1"],
           ["self.O","self.I"]
         ]
       }

--- a/tests/gold/test_compile_guard_contained_inline_verilog.v
+++ b/tests/gold/test_compile_guard_contained_inline_verilog.v
@@ -56,16 +56,16 @@ assign O = reg_P1_inst0_out[0];
 endmodule
 
 module DebugModule (
-    input CLK,
     input port_0,
-    input port_1
+    input port_1,
+    input port_2
 );
 wire _magma_inline_wire0_out;
 wire _magma_inline_wire1_out;
 wire magma_Bit_or_inst0_out;
 wire reg_O;
 corebit_wire _magma_inline_wire0 (
-    .in(port_1),
+    .in(port_2),
     .out(_magma_inline_wire0_out)
 );
 corebit_wire _magma_inline_wire1 (
@@ -74,13 +74,13 @@ corebit_wire _magma_inline_wire1 (
 );
 corebit_or magma_Bit_or_inst0 (
     .in0(\reg _O),
-    .in1(port_0),
+    .in1(port_1),
     .out(magma_Bit_or_inst0_out)
 );
 Register reg (
     .I(magma_Bit_or_inst0_out),
     .O(reg_O),
-    .CLK(CLK)
+    .CLK(port_0)
 );
 assert _magma_inline_wire0_out;
 assert ~_magma_inline_wire1_out;
@@ -93,9 +93,9 @@ module Top (
 );
 `ifdef DEBUG
 DebugModule DebugModule (
-    .CLK(CLK),
-    .port_0(I),
-    .port_1(I)
+    .port_0(CLK),
+    .port_1(I),
+    .port_2(I)
 );
 `endif
 assign O = I;

--- a/tests/gold/test_compile_guard_drive_output.json
+++ b/tests/gold/test_compile_guard_drive_output.json
@@ -2,9 +2,9 @@
 "namespaces":{
   "global":{
     "modules":{
-      "COND_compile_guard":{
+      "CompileGuardCircuit_1":{
         "type":["Record",[
-          ["port_0","BitIn"],
+          ["port_0","Bit"],
           ["port_1",["Named","coreir.clkIn"]],
           ["port_2","BitIn"]
         ]],
@@ -12,15 +12,20 @@
           "Register_inst0":{
             "modref":"global.Register"
           },
-          "Register_inst1":{
-            "modref":"global.Register"
+          "bit_const_1_None":{
+            "modref":"corebit.const",
+            "modargs":{"value":["Bool",true]}
+          },
+          "magma_Bit_xor_inst0":{
+            "modref":"corebit.xor"
           }
         },
         "connections":[
           ["self.port_1","Register_inst0.CLK"],
-          ["self.port_0","Register_inst0.I"],
-          ["self.port_1","Register_inst1.CLK"],
-          ["self.port_2","Register_inst1.I"]
+          ["magma_Bit_xor_inst0.out","Register_inst0.I"],
+          ["self.port_0","Register_inst0.O"],
+          ["magma_Bit_xor_inst0.in1","bit_const_1_None.out"],
+          ["self.port_2","magma_Bit_xor_inst0.in0"]
         ]
       },
       "Register":{
@@ -44,21 +49,20 @@
       },
       "_Top":{
         "type":["Record",[
-          ["I",["Array",2,"BitIn"]],
+          ["I","BitIn"],
           ["O","Bit"],
           ["CLK",["Named","coreir.clkIn"]]
         ]],
         "instances":{
-          "COND_compile_guard":{
-            "modref":"global.COND_compile_guard",
+          "CompileGuardCircuit_1":{
+            "modref":"global.CompileGuardCircuit_1",
             "metadata":{"compile_guard":{"condition_str":"COND","type":"defined"}}
           }
         },
         "connections":[
-          ["self.I.1","COND_compile_guard.port_0"],
-          ["self.CLK","COND_compile_guard.port_1"],
-          ["self.I.0","COND_compile_guard.port_2"],
-          ["self.O","self.I.1"]
+          ["self.O","CompileGuardCircuit_1.port_0"],
+          ["self.CLK","CompileGuardCircuit_1.port_1"],
+          ["self.I","CompileGuardCircuit_1.port_2"]
         ]
       }
     }

--- a/tests/gold/test_compile_guard_inline_verilog_reset.mlir
+++ b/tests/gold/test_compile_guard_inline_verilog_reset.mlir
@@ -1,0 +1,40 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @WireAsyncResetN(%I: i1) -> (O: i1) {
+        %1 = sv.wire sym @WireAsyncResetN.coreir_wrapInAsyncResetN_inst0 {name="coreir_wrapInAsyncResetN_inst0"} : !hw.inout<i1>
+        sv.assign %1, %I : i1
+        %0 = sv.read_inout %1 : !hw.inout<i1>
+        %3 = sv.wire sym @WireAsyncResetN.Wire_inst0 {name="Wire_inst0"} : !hw.inout<i1>
+        sv.assign %3, %0 : i1
+        %2 = sv.read_inout %3 : !hw.inout<i1>
+        %5 = sv.wire sym @WireAsyncResetN.coreir_wrapOutAsyncResetN_inst0 {name="coreir_wrapOutAsyncResetN_inst0"} : !hw.inout<i1>
+        sv.assign %5, %2 : i1
+        %4 = sv.read_inout %5 : !hw.inout<i1>
+        hw.output %4 : i1
+    }
+    hw.module @WireClock(%I: i1) -> (O: i1) {
+        %1 = sv.wire sym @WireClock.coreir_wrapInClock_inst0 {name="coreir_wrapInClock_inst0"} : !hw.inout<i1>
+        sv.assign %1, %I : i1
+        %0 = sv.read_inout %1 : !hw.inout<i1>
+        %3 = sv.wire sym @WireClock.Wire_inst0 {name="Wire_inst0"} : !hw.inout<i1>
+        sv.assign %3, %0 : i1
+        %2 = sv.read_inout %3 : !hw.inout<i1>
+        %5 = sv.wire sym @WireClock.coreir_wrapOutClock_inst0 {name="coreir_wrapOutClock_inst0"} : !hw.inout<i1>
+        sv.assign %5, %2 : i1
+        %4 = sv.read_inout %5 : !hw.inout<i1>
+        hw.output %4 : i1
+    }
+    hw.module @COND_compile_guard(%port_0: i1, %port_1: i1, %port_2: i1) -> () {
+        %1 = sv.wire sym @COND_compile_guard._magma_inline_wire0 {name="_magma_inline_wire0"} : !hw.inout<i1>
+        sv.assign %1, %port_0 : i1
+        %0 = sv.read_inout %1 : !hw.inout<i1>
+        %2 = hw.instance "_magma_inline_wire1" @WireAsyncResetN(I: %port_1: i1) -> (O: i1)
+        %3 = hw.instance "_magma_inline_wire2" @WireClock(I: %port_2: i1) -> (O: i1)
+        sv.verbatim "\nassert property (@(posedge {{2}}) disable iff {{1}} {{0}} |-> ##1 {{0}};\n                " (%0, %2, %3) : i1, i1, i1
+    }
+    hw.module @_Top(%I: i1, %CLK: i1, %ASYNCRESETN: i1) -> (O: i1) {
+        sv.ifdef "COND" {
+            hw.instance "COND_compile_guard" @COND_compile_guard(port_0: %I: i1, port_1: %ASYNCRESETN: i1, port_2: %CLK: i1) -> ()
+        }
+        hw.output %I : i1
+    }
+}

--- a/tests/gold/test_compile_guard_inline_verilog_reset.mlir
+++ b/tests/gold/test_compile_guard_inline_verilog_reset.mlir
@@ -1,27 +1,15 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
-    hw.module @WireAsyncResetN(%I: i1) -> (O: i1) {
-        %1 = sv.wire sym @WireAsyncResetN.coreir_wrapInAsyncResetN_inst0 {name="coreir_wrapInAsyncResetN_inst0"} : !hw.inout<i1>
-        sv.assign %1, %I : i1
-        %0 = sv.read_inout %1 : !hw.inout<i1>
-        %3 = sv.wire sym @WireAsyncResetN.Wire_inst0 {name="Wire_inst0"} : !hw.inout<i1>
-        sv.assign %3, %0 : i1
-        %2 = sv.read_inout %3 : !hw.inout<i1>
-        %5 = sv.wire sym @WireAsyncResetN.coreir_wrapOutAsyncResetN_inst0 {name="coreir_wrapOutAsyncResetN_inst0"} : !hw.inout<i1>
-        sv.assign %5, %2 : i1
-        %4 = sv.read_inout %5 : !hw.inout<i1>
-        hw.output %4 : i1
-    }
     hw.module @WireClock(%I: i1) -> (O: i1) {
-        %1 = sv.wire sym @WireClock.coreir_wrapInClock_inst0 {name="coreir_wrapInClock_inst0"} : !hw.inout<i1>
+        %1 = sv.wire sym @WireClock.Wire_inst0 {name="Wire_inst0"} : !hw.inout<i1>
         sv.assign %1, %I : i1
         %0 = sv.read_inout %1 : !hw.inout<i1>
-        %3 = sv.wire sym @WireClock.Wire_inst0 {name="Wire_inst0"} : !hw.inout<i1>
-        sv.assign %3, %0 : i1
-        %2 = sv.read_inout %3 : !hw.inout<i1>
-        %5 = sv.wire sym @WireClock.coreir_wrapOutClock_inst0 {name="coreir_wrapOutClock_inst0"} : !hw.inout<i1>
-        sv.assign %5, %2 : i1
-        %4 = sv.read_inout %5 : !hw.inout<i1>
-        hw.output %4 : i1
+        hw.output %0 : i1
+    }
+    hw.module @WireAsyncResetN(%I: i1) -> (O: i1) {
+        %1 = sv.wire sym @WireAsyncResetN.Wire_inst0 {name="Wire_inst0"} : !hw.inout<i1>
+        sv.assign %1, %I : i1
+        %0 = sv.read_inout %1 : !hw.inout<i1>
+        hw.output %0 : i1
     }
     hw.module @COND_compile_guard(%port_0: i1, %port_1: i1, %port_2: i1) -> () {
         %1 = sv.wire sym @COND_compile_guard._magma_inline_wire0 {name="_magma_inline_wire0"} : !hw.inout<i1>

--- a/tests/gold/test_compile_guard_nested_type.json
+++ b/tests/gold/test_compile_guard_nested_type.json
@@ -5,8 +5,8 @@
       "COND_compile_guard":{
         "type":["Record",[
           ["port_0","BitIn"],
-          ["CLK",["Named","coreir.clkIn"]],
-          ["port_1","BitIn"]
+          ["port_1",["Named","coreir.clkIn"]],
+          ["port_2","BitIn"]
         ]],
         "instances":{
           "Register_inst0":{
@@ -17,10 +17,10 @@
           }
         },
         "connections":[
-          ["self.CLK","Register_inst0.CLK"],
+          ["self.port_1","Register_inst0.CLK"],
           ["self.port_0","Register_inst0.I"],
-          ["self.CLK","Register_inst1.CLK"],
-          ["self.port_1","Register_inst1.I"]
+          ["self.port_1","Register_inst1.CLK"],
+          ["self.port_2","Register_inst1.I"]
         ]
       },
       "Register":{
@@ -55,9 +55,9 @@
           }
         },
         "connections":[
-          ["self.CLK","COND_compile_guard.CLK"],
           ["self.I.1.x","COND_compile_guard.port_0"],
-          ["self.I.0.y","COND_compile_guard.port_1"],
+          ["self.CLK","COND_compile_guard.port_1"],
+          ["self.I.0.y","COND_compile_guard.port_2"],
           ["self.O","self.I.0.x"]
         ]
       }

--- a/tests/test_backend/test_mlir/golds/simple_compile_guard.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_compile_guard.mlir
@@ -1,7 +1,7 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
-    hw.module @COND1_compile_guard(%port_0: i1, %CLK: i1) -> () {
+    hw.module @COND1_compile_guard(%port_0: i1, %port_1: i1) -> () {
         %1 = sv.reg {name = "Register_inst0"} : !hw.inout<i1>
-        sv.alwaysff(posedge %CLK) {
+        sv.alwaysff(posedge %port_1) {
             sv.passign %1, %port_0 : i1
         }
         %2 = hw.constant 0 : i1
@@ -10,9 +10,9 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
         }
         %0 = sv.read_inout %1 : !hw.inout<i1>
     }
-    hw.module @COND2_compile_guard(%port_0: i1, %CLK: i1) -> () {
+    hw.module @COND2_compile_guard(%port_0: i1, %port_1: i1) -> () {
         %1 = sv.reg {name = "Register_inst0"} : !hw.inout<i1>
-        sv.alwaysff(posedge %CLK) {
+        sv.alwaysff(posedge %port_1) {
             sv.passign %1, %port_0 : i1
         }
         %2 = hw.constant 0 : i1
@@ -23,11 +23,11 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
     }
     hw.module @simple_compile_guard(%I: i1, %CLK: i1) -> (O: i1) {
         sv.ifdef "COND1" {
-            hw.instance "COND1_compile_guard" @COND1_compile_guard(port_0: %I: i1, CLK: %CLK: i1) -> ()
+            hw.instance "COND1_compile_guard" @COND1_compile_guard(port_0: %I: i1, port_1: %CLK: i1) -> ()
         }
         sv.ifdef "COND2" {
         } else {
-            hw.instance "COND2_compile_guard" @COND2_compile_guard(port_0: %I: i1, CLK: %CLK: i1) -> ()
+            hw.instance "COND2_compile_guard" @COND2_compile_guard(port_0: %I: i1, port_1: %CLK: i1) -> ()
         }
         hw.output %I : i1
     }


### PR DESCRIPTION
Since a value's name is not guaranteed to be unique (e.g. inline wire's get `I` for the wire instance port name), there's a possibility for a name collision.  Since the compile_guard logic is hidden to the user, I think for simplicity's sake it's easiest to just avoid the collision by not giving the port an explicit name in the clock case.