### PR TITLE
[When] Fix bug in default_driver logic

### DIFF
--- a/magma/when.py
+++ b/magma/when.py
@@ -106,12 +106,21 @@ class _BlockBase(contextlib.AbstractContextManager):
         yield from self._conditional_wires
 
     def default_drivers(self) -> Iterable[ConditionalWire]:
+        if self.root is not self:
+            raise RuntimeError("Can only get default drivers from root")
         return (
             ConditionalWire(k, v)
             for k, v in self._default_drivers.items()
         )
 
+    def get_default_drivers_dict(self) -> Iterable[ConditionalWire]:
+        if self.root is not self:
+            raise RuntimeError("Can only get default drivers from root")
+        return self._default_drivers
+
     def get_default_driver(self, drivee) -> Any:
+        if self.root is not self:
+            raise RuntimeError("Can only get default driver from root")
         return self._default_drivers[drivee]
 
     def add_default_driver(self, drivee, driver):

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -281,7 +281,9 @@ class AggregateWireable(Wireable):
         default_drivers = []
         for ctx in self._wired_when_contexts:
             conditional_wires.append(ctx.get_conditional_wires_for_drivee(self))
-            default_drivers.append(ctx._default_drivers.pop(self, None))
+            default_drivers.append(
+                ctx.root.get_default_drivers_dict().pop(self, None)
+            )
         return self._wired_when_contexts, conditional_wires, default_drivers
 
     def _rewire_conditional_children(self, wired_when_contexts,

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -869,7 +869,7 @@ def test_when_reg_ce_multiple():
     assert check_gold(__file__, f"{_Test.name}.mlir")
 
 
-def test_when_latch_zext():
+def test_when_latch_nested_multiple():
     # Should not raise a LatchError
     class _Test(m.Circuit):
         name = "test_when_latch_nested_multiple"


### PR DESCRIPTION
In the bulk resolve logic, there was a case where the root was not being used to get the default drivers, this manifested in a latch being inferred when there was nested whens and the bulk resolution was happening inside the nesting.