### PR TITLE
[WireClockPass] Avoid Tuple recursion/elaboration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,10 @@ jobs:
       run: |
         sudo apt install -y verilator libgmp-dev libmpfr-dev libmpc-dev
         python -m pip install --upgrade pip
+        # BEGIN: Temp fix, see
+        # https://github.com/henry0312/pytest-pycodestyle/issues/97
+        pip install py
+        # END: Temp fix
         pip install flake8 pytest pytest-cov pytest-pycodestyle fault>=3.1.1
         pip install kratos  # test optional dependency
         python setup.py install

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -26,6 +26,10 @@ jobs:
         sudo apt-get update
         sudo apt install -y verilator libgmp-dev libmpfr-dev libmpc-dev
         python -m pip install --upgrade pip
+        # BEGIN: Temp fix, see
+        # https://github.com/henry0312/pytest-pycodestyle/issues/97
+        pip install py
+        # END: Temp fix
         pip install flake8 pytest pytest-cov pytest-pycodestyle fault>=3.1.1
         pip install kratos  # test optional dependency
         python setup.py install

--- a/magma/passes/clock.py
+++ b/magma/passes/clock.py
@@ -31,7 +31,8 @@ def _get_output_clocks_in_array(
 
 
 def _get_output_clocks_in_tuple(
-        value: Tuple, clock_type: Kind) -> Iterable[Type]:
+        value: Tuple, clock_type: Kind
+) -> Iterable[Type]:
     """
     Gets all output values of type @clock_type recursively contained in @value.
     """

--- a/magma/passes/clock.py
+++ b/magma/passes/clock.py
@@ -30,6 +30,16 @@ def _get_output_clocks_in_array(
         yield from get_output_clocks_in_value(elem, clock_type)
 
 
+def _get_output_clocks_in_tuple(
+        value: Tuple, clock_type: Kind) -> Iterable[Type]:
+    """
+    Gets all output values of type @clock_type recursively contained in @value.
+    """
+    for key, type_ in type(value).field_dict.items():
+        if is_clock_or_nested_clock(type_, (clock_type, )):
+            yield from get_output_clocks_in_value(value[key], clock_type)
+
+
 def get_output_clocks_in_value(value: Type, clock_type: Kind) -> Iterable[Type]:
     """
     Gets all output values of type @clock_type recursively contained in @value.
@@ -40,8 +50,7 @@ def get_output_clocks_in_value(value: Type, clock_type: Kind) -> Iterable[Type]:
     if isinstance(value, clock_type):
         yield value
     if isinstance(value, Tuple):
-        for elem in value:
-            yield from get_output_clocks_in_value(elem, clock_type)
+        yield from _get_output_clocks_in_tuple(value, clock_type)
     if isinstance(value, Array):
         yield from _get_output_clocks_in_array(value, clock_type)
 

--- a/tests/test_passes/test_clock_pass.py
+++ b/tests/test_passes/test_clock_pass.py
@@ -70,6 +70,7 @@ def test_drive_undriven_clock_types_combinational_logging(caplog):
 
 
 def test_clock_pass_tuple():
+
     class T(m.Product):
         x = m.In(m.Clock)
         y = m.In(m.Reset)


### PR DESCRIPTION
Checks Tuple subtypes before recursion to avoid unnecessary traversal