### PR TITLE
[When] Fix bug in resolve logic for when output

### DIFF
--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -207,8 +207,7 @@ class WhenBuilder(CircuitBuilder):
         self._default_drivers[drivee] = driver
 
     def _update_resolved_refs(self):
-        """
-        When a value driven by a when is resolved, it's children are added as
+        """When a value driven by a when is resolved, its children are added as
         outputs.  The user may have referenced the unresolved when output using
         .value(), so at this point, we update all the references by checking if
         any resolved outputs are being used to drive values.
@@ -218,7 +217,7 @@ class WhenBuilder(CircuitBuilder):
                 continue
             if value.name._parent not in self._output_to_name:
                 continue
-            # Found resolved port, rewire to child output
+            # Found resolved port, rewire to child output.
             port = getattr(self, self._output_to_name[value.name._parent])
             for drivee in port[value.name.index].driving():
                 drivee.rewire(getattr(self, name))

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -8,6 +8,7 @@ from magma.circuit import Circuit, CircuitType, CircuitBuilder
 from magma.conversions import from_bits
 from magma.digital import Digital
 from magma.primitives.register import AbstractRegister
+from magma.ref import DerivedRef
 from magma.t import Type, In, Out
 from magma.when import (
     BlockBase as WhenBlock,
@@ -205,7 +206,25 @@ class WhenBuilder(CircuitBuilder):
         self.add_drivee(drivee)
         self._default_drivers[drivee] = driver
 
+    def _update_resolved_refs(self):
+        """
+        When a value driven by a when is resolved, it's children are added as
+        outputs.  The user may have referenced the unresolved when output using
+        .value(), so at this point, we update all the references by checking if
+        any resolved outputs are being used to drive values.
+        """
+        for value, name in self._output_to_name.items():
+            if not isinstance(value.name, DerivedRef):
+                continue
+            if value.name._parent not in self._output_to_name:
+                continue
+            # Found resolved port, rewire to child output
+            port = getattr(self, self._output_to_name[value.name._parent])
+            for drivee in port[value.name.index].driving():
+                drivee.rewire(getattr(self, name))
+
     def _finalize(self):
+        self._update_resolved_refs()
         # Detect latches which would be inferred from the context of the when
         # block.
         latches = find_inferred_latches(self.block)

--- a/magma/ref.py
+++ b/magma/ref.py
@@ -198,7 +198,7 @@ class LazyDefnRef(DefnRef):
 class DerivedRef(Ref):
     def __init__(self, parent, index):
         self._parent = parent
-        self.index = index
+        self._index = index
 
     def __str__(self):
         return self.qualifiedname()
@@ -214,6 +214,10 @@ class DerivedRef(Ref):
 
     def parent(self):
         return self._parent.name
+
+    @property
+    def index(self):
+        return self._index
 
 
 class ArrayRef(DerivedRef):

--- a/magma/ref.py
+++ b/magma/ref.py
@@ -196,8 +196,9 @@ class LazyDefnRef(DefnRef):
 
 
 class DerivedRef(Ref):
-    def __init__(self, parent):
+    def __init__(self, parent, index):
         self._parent = parent
+        self.index = index
 
     def __str__(self):
         return self.qualifiedname()
@@ -217,9 +218,8 @@ class DerivedRef(Ref):
 
 class ArrayRef(DerivedRef):
     def __init__(self, array, index):
-        super().__init__(array)
+        super().__init__(array, index)
         self.array = array
-        self.index = index
 
     def qualifiedname(self, sep="."):
         return f"{self.parent().qualifiedname(sep=sep)}[{self.index}]"
@@ -227,9 +227,8 @@ class ArrayRef(DerivedRef):
 
 class TupleRef(DerivedRef):
     def __init__(self, tuple, index):
-        super().__init__(tuple)
+        super().__init__(tuple, index)
         self.tuple = tuple
-        self.index = index
 
     def qualifiedname(self, sep="."):
         try:

--- a/tests/gold/test_when_output_resolve.mlir
+++ b/tests/gold/test_when_output_resolve.mlir
@@ -1,0 +1,67 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @test_when_output_resolve(%I: i8, %x: i1) -> (O0: i8, O1: i2) {
+        %1 = sv.wire sym @test_when_output_resolve.x {name="x"} : !hw.inout<i8>
+        sv.assign %1, %I : i8
+        %0 = sv.read_inout %1 : !hw.inout<i8>
+        %3 = hw.constant -1 : i8
+        %2 = comb.xor %3, %0 : i8
+        %4 = comb.extract %0 from 0 : (i8) -> i1
+        %5 = comb.extract %2 from 0 : (i8) -> i1
+        %6 = comb.extract %0 from 1 : (i8) -> i1
+        %7 = comb.extract %2 from 1 : (i8) -> i1
+        %8 = comb.extract %0 from 2 : (i8) -> i1
+        %9 = comb.extract %2 from 2 : (i8) -> i1
+        %10 = comb.extract %0 from 3 : (i8) -> i1
+        %11 = comb.extract %2 from 3 : (i8) -> i1
+        %12 = comb.extract %0 from 4 : (i8) -> i1
+        %13 = comb.extract %2 from 4 : (i8) -> i1
+        %14 = comb.extract %0 from 5 : (i8) -> i1
+        %15 = comb.extract %2 from 5 : (i8) -> i1
+        %16 = comb.extract %0 from 6 : (i8) -> i1
+        %17 = comb.extract %2 from 6 : (i8) -> i1
+        %18 = comb.extract %0 from 7 : (i8) -> i1
+        %19 = comb.extract %2 from 7 : (i8) -> i1
+        %29 = sv.reg : !hw.inout<i8>
+        %20 = sv.read_inout %29 : !hw.inout<i8>
+        %30 = sv.reg : !hw.inout<i1>
+        %21 = sv.read_inout %30 : !hw.inout<i1>
+        %31 = sv.reg : !hw.inout<i1>
+        %22 = sv.read_inout %31 : !hw.inout<i1>
+        %32 = sv.reg : !hw.inout<i1>
+        %23 = sv.read_inout %32 : !hw.inout<i1>
+        %33 = sv.reg : !hw.inout<i1>
+        %24 = sv.read_inout %33 : !hw.inout<i1>
+        %34 = sv.reg : !hw.inout<i1>
+        %25 = sv.read_inout %34 : !hw.inout<i1>
+        %35 = sv.reg : !hw.inout<i1>
+        %26 = sv.read_inout %35 : !hw.inout<i1>
+        %36 = sv.reg : !hw.inout<i1>
+        %27 = sv.read_inout %36 : !hw.inout<i1>
+        %37 = sv.reg : !hw.inout<i1>
+        %28 = sv.read_inout %37 : !hw.inout<i1>
+        sv.alwayscomb {
+            sv.if %x {
+                sv.bpassign %30, %4 : i1
+                sv.bpassign %31, %6 : i1
+                sv.bpassign %32, %8 : i1
+                sv.bpassign %33, %10 : i1
+                sv.bpassign %34, %12 : i1
+                sv.bpassign %35, %14 : i1
+                sv.bpassign %36, %16 : i1
+                sv.bpassign %37, %18 : i1
+            } else {
+                sv.bpassign %30, %5 : i1
+                sv.bpassign %31, %7 : i1
+                sv.bpassign %32, %9 : i1
+                sv.bpassign %33, %11 : i1
+                sv.bpassign %34, %13 : i1
+                sv.bpassign %35, %15 : i1
+                sv.bpassign %36, %17 : i1
+                sv.bpassign %37, %19 : i1
+            }
+        }
+        %38 = comb.concat %28, %27, %26, %25, %24, %23, %22, %21 : i1, i1, i1, i1, i1, i1, i1, i1
+        %39 = comb.concat %21, %22 : i1, i1
+        hw.output %38, %39 : i8, i2
+    }
+}

--- a/tests/gold/test_when_output_resolve2.mlir
+++ b/tests/gold/test_when_output_resolve2.mlir
@@ -1,0 +1,64 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @test_when_output_resolve2(%I: i8, %x: i1) -> (O0: i8, O1: i8) {
+        %1 = hw.constant -1 : i8
+        %0 = comb.xor %1, %I : i8
+        %2 = comb.extract %I from 0 : (i8) -> i1
+        %3 = comb.extract %0 from 0 : (i8) -> i1
+        %4 = comb.extract %I from 1 : (i8) -> i1
+        %5 = comb.extract %0 from 1 : (i8) -> i1
+        %6 = comb.extract %I from 2 : (i8) -> i1
+        %7 = comb.extract %0 from 2 : (i8) -> i1
+        %8 = comb.extract %I from 3 : (i8) -> i1
+        %9 = comb.extract %0 from 3 : (i8) -> i1
+        %10 = comb.extract %I from 4 : (i8) -> i1
+        %11 = comb.extract %0 from 4 : (i8) -> i1
+        %12 = comb.extract %I from 5 : (i8) -> i1
+        %13 = comb.extract %0 from 5 : (i8) -> i1
+        %14 = comb.extract %I from 6 : (i8) -> i1
+        %15 = comb.extract %0 from 6 : (i8) -> i1
+        %16 = comb.extract %I from 7 : (i8) -> i1
+        %17 = comb.extract %0 from 7 : (i8) -> i1
+        %27 = sv.reg : !hw.inout<i8>
+        %18 = sv.read_inout %27 : !hw.inout<i8>
+        %28 = sv.reg : !hw.inout<i1>
+        %19 = sv.read_inout %28 : !hw.inout<i1>
+        %29 = sv.reg : !hw.inout<i1>
+        %20 = sv.read_inout %29 : !hw.inout<i1>
+        %30 = sv.reg : !hw.inout<i1>
+        %21 = sv.read_inout %30 : !hw.inout<i1>
+        %31 = sv.reg : !hw.inout<i1>
+        %22 = sv.read_inout %31 : !hw.inout<i1>
+        %32 = sv.reg : !hw.inout<i1>
+        %23 = sv.read_inout %32 : !hw.inout<i1>
+        %33 = sv.reg : !hw.inout<i1>
+        %24 = sv.read_inout %33 : !hw.inout<i1>
+        %34 = sv.reg : !hw.inout<i1>
+        %25 = sv.read_inout %34 : !hw.inout<i1>
+        %35 = sv.reg : !hw.inout<i1>
+        %26 = sv.read_inout %35 : !hw.inout<i1>
+        sv.alwayscomb {
+            sv.if %x {
+                sv.bpassign %28, %2 : i1
+                sv.bpassign %29, %4 : i1
+                sv.bpassign %30, %6 : i1
+                sv.bpassign %31, %8 : i1
+                sv.bpassign %32, %10 : i1
+                sv.bpassign %33, %12 : i1
+                sv.bpassign %34, %14 : i1
+                sv.bpassign %35, %16 : i1
+            } else {
+                sv.bpassign %28, %3 : i1
+                sv.bpassign %29, %5 : i1
+                sv.bpassign %30, %7 : i1
+                sv.bpassign %31, %9 : i1
+                sv.bpassign %32, %11 : i1
+                sv.bpassign %33, %13 : i1
+                sv.bpassign %34, %15 : i1
+                sv.bpassign %35, %17 : i1
+            }
+        }
+        %36 = comb.concat %26, %25, %24, %23, %22, %21, %20, %19 : i1, i1, i1, i1, i1, i1, i1, i1
+        %37 = comb.concat %26, %25, %24, %23, %22, %21, %20, %19 : i1, i1, i1, i1, i1, i1, i1, i1
+        hw.output %36, %37 : i8, i8
+    }
+}


### PR DESCRIPTION
If the user call's .value() on a conditionally driven value, they may leave a hanging reference to a when output that was resolved.  When a value is resolved, it's children are added as output ports to the builder and original output "discarded".  To handle these stale references, at finalization we can traverse the outputs and update anything still driven by a stale output with the resolved children.