### PR TITLE
[Generator2] Improve class creation pipeline

### DIFF
--- a/tests/test_generator2.py
+++ b/tests/test_generator2.py
@@ -92,3 +92,13 @@ def test_no_cache():
     my_gen_other = _MyGen()
     assert my_gen is not my_gen_other
     assert repr(my_gen) == repr(my_gen_other)
+
+
+def test_subclass_generator_instance():
+    Base = m.Register(m.Bit)
+
+    class MyRegister(Base):
+        io = Base.io
+        verilog = "Foo"
+
+    assert isinstance(MyRegister, m.Register)


### PR DESCRIPTION
Currently we have a guard for when the Generator2 class is created.  In fact, we need a more general check for when any class is created has the metaclass Generator2Meta.

One hacky way to determine that this is a type(...) call, i.e. it is invoked in the class creation pipeline.  In that case, there are exactly 3 arguments of the form name, bases, dct In theory, it would be possible for a Generator subclass to have the same argument number and types, but having the "__module__" member of the dct would be highly unlikely, furthmore they should be using a hashable dict, so it shouldn't satisfy that check.  Note that this is why we use "type is" instead of isinstance