### PR TITLE
[Types] Fix bug in mixed direction Tuple wiring logic

### DIFF
--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -329,10 +329,13 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
                 debug_info=debug_info
             )
             return
-        if (
-            self.is_mixed() or o.is_mixed() or
-            self.has_elaborated_children() or o.has_elaborated_children()
-        ):
+        should_elaborate = (
+            self.is_mixed()
+            or o.is_mixed()
+            or self.has_elaborated_children()
+            or o.has_elaborated_children()
+        )
+        if should_elaborate:
             for self_elem, o_elem in zip(self, o):
                 self_elem = magma_value(self_elem)
                 o_elem = magma_value(o_elem)

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -329,9 +329,10 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
                 debug_info=debug_info
             )
             return
-        if (self.is_mixed() or
-                self.has_elaborated_children() or
-                o.has_elaborated_children()):
+        if (
+            self.is_mixed() or o.is_mixed() or
+            self.has_elaborated_children() or o.has_elaborated_children()
+        ):
             for self_elem, o_elem in zip(self, o):
                 self_elem = magma_value(self_elem)
                 o_elem = magma_value(o_elem)

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -336,6 +336,7 @@ def test_key_error():
 
 
 def test_mixed_direction_lazy_resolve(caplog):
+
     class T(m.Product):
         x = m.In(m.Bit)
         y = m.Out(m.Bit)

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -333,3 +333,26 @@ def test_key_error():
             io.I[None]
         with pytest.raises(KeyError):
             io.I[object()]
+
+
+def test_mixed_direction_lazy_resolve(caplog):
+    class T(m.Product):
+        x = m.In(m.Bit)
+        y = m.Out(m.Bit)
+
+    class U(m.Product):
+        x = m.Bit
+        y = m.Bit
+
+    class Foo(m.Circuit):
+        io = m.IO(I=T, O=m.Flip(T))
+        u = U()
+        u @= io.I  # bulk wire
+        u.y @= io.O.y
+        io.O.x @= u.x
+        assert io.O.x.value() is u.x
+        assert u.y.value() is io.O.y
+        assert u.x.value() is io.I.x
+        assert io.I.y.value() is u.y
+
+    assert not caplog.messages, "Should not raise wiring errors"


### PR DESCRIPTION
Mixed direction values should not use lazy bulk wiring but the wiring check was missing a case.