### PR TITLE
Elaborate primitives in pass

### DIFF
--- a/magma/backend/coreir/insert_coreir_wires.py
+++ b/magma/backend/coreir/insert_coreir_wires.py
@@ -17,10 +17,11 @@ def _sanitize_name(name):
 
 
 class InsertCoreIRWires(DefinitionPass):
-    def __init__(self, main):
+    def __init__(self, main, flatten: bool = True):
         super().__init__(main)
         self.seen = set()
         self.wire_map = {}
+        self._flatten = flatten
 
     def _make_wire(self, driver, value, definition):
         is_bits = (isinstance(driver.name, ArrayRef) and
@@ -42,7 +43,7 @@ class InsertCoreIRWires(DefinitionPass):
                 driver.name.name = "_" + driver.name.name
 
             name = f"{driver_name}"
-            wire_inst = Wire(T)(name=name)
+            wire_inst = Wire(T, flatten=self._flatten)(name=name)
             self.wire_map[driver] = wire_inst
         wire_inst = self.wire_map[driver]
         wire_input = wire_inst.I
@@ -55,15 +56,21 @@ class InsertCoreIRWires(DefinitionPass):
             # the entire bits (this avoids an "undriven" error when only one
             # index of the bits is used)
 
-        if not is_bits and not isinstance(driver, Digital):
+        if self._flatten and not is_bits and not isinstance(driver, Digital):
             driver = as_bits(driver)
             wire_output = from_bits(T, wire_output)
 
         # Could be already wired for fanout cases
         if not wire_input.driven():
             wire_input @= driver
-        if (isinstance(value, _ClockType) and
-                not isinstance(wire_output, type(value))):
+        recast = (
+            self._flatten
+            and (
+                isinstance(value, _ClockType)
+                and not isinstance(wire_output, type(value))
+            )
+        )
+        if recast:
             # This mean it was cast by the user (e.g. m.clock(value)), so we
             # need to "recast" the wire output
             wire_output = convertbit(wire_output, type(value))

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -42,7 +42,7 @@ class MlirCompiler(Compiler):
         if self.opts.get("flatten_all_tuples", False):
             elaborate_tuples(self.main)
 
-        insert_coreir_wires(self.main)
+        insert_coreir_wires(self.main, flatten=False)
         wire_clocks(self.main)
         # NOTE(leonardt): finalizing whens must happen after any
         # passes that modify the circuit.  This is because passes

--- a/magma/passes/elaborate_circuit.py
+++ b/magma/passes/elaborate_circuit.py
@@ -1,0 +1,42 @@
+from magma.circuit import CircuitKind
+from magma.passes.passes import CircuitPass, pass_lambda
+
+
+def elaborate_circuit(ckt: CircuitKind):
+    with ckt.open():
+        ckt.elaborate()
+    if getattr(ckt, "primitive", False):
+        setattr(ckt, "primitive", False)
+    ckt._is_definition = True
+
+
+class ElaborationPass(CircuitPass):
+    def __init__(self, main):
+        super().__init__(main)
+
+    def should_elaborate(self, ckt):
+        raise NotImplementedError()
+
+    def __call__(self, ckt):
+        if self.should_elaborate(ckt):
+            elaborate_circuit(ckt)
+
+
+class ElaborateAllPass(ElaborationPass):
+    def __init__(self, main, circuits=(), generators=()):
+        super().__init__(main)
+        self._circuits = circuits
+        self._generators = generators
+
+    def should_elaborate(self, ckt):
+        # NOTE(rsetaluri): We are using a subclass check for circuits. This is
+        # not necessarily guaranteed to be equivalent to checking that the
+        # instance itself isinstance of the circuit, but we can expect it to
+        # work for most cases.
+        return (
+            issubclass(ckt, self._circuits)
+            or isinstance(ckt, self._generators)
+        )
+
+
+elaborate_all_pass = pass_lambda(ElaborateAllPass)

--- a/magma/primitives/mux.py
+++ b/magma/primitives/mux.py
@@ -62,8 +62,6 @@ class Mux(Generator2):
         self.height = height
         self.T = T
 
-        self.elaborate()
-
     def elaborate(self):
         N = magma_type(self.T).flat_length()
         mux = CoreIRCommonLibMuxN(self.height, N)()

--- a/magma/primitives/mux.py
+++ b/magma/primitives/mux.py
@@ -62,6 +62,14 @@ class Mux(Generator2):
         self.height = height
         self.T = T
 
+        self.primitive = True
+        self.stateful = False
+
+        def _simulate(_, __, ___):
+            raise NotImplementedError()
+
+        self.simulate = _simulate
+
     def elaborate(self):
         N = magma_type(self.T).flat_length()
         mux = CoreIRCommonLibMuxN(self.height, N)()

--- a/magma/primitives/mux.py
+++ b/magma/primitives/mux.py
@@ -46,31 +46,40 @@ class Mux(Generator2):
             T = Bits[len(T)]
         if issubclass(T, (bool, ht.Bit)):
             T = Bit
+
         # TODO(rsetaluri): Type should be hashable so the generator instance can
         # be cached.
         T_str = type_to_sanitized_string(T)
         self.name = f"Mux{height}x{T_str}"
-        N = magma_type(T).flat_length()
 
         ports = {f"I{i}": In(T) for i in range(height)}
         T_S = Bit if height == 2 else Bits[clog2(height)]
         ports["S"] = In(T_S)
         ports["O"] = Out(T)
 
-        self.io = io = IO(**ports)
+        self.io = IO(**ports)
 
-        mux = CoreIRCommonLibMuxN(height, N)()
-        data = [as_bits(getattr(io, f"I{i}")) for i in range(height)]
-        mux.I.data @= Array[height, Bits[N]](data)
-        if height == 2:
-            mux.I.sel[0] @= io.S
+        self.height = height
+        self.T = T
+
+        self.elaborate()
+
+    def elaborate(self):
+        N = magma_type(self.T).flat_length()
+        mux = CoreIRCommonLibMuxN(self.height, N)()
+        data = [as_bits(self.io[f"I{i}"]) for i in range(self.height)]
+        mux.I.data @= Array[self.height, Bits[N]](data)
+        sel = mux.I.sel
+        if self.height == 2:
+            sel = sel[0]
+        sel @= self.io.S
+        if issubclass(self.T, MagmaProtocol):
+            out = Out(self.T)._from_magma_value_(
+                from_bits(self.T._to_magma_(), mux.O)
+            )
         else:
-            mux.I.sel @= io.S
-        if issubclass(T, MagmaProtocol):
-            out = Out(T)._from_magma_value_(from_bits(T._to_magma_(), mux.O))
-        else:
-            out = from_bits(T, mux.O)
-        io.O @= out
+            out = from_bits(self.T, mux.O)
+        self.io.O @= out
 
 
 def _infer_mux_type(args):

--- a/magma/primitives/wire.py
+++ b/magma/primitives/wire.py
@@ -6,18 +6,23 @@ from magma.conversions import bit, convertbit
 from magma.digital import Digital
 from magma.generator import Generator2
 from magma.interface import IO
-from magma.t import In, Out
+from magma.t import Kind, In, Out
+from magma.type_utils import type_to_sanitized_string
 
 
-def _simulate_wire(self, value_store, state_store):
-    value_store.set_value(self.O, value_store.get_value(self.I))
+def _simulate_wire(this, value_store, state_store):
+    value_store.set_value(this.O, value_store.get_value(this.I))
 
 
 class Wire(Generator2):
-    def __init__(self, T):
+    def __init__(self, T: Kind, flatten: bool = True):
+        self.T = T
+        self.flattened = flatten
+        if not flatten:
+            self._init_unflattened(T)
+            return
         if issubclass(T, (AsyncReset, AsyncResetN, Clock)):
-            self._gen_named_type_wrapper(T)
-            # Standalone return to avoid return-in-init lint warning
+            self._init_named_type_wrapper(T)
             return
         if issubclass(T, Digital):
             coreir_lib = "corebit"
@@ -36,10 +41,15 @@ class Wire(Generator2):
         self.renamed_ports = coreir_port_mapping
         self.primitive = True
 
-    def _gen_named_type_wrapper(self, T):
-        """
-        Generates a container around Wire(Bit) so named types are wrapped
-        properly
+    def _init_unflattened(self, T: Kind):
+        self.name = f"Wire{type_to_sanitized_string(T)}"
+        self.io = IO(I=In(T), O=Out(T))
+        self.simulate = _simulate_wire
+        self.primitive = True
+
+    def _init_named_type_wrapper(self, T: Kind):
+        """Generates a container around Wire(Bit) so named types are wrapped
+        properly.
         """
         assert issubclass(T, Digital)
         self.io = IO(I=In(T), O=Out(T))

--- a/tests/gold/test_when_lazy_array_nested.mlir
+++ b/tests/gold/test_when_lazy_array_nested.mlir
@@ -1,5 +1,5 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
-    hw.module @test_when_lazy_array_nested(%S: i1) -> (O: !hw.array<2x!hw.struct<0: i1, 1: i1>>) {
+    hw.module @test_when_lazy_array_nested(%S: i1) -> (O: !hw.array<2x!hw.struct<x: i1, y: i1>>) {
         %0 = hw.constant 0 : i1
         %1 = hw.constant 1 : i1
         %6 = sv.reg : !hw.inout<i1>
@@ -23,17 +23,12 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
                 sv.bpassign %9, %0 : i1
             }
         }
-        %10 = comb.concat %5, %4, %3, %2 : i1, i1, i1, i1
-        %12 = sv.wire sym @test_when_lazy_array_nested.x {name="x"} : !hw.inout<i4>
-        sv.assign %12, %10 : i4
-        %11 = sv.read_inout %12 : !hw.inout<i4>
-        %13 = comb.extract %11 from 0 : (i4) -> i1
-        %14 = comb.extract %11 from 1 : (i4) -> i1
-        %15 = hw.struct_create (%13, %14) : !hw.struct<0: i1, 1: i1>
-        %16 = comb.extract %11 from 2 : (i4) -> i1
-        %17 = comb.extract %11 from 3 : (i4) -> i1
-        %18 = hw.struct_create (%16, %17) : !hw.struct<0: i1, 1: i1>
-        %19 = hw.array_create %18, %15 : !hw.struct<0: i1, 1: i1>
-        hw.output %19 : !hw.array<2x!hw.struct<0: i1, 1: i1>>
+        %10 = hw.struct_create (%2, %3) : !hw.struct<x: i1, y: i1>
+        %11 = hw.struct_create (%4, %5) : !hw.struct<x: i1, y: i1>
+        %12 = hw.array_create %11, %10 : !hw.struct<x: i1, y: i1>
+        %14 = sv.wire sym @test_when_lazy_array_nested.x {name="x"} : !hw.inout<!hw.array<2x!hw.struct<x: i1, y: i1>>>
+        sv.assign %14, %12 : !hw.array<2x!hw.struct<x: i1, y: i1>>
+        %13 = sv.read_inout %14 : !hw.inout<!hw.array<2x!hw.struct<x: i1, y: i1>>>
+        hw.output %13 : !hw.array<2x!hw.struct<x: i1, y: i1>>
     }
 }

--- a/tests/gold/test_when_lazy_array_protocol.mlir
+++ b/tests/gold/test_when_lazy_array_protocol.mlir
@@ -15,10 +15,10 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
                 sv.bpassign %5, %1 : i1
             }
         }
-        %6 = comb.concat %3, %2 : i1, i1
-        %8 = sv.wire sym @test_when_lazy_array_protocol.x {name="x"} : !hw.inout<i2>
-        sv.assign %8, %6 : i2
-        %7 = sv.read_inout %8 : !hw.inout<i2>
-        hw.output %7 : i2
+        %6 = hw.array_create %3, %2 : i1
+        %8 = sv.wire sym @test_when_lazy_array_protocol.x {name="x"} : !hw.inout<!hw.array<2xi1>>
+        sv.assign %8, %6 : !hw.array<2xi1>
+        %7 = sv.read_inout %8 : !hw.inout<!hw.array<2xi1>>
+        hw.output %7 : !hw.array<2xi1>
     }
 }

--- a/tests/test_backend/test_mlir/examples.py
+++ b/tests/test_backend/test_mlir/examples.py
@@ -297,8 +297,8 @@ class complex_wire(m.Circuit):
         O @= tmp
 
 
-m.backend.coreir.insert_coreir_wires.insert_coreir_wires(simple_wire)
-m.backend.coreir.insert_coreir_wires.insert_coreir_wires(complex_wire)
+m.backend.coreir.insert_coreir_wires.insert_coreir_wires(simple_wire, flatten=False)
+m.backend.coreir.insert_coreir_wires.insert_coreir_wires(complex_wire, flatten=False)
 
 
 class simple_clock_cast(m.Circuit):

--- a/tests/test_backend/test_mlir/golds/complex_wire.mlir
+++ b/tests/test_backend/test_mlir/golds/complex_wire.mlir
@@ -6,87 +6,9 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
         %3 = sv.wire sym @complex_wire.tmp1 {name="tmp1"} : !hw.inout<i1>
         sv.assign %3, %I1 : i1
         %2 = sv.read_inout %3 : !hw.inout<i1>
-        %5 = hw.constant 0 : i2
-        %4 = hw.array_get %I2[%5] : !hw.array<4xi8>, i2
-        %6 = comb.extract %4 from 0 : (i8) -> i1
-        %7 = comb.extract %4 from 1 : (i8) -> i1
-        %8 = comb.extract %4 from 2 : (i8) -> i1
-        %9 = comb.extract %4 from 3 : (i8) -> i1
-        %10 = comb.extract %4 from 4 : (i8) -> i1
-        %11 = comb.extract %4 from 5 : (i8) -> i1
-        %12 = comb.extract %4 from 6 : (i8) -> i1
-        %13 = comb.extract %4 from 7 : (i8) -> i1
-        %15 = hw.constant 1 : i2
-        %14 = hw.array_get %I2[%15] : !hw.array<4xi8>, i2
-        %16 = comb.extract %14 from 0 : (i8) -> i1
-        %17 = comb.extract %14 from 1 : (i8) -> i1
-        %18 = comb.extract %14 from 2 : (i8) -> i1
-        %19 = comb.extract %14 from 3 : (i8) -> i1
-        %20 = comb.extract %14 from 4 : (i8) -> i1
-        %21 = comb.extract %14 from 5 : (i8) -> i1
-        %22 = comb.extract %14 from 6 : (i8) -> i1
-        %23 = comb.extract %14 from 7 : (i8) -> i1
-        %25 = hw.constant 2 : i2
-        %24 = hw.array_get %I2[%25] : !hw.array<4xi8>, i2
-        %26 = comb.extract %24 from 0 : (i8) -> i1
-        %27 = comb.extract %24 from 1 : (i8) -> i1
-        %28 = comb.extract %24 from 2 : (i8) -> i1
-        %29 = comb.extract %24 from 3 : (i8) -> i1
-        %30 = comb.extract %24 from 4 : (i8) -> i1
-        %31 = comb.extract %24 from 5 : (i8) -> i1
-        %32 = comb.extract %24 from 6 : (i8) -> i1
-        %33 = comb.extract %24 from 7 : (i8) -> i1
-        %35 = hw.constant 3 : i2
-        %34 = hw.array_get %I2[%35] : !hw.array<4xi8>, i2
-        %36 = comb.extract %34 from 0 : (i8) -> i1
-        %37 = comb.extract %34 from 1 : (i8) -> i1
-        %38 = comb.extract %34 from 2 : (i8) -> i1
-        %39 = comb.extract %34 from 3 : (i8) -> i1
-        %40 = comb.extract %34 from 4 : (i8) -> i1
-        %41 = comb.extract %34 from 5 : (i8) -> i1
-        %42 = comb.extract %34 from 6 : (i8) -> i1
-        %43 = comb.extract %34 from 7 : (i8) -> i1
-        %44 = comb.concat %43, %42, %41, %40, %39, %38, %37, %36, %33, %32, %31, %30, %29, %28, %27, %26, %23, %22, %21, %20, %19, %18, %17, %16, %13, %12, %11, %10, %9, %8, %7, %6 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
-        %46 = sv.wire sym @complex_wire.tmp2 {name="tmp2"} : !hw.inout<i32>
-        sv.assign %46, %44 : i32
-        %45 = sv.read_inout %46 : !hw.inout<i32>
-        %47 = comb.extract %45 from 0 : (i32) -> i1
-        %48 = comb.extract %45 from 1 : (i32) -> i1
-        %49 = comb.extract %45 from 2 : (i32) -> i1
-        %50 = comb.extract %45 from 3 : (i32) -> i1
-        %51 = comb.extract %45 from 4 : (i32) -> i1
-        %52 = comb.extract %45 from 5 : (i32) -> i1
-        %53 = comb.extract %45 from 6 : (i32) -> i1
-        %54 = comb.extract %45 from 7 : (i32) -> i1
-        %55 = comb.concat %54, %53, %52, %51, %50, %49, %48, %47 : i1, i1, i1, i1, i1, i1, i1, i1
-        %56 = comb.extract %45 from 8 : (i32) -> i1
-        %57 = comb.extract %45 from 9 : (i32) -> i1
-        %58 = comb.extract %45 from 10 : (i32) -> i1
-        %59 = comb.extract %45 from 11 : (i32) -> i1
-        %60 = comb.extract %45 from 12 : (i32) -> i1
-        %61 = comb.extract %45 from 13 : (i32) -> i1
-        %62 = comb.extract %45 from 14 : (i32) -> i1
-        %63 = comb.extract %45 from 15 : (i32) -> i1
-        %64 = comb.concat %63, %62, %61, %60, %59, %58, %57, %56 : i1, i1, i1, i1, i1, i1, i1, i1
-        %65 = comb.extract %45 from 16 : (i32) -> i1
-        %66 = comb.extract %45 from 17 : (i32) -> i1
-        %67 = comb.extract %45 from 18 : (i32) -> i1
-        %68 = comb.extract %45 from 19 : (i32) -> i1
-        %69 = comb.extract %45 from 20 : (i32) -> i1
-        %70 = comb.extract %45 from 21 : (i32) -> i1
-        %71 = comb.extract %45 from 22 : (i32) -> i1
-        %72 = comb.extract %45 from 23 : (i32) -> i1
-        %73 = comb.concat %72, %71, %70, %69, %68, %67, %66, %65 : i1, i1, i1, i1, i1, i1, i1, i1
-        %74 = comb.extract %45 from 24 : (i32) -> i1
-        %75 = comb.extract %45 from 25 : (i32) -> i1
-        %76 = comb.extract %45 from 26 : (i32) -> i1
-        %77 = comb.extract %45 from 27 : (i32) -> i1
-        %78 = comb.extract %45 from 28 : (i32) -> i1
-        %79 = comb.extract %45 from 29 : (i32) -> i1
-        %80 = comb.extract %45 from 30 : (i32) -> i1
-        %81 = comb.extract %45 from 31 : (i32) -> i1
-        %82 = comb.concat %81, %80, %79, %78, %77, %76, %75, %74 : i1, i1, i1, i1, i1, i1, i1, i1
-        %83 = hw.array_create %82, %73, %64, %55 : i8
-        hw.output %0, %2, %83 : i8, i1, !hw.array<4xi8>
+        %5 = sv.wire sym @complex_wire.tmp2 {name="tmp2"} : !hw.inout<!hw.array<4xi8>>
+        sv.assign %5, %I2 : !hw.array<4xi8>
+        %4 = sv.read_inout %5 : !hw.inout<!hw.array<4xi8>>
+        hw.output %0, %2, %4 : i8, i1, !hw.array<4xi8>
     }
 }

--- a/tests/test_backend/test_mlir/golds/complex_wire.v
+++ b/tests/test_backend/test_mlir/golds/complex_wire.v
@@ -7,11 +7,11 @@ module complex_wire(
   output            O1,
   output [3:0][7:0] O2);
 
-  wire [7:0]  tmp0 = I0;
-  wire        tmp1 = I1;
-  wire [31:0] tmp2 = {I2[2'h3], I2[2'h2], I2[2'h1], I2[2'h0]};
+  wire [7:0]      tmp0 = I0;
+  wire            tmp1 = I1;
+  wire [3:0][7:0] tmp2 = I2;
   assign O0 = tmp0;
   assign O1 = tmp1;
-  assign O2 = {{tmp2[31:24]}, {tmp2[23:16]}, {tmp2[15:8]}, {tmp2[7:0]}};
+  assign O2 = tmp2;
 endmodule
 

--- a/tests/test_passes/test_elaborate_generator.py
+++ b/tests/test_passes/test_elaborate_generator.py
@@ -1,0 +1,105 @@
+import magma as m
+from magma.passes.elaborate_circuit import elaborate_circuit, elaborate_all_pass
+
+
+def test_circuit():
+
+    class Ckt(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+        primitive = True
+
+        @classmethod
+        def elaborate(cls):
+            cls.io.O @= ~cls.io.I
+
+    assert repr(Ckt) == 'Ckt = DeclareCircuit("Ckt", "I", In(Bit), "O", Out(Bit))'
+    assert not m.isdefinition(Ckt)
+    assert m.isprimitive(Ckt)
+
+    elaborate_circuit(Ckt)
+    assert repr(Ckt) == ("""\
+Ckt = DefineCircuit("Ckt", "I", In(Bit), "O", Out(Bit))
+magma_Bit_not_inst0 = magma_Bit_not()
+wire(Ckt.I, magma_Bit_not_inst0.in)
+wire(magma_Bit_not_inst0.out, Ckt.O)
+EndCircuit()"""
+    )
+    assert m.isdefinition(Ckt)
+    assert not m.isprimitive(Ckt)
+
+
+def test_generator():
+
+    class Gen(m.Generator2):
+        def __init__(self):
+            self.io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+            self.primitive = True
+            self.name = "Ckt"
+
+        def elaborate(self):
+            self.io.O @= ~self.io.I
+
+    Ckt = Gen()
+
+    assert repr(Ckt) == 'Ckt = DeclareCircuit("Ckt", "I", In(Bit), "O", Out(Bit))'
+    assert not m.isdefinition(Ckt)
+    assert m.isprimitive(Ckt)
+
+    elaborate_circuit(Ckt)
+    assert repr(Ckt) == ("""\
+Ckt = DefineCircuit("Ckt", "I", In(Bit), "O", Out(Bit))
+magma_Bit_not_inst0 = magma_Bit_not()
+wire(Ckt.I, magma_Bit_not_inst0.in)
+wire(magma_Bit_not_inst0.out, Ckt.O)
+EndCircuit()"""
+    )
+    assert m.isdefinition(Ckt)
+    assert not m.isprimitive(Ckt)
+
+
+def test_pass():
+
+    class Ckt(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+        primitive = True
+
+        @classmethod
+        def elaborate(cls):
+            cls.io.O @= ~cls.io.I
+
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+        io.O @= io.I
+
+    class Top(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+
+        @classmethod
+        def elaborate(cls):
+            cls.io.O @= Foo()(Ckt()(cls.io.I))
+
+    assert repr(Ckt) == 'Ckt = DeclareCircuit("Ckt", "I", In(Bit), "O", Out(Bit))'
+    assert repr(Top) == 'Top = DeclareCircuit("Top", "I", In(Bit), "O", Out(Bit))'
+
+    elaborate_all_pass(Top, circuits=(Top,))
+
+    assert repr(Ckt) == 'Ckt = DeclareCircuit("Ckt", "I", In(Bit), "O", Out(Bit))'
+    assert repr(Top) == ("""\
+Top = DefineCircuit("Top", "I", In(Bit), "O", Out(Bit))
+Ckt_inst0 = Ckt()
+Foo_inst0 = Foo()
+wire(Top.I, Ckt_inst0.I)
+wire(Ckt_inst0.O, Foo_inst0.I)
+wire(Foo_inst0.O, Top.O)
+EndCircuit()"""
+    )
+
+    elaborate_all_pass(Top, circuits=(Ckt,))
+
+    assert repr(Ckt) == ("""\
+Ckt = DefineCircuit("Ckt", "I", In(Bit), "O", Out(Bit))
+magma_Bit_not_inst0 = magma_Bit_not()
+wire(Ckt.I, magma_Bit_not_inst0.in)
+wire(magma_Bit_not_inst0.out, Ckt.O)
+EndCircuit()"""
+    )

--- a/tests/test_simulator/test_register.py
+++ b/tests/test_simulator/test_register.py
@@ -1,4 +1,5 @@
 import magma as m
+from magma.passes.elaborate_circuit import elaborate_all_pass
 import fault as f
 
 
@@ -9,6 +10,8 @@ def test_register():
         io.O @= m.Register(
             m.Bits[4], reset_type=m.Reset
         )()(io.I)
+
+    elaborate_all_pass(Foo, generators=(m.Mux,))
 
     tester = f.PythonTester(Foo, Foo.CLK)
     tester.circuit.I = 3

--- a/tests/test_syntax/test_counter.py
+++ b/tests/test_syntax/test_counter.py
@@ -1,4 +1,5 @@
 import magma as m
+from magma.passes.elaborate_circuit import elaborate_all_pass
 from magma.simulator import PythonSimulator
 from magma.simulator.coreir_simulator import CoreIRSimulator
 from hwtypes import BitVector as BV
@@ -17,6 +18,8 @@ def test_counter():
             O = self.count
             return O
     print(repr(Counter))
+
+    elaborate_all_pass(Counter, generators=(m.Mux,))
 
     sim = PythonSimulator(Counter, Counter.CLK)
     sim.set_value(Counter.inc, True)

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -716,9 +716,11 @@ def test_lazy_array_nested(caplog):
 
     class _Test(m.Circuit):
         name = "test_when_lazy_array_nested"
-        io = m.IO(S=m.In(m.Bit), O=m.Out(m.Array[2, m.Tuple[m.Bit, m.Bit]]))
 
-        x = m.Array[2, m.Tuple[m.Bit, m.Bit]](name="x")
+        T = m.Product.from_fields("anon", {"x": m.Bit, "y": m.Bit})
+        io = m.IO(S=m.In(m.Bit), O=m.Out(m.Array[2, T]))
+
+        x = m.Array[2, T](name="x")
 
         with m.when(io.S):
             x[0][0] @= 0


### PR DESCRIPTION
* Adds the notion of "elaboration" to generators. Generators can now declare themselves as primitives and add a separate elaboration function. This is not really a first class citizen, but just an API for generators to declare themselves to have separate elaboration steps.
* Adds a pass to elaborate specified primitives
* Makes Mux an elaboratable primitive
* Adds a "flatten" option to Wire primitive which specifies whether or not the interface type is flattened to bits. Also adds this option to CoreIR wire insertion pass.