### PR TITLE
[When] Allow user to override implicit logic

### DIFF
--- a/magma/clock.py
+++ b/magma/clock.py
@@ -96,8 +96,7 @@ class Enable(Bit):
         if get_debug_mode() and debug_info is None:
             debug_info = get_callee_frame_info()
         if self._driven_implicitly_by_when and not driven_implicitly_by_when:
-            # User is overriding the implicit when logic
-            self.unwire(debug_info)
+            self.unwire(debug_info)  # user is overriding the implicit when logic
         super().wire(o, debug_info)
         self._driven_implicitly_by_when = driven_implicitly_by_when
 

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -100,7 +100,7 @@ class Enable(Bit):
             # a when statement, but now the user is explicitly wiring the enable
             # When this happens, we choose the user's explicit wiring, and
             # discard the implicit logic (rather than forcing the user to call
-            # rewire explicitly)
+            # rewire explicitly).
             self.unwire(debug_info)
         super().wire(o, debug_info)
         self._driven_implicitly_by_when = driven_implicitly_by_when

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -96,7 +96,12 @@ class Enable(Bit):
         if get_debug_mode() and debug_info is None:
             debug_info = get_callee_frame_info()
         if self._driven_implicitly_by_when and not driven_implicitly_by_when:
-            self.unwire(debug_info)  # user is overriding the implicit when logic
+            # In this case, the enable value was previously implicitly driven by
+            # a when statement, but now the user is explicitly wiring the enable
+            # When this happens, we choose the user's explicit wiring, and
+            # discard the implicit logic (rather than forcing the user to call
+            # rewire explicitly)
+            self.unwire(debug_info)
         super().wire(o, debug_info)
         self._driven_implicitly_by_when = driven_implicitly_by_when
 

--- a/magma/clock.py
+++ b/magma/clock.py
@@ -95,6 +95,9 @@ class Enable(Bit):
     def wire(self, o, debug_info=None, driven_implicitly_by_when=False):
         if get_debug_mode() and debug_info is None:
             debug_info = get_callee_frame_info()
+        if self._driven_implicitly_by_when and not driven_implicitly_by_when:
+            # User is overriding the implicit when logic
+            self.unwire(debug_info)
         super().wire(o, debug_info)
         self._driven_implicitly_by_when = driven_implicitly_by_when
 

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -166,10 +166,13 @@ class WhenBuilder(CircuitBuilder):
         self._add_port(port_name, type_qualifier(type(value).undirected_t))
         with no_when():
             port = getattr(self, port_name)
-            wire_kwargs = {}
             if value.is_input() and isinstance(value, Enable):
-                wire_kwargs["driven_implicitly_by_when"] = value.driven_implicitly_by_when
-            value.wire(port, **wire_kwargs)
+                value.wire(
+                    port,
+                    driven_implicitly_by_when=value.driven_implicitly_by_when
+                )
+            else:
+                wire(port, value)
         value_to_name[value] = port_name
 
     def add_drivee(self, value: Type):

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -166,13 +166,10 @@ class WhenBuilder(CircuitBuilder):
         self._add_port(port_name, type_qualifier(type(value).undirected_t))
         with no_when():
             port = getattr(self, port_name)
+            wire_kwargs = {}
             if value.is_input() and isinstance(value, Enable):
-                value.wire(
-                    port,
-                    driven_implicitly_by_when=value.driven_implicitly_by_when
-                )
-            else:
-                wire(port, value)
+                wire_kwargs["driven_implicitly_by_when"] = value.driven_implicitly_by_when
+            value.wire(port, **wire_kwargs)
         value_to_name[value] = port_name
 
     def add_drivee(self, value: Type):

--- a/tests/gold/test_when_reg_ce_implicit_override.mlir
+++ b/tests/gold/test_when_reg_ce_implicit_override.mlir
@@ -1,0 +1,27 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @test_when_reg_ce_implicit_override(%I: i8, %x: i1, %y: i1, %CLK: i1) -> (O: i8) {
+        %0 = hw.constant 1 : i1
+        %4 = sv.reg : !hw.inout<i8>
+        %2 = sv.read_inout %4 : !hw.inout<i8>
+        %5 = sv.reg : !hw.inout<i1>
+        %3 = sv.read_inout %5 : !hw.inout<i1>
+        sv.alwayscomb {
+            sv.bpassign %4, %1 : i8
+            sv.if %y {
+                sv.bpassign %4, %I : i8
+            }
+        }
+        %6 = sv.reg {name = "Register_inst0"} : !hw.inout<i8>
+        sv.alwaysff(posedge %CLK) {
+            sv.if %x {
+                sv.passign %6, %2 : i8
+            }
+        }
+        %7 = hw.constant 0 : i8
+        sv.initial {
+            sv.bpassign %6, %7 : i8
+        }
+        %1 = sv.read_inout %6 : !hw.inout<i8>
+        hw.output %1 : i8
+    }
+}

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -1137,3 +1137,20 @@ def test_when_spurious_assign():
     m.compile(f"build/{_Test.name}", _Test,
               output="mlir", flatten_all_tuples=True)
     assert check_gold(__file__, f"{_Test.name}.mlir")
+
+
+def test_reg_ce_implicit_override():
+
+    class _Test(m.Circuit):
+        name = "test_when_reg_ce_implicit_override"
+        io = m.IO(I=m.In(m.Bits[8]), O=m.Out(m.Bits[8]),
+                  x=m.In(m.Bit), y=m.In(m.Bit))
+
+        x = m.Register(m.Bits[8], has_enable=True)()
+        with m.when(io.y):
+            x.I @= io.I
+        x.CE @= io.x
+        io.O @= x.O
+
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
+    assert check_gold(__file__, f"{_Test.name}.mlir")


### PR DESCRIPTION
In the spirit of explicit is better than implicit, I think it's best if we don't require the user to use `rewire` if they want to override the implicit wire logic.  This changes the logic so that if we encounter a wire called on something implicitly wired, we remove the implicit wire (without raising an already driven error).  For this to work, we need to update the when builder code to mark that it is wiring implicitly when adding the drivee port logic.