### PR TITLE
[When] Only add necessary implicit default values

### DIFF
--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -217,10 +217,10 @@ class WhenBuilder(CircuitBuilder):
         # builder's finalization, although it is a bit "hacky". Ideally, this
         # builder should be completely agnostic of anything it is connected to,
         # and a global (post-processing) pass should be used instead.
-        # NOTE(leonardt): we only add default drivers if a value is inferred to
+        # NOTE(leonardt): We only add default drivers if a value is inferred to
         # be a latch, otherwise we skip this implicit logic so the output is
         # cleaner (e.g. if a register is assigned in every case, we don't need
-        # the default value)
+        # the default value).
         _add_default_drivers_to_memory_ports(self, latches)
         _add_default_drivers_to_register_inputs(self, latches)
 

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -94,8 +94,9 @@ def _get_corresponding_register_default(value: Type) -> Optional[Type]:
     return sel.select(value_inst.O)
 
 
-def _add_default_drivers_to_register_inputs(builder: 'WhenBuilder',
-                                            latches: Set[Type]):
+def _add_default_drivers_to_register_inputs(
+    builder: 'WhenBuilder', latches: Set[Type]
+):
     """
     Adds default drivers to register inputs (reg.O is the default value
     for inputs, False is the default for enables).

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -53,8 +53,9 @@ def _is_memory_port(value: Type) -> bool:
     return True
 
 
-def _add_default_drivers_to_memory_ports(builder: 'WhenBuilder',
-                                         latches: Set[Type]):
+def _add_default_drivers_to_memory_ports(
+    builder: 'WhenBuilder', latches: Set[Type]
+):
     for drivee in builder.output_to_index:
         if drivee in builder.default_drivers:
             continue

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -212,7 +212,6 @@ class WhenBuilder(CircuitBuilder):
         # Detect latches which would be inferred from the context of the when
         # block.
         latches = find_inferred_latches(self.block)
-
         # NOTE(rsetaluri): These passes should ideally be done after circuit
         # creation. However, it is quite unwieldy, so we opt to do it in this
         # builder's finalization, although it is a bit "hacky". Ideally, this

--- a/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
+++ b/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
@@ -34,63 +34,59 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
         %8 = hw.constant 127 : i7
         %9 = hw.constant 0 : i5
         %10 = hw.constant 0 : i1
-        %11 = hw.constant 0 : i7
-        %12 = hw.constant 0 : i1
-        %13 = hw.constant 0 : i5
-        %14 = hw.constant 0 : i7
-        %21 = sv.reg : !hw.inout<i5>
-        %2 = sv.read_inout %21 : !hw.inout<i5>
+        %11 = hw.constant 0 : i5
+        %12 = hw.constant 0 : i7
+        %19 = sv.reg : !hw.inout<i5>
+        %2 = sv.read_inout %19 : !hw.inout<i5>
+        %20 = sv.reg : !hw.inout<i1>
+        %13 = sv.read_inout %20 : !hw.inout<i1>
+        %21 = sv.reg : !hw.inout<i7>
+        %14 = sv.read_inout %21 : !hw.inout<i7>
         %22 = sv.reg : !hw.inout<i1>
-        %15 = sv.read_inout %22 : !hw.inout<i1>
-        %23 = sv.reg : !hw.inout<i7>
-        %16 = sv.read_inout %23 : !hw.inout<i7>
+        %5 = sv.read_inout %22 : !hw.inout<i1>
+        %23 = sv.reg : !hw.inout<i5>
+        %1 = sv.read_inout %23 : !hw.inout<i5>
         %24 = sv.reg : !hw.inout<i1>
-        %5 = sv.read_inout %24 : !hw.inout<i1>
-        %25 = sv.reg : !hw.inout<i5>
-        %1 = sv.read_inout %25 : !hw.inout<i5>
+        %15 = sv.read_inout %24 : !hw.inout<i1>
+        %25 = sv.reg : !hw.inout<i7>
+        %16 = sv.read_inout %25 : !hw.inout<i7>
         %26 = sv.reg : !hw.inout<i1>
         %17 = sv.read_inout %26 : !hw.inout<i1>
         %27 = sv.reg : !hw.inout<i7>
         %18 = sv.read_inout %27 : !hw.inout<i7>
         %28 = sv.reg : !hw.inout<i1>
-        %19 = sv.read_inout %28 : !hw.inout<i1>
+        %3 = sv.read_inout %28 : !hw.inout<i1>
         %29 = sv.reg : !hw.inout<i7>
-        %20 = sv.read_inout %29 : !hw.inout<i7>
-        %30 = sv.reg : !hw.inout<i1>
-        %3 = sv.read_inout %30 : !hw.inout<i1>
-        %31 = sv.reg : !hw.inout<i7>
-        %4 = sv.read_inout %31 : !hw.inout<i7>
+        %4 = sv.read_inout %29 : !hw.inout<i7>
         sv.alwayscomb {
-            sv.bpassign %21, %9 : i5
-            sv.bpassign %30, %12 : i1
-            sv.bpassign %31, %11 : i7
-            sv.bpassign %24, %12 : i1
-            sv.bpassign %25, %13 : i5
-            sv.bpassign %30, %12 : i1
-            sv.bpassign %31, %14 : i7
+            sv.bpassign %19, %9 : i5
+            sv.bpassign %22, %10 : i1
+            sv.bpassign %23, %11 : i5
+            sv.bpassign %28, %10 : i1
+            sv.bpassign %29, %12 : i7
             sv.if %en0 {
-                sv.bpassign %21, %addr0 : i5
-                sv.bpassign %24, %0 : i1
-                sv.bpassign %25, %addr1 : i5
-                sv.bpassign %28, %6 : i1
-                sv.bpassign %29, %7 : i7
-                sv.bpassign %30, %data0_x : i1
-                sv.bpassign %31, %data0_y : i7
+                sv.bpassign %19, %addr0 : i5
+                sv.bpassign %22, %0 : i1
+                sv.bpassign %23, %addr1 : i5
+                sv.bpassign %26, %6 : i1
+                sv.bpassign %27, %7 : i7
+                sv.bpassign %28, %data0_x : i1
+                sv.bpassign %29, %data0_y : i7
             } else {
                 sv.if %en1 {
-                    sv.bpassign %21, %addr1 : i5
-                    sv.bpassign %24, %0 : i1
-                    sv.bpassign %25, %addr0 : i5
-                    sv.bpassign %28, %6 : i1
-                    sv.bpassign %29, %7 : i7
-                    sv.bpassign %30, %data1_x : i1
-                    sv.bpassign %31, %data1_y : i7
+                    sv.bpassign %19, %addr1 : i5
+                    sv.bpassign %22, %0 : i1
+                    sv.bpassign %23, %addr0 : i5
+                    sv.bpassign %26, %6 : i1
+                    sv.bpassign %27, %7 : i7
+                    sv.bpassign %28, %data1_x : i1
+                    sv.bpassign %29, %data1_y : i7
                 } else {
-                    sv.bpassign %28, %0 : i1
-                    sv.bpassign %29, %8 : i7
+                    sv.bpassign %26, %0 : i1
+                    sv.bpassign %27, %8 : i7
                 }
             }
         }
-        hw.output %19, %20 : i1, i7
+        hw.output %17, %18 : i1, i7
     }
 }

--- a/tests/gold/test_when_register_no_default.mlir
+++ b/tests/gold/test_when_register_no_default.mlir
@@ -1,0 +1,25 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @test_register_no_default(%I: i1, %E: i1, %CLK: i1) -> (O: i1) {
+        %1 = hw.constant -1 : i1
+        %0 = comb.xor %1, %I : i1
+        %3 = sv.reg : !hw.inout<i1>
+        %2 = sv.read_inout %3 : !hw.inout<i1>
+        sv.alwayscomb {
+            sv.if %E {
+                sv.bpassign %3, %I : i1
+            } else {
+                sv.bpassign %3, %0 : i1
+            }
+        }
+        %5 = sv.reg {name = "Register_inst0"} : !hw.inout<i1>
+        sv.alwaysff(posedge %CLK) {
+            sv.passign %5, %2 : i1
+        }
+        %6 = hw.constant 0 : i1
+        sv.initial {
+            sv.bpassign %5, %6 : i1
+        }
+        %4 = sv.read_inout %5 : !hw.inout<i1>
+        hw.output %4 : i1
+    }
+}

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -346,7 +346,7 @@ def test_when_memory(T, bits_to_fault_value):
     if check_gold(__file__, f"test_when_memory_{T_str}.mlir"):
         return
 
-    tester = f.SynchronousTester(test_when_memory)
+    tester = f.SynchronousTester(test_when_memory, clock=test_when_memory.CLK)
     tester.advance_cycle()
     tester.expect(test_when_memory.out, bits_to_fault_value(m.Bits[8](0xFF)))
 
@@ -521,6 +521,26 @@ def test_when_register_default():
         io.O @= reg.O
 
     basename = "test_when_register_default"
+    m.compile(f"build/{basename}", _Test, output="mlir")
+    assert check_gold(__file__, f"{basename}.mlir")
+
+
+def test_when_register_no_default():
+
+    class _Test(m.Circuit):
+        name = "test_register_no_default"
+        io = m.IO(I=m.In(m.Bit), E=m.In(m.Bit), O=m.Out(m.Bit))
+
+        reg = m.Register(m.Bit)()
+
+        with m.when(io.E):
+            reg.I @= io.I
+        with m.otherwise():
+            reg.I @= ~io.I
+
+        io.O @= reg.O
+
+    basename = "test_when_register_no_default"
     m.compile(f"build/{basename}", _Test, output="mlir")
     assert check_gold(__file__, f"{basename}.mlir")
 


### PR DESCRIPTION
Do latch detection, then pass latches to the implicit default value logic, only add the implicit default value if it is a latch (avoids unnecessary code in the generated verilog, e.g. when a register is assigned in every case we don't need the default update)