### PR TITLE
[MLIR] Add infrastructure to pass location info to IR

### DIFF
--- a/magma/backend/mlir/builtin.py
+++ b/magma/backend/mlir/builtin.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 from magma.backend.mlir.mlir import MlirDialect, begin_dialect, end_dialect
+from magma.backend.mlir.mlir import MlirLocation
 from magma.backend.mlir.mlir import MlirAttribute
 from magma.backend.mlir.mlir import MlirOp, MlirRegion, MlirBlock
 from magma.backend.mlir.mlir import MlirType
@@ -10,6 +11,11 @@ from magma.backend.mlir.printer_base import PrinterBase
 
 builtin = MlirDialect("builtin")
 begin_dialect(builtin)
+
+
+class UnknownLoc(MlirLocation):
+    def emit(self) -> str:
+        return "loc(unknown)"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/magma/backend/mlir/builtin.py
+++ b/magma/backend/mlir/builtin.py
@@ -19,6 +19,16 @@ class UnknownLoc(MlirLocation):
 
 
 @dataclasses.dataclass(frozen=True)
+class FileLineColLoc(MlirLocation):
+    file: str
+    line: int
+    col: int
+
+    def emit(self) -> str:
+        return f"loc(\"{self.file}\":{self.line}:{self.col})"
+
+
+@dataclasses.dataclass(frozen=True)
 class IntegerType(MlirType):
     n: int
 

--- a/magma/backend/mlir/compile_to_mlir.py
+++ b/magma/backend/mlir/compile_to_mlir.py
@@ -3,9 +3,15 @@ import sys
 from typing import Optional
 
 from magma.backend.mlir.compile_to_mlir_opts import CompileToMlirOpts
+from magma.backend.mlir.print_opts import PrintOpts
 from magma.backend.mlir.printer_base import PrinterBase
 from magma.backend.mlir.translation_unit import TranslationUnit
 from magma.circuit import DefineCircuitKind
+
+
+def _make_print_opts(opts: CompileToMlirOpts) -> PrintOpts:
+    print_locations = opts.location_info_style != "none"
+    return PrintOpts(print_locations=print_locations)
 
 
 def compile_to_mlir(
@@ -17,4 +23,4 @@ def compile_to_mlir(
     translation_unit = TranslationUnit(top, opts)
     translation_unit.compile()
     printer = PrinterBase(sout=sout)
-    translation_unit.mlir_module.print(printer)
+    translation_unit.mlir_module.print(printer, _make_print_opts(opts))

--- a/magma/backend/mlir/print_opts.py
+++ b/magma/backend/mlir/print_opts.py
@@ -1,0 +1,6 @@
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class PrintOpts:
+    print_locations: bool = False

--- a/magma/backend/mlir/sv.py
+++ b/magma/backend/mlir/sv.py
@@ -6,6 +6,7 @@ from magma.backend.mlir.mlir import (
     MlirDialect, MlirOp, MlirBlock, MlirValue, MlirSymbol,
     begin_dialect, end_dialect)
 from magma.backend.mlir.mlir_printer_utils import print_names, print_types
+from magma.backend.mlir.print_opts import PrintOpts
 from magma.backend.mlir.printer_base import PrinterBase
 
 
@@ -90,13 +91,13 @@ class AlwaysFFOp(MlirOp):
     def reset_block(self) -> MlirBlock:
         return self._reset_block
 
-    def print(self, printer: PrinterBase):
+    def print(self, printer: PrinterBase, opts: PrintOpts):
         printer.print(f"sv.alwaysff({self.clock_edge} ")
         print_names(self.operands[0], printer)
         printer.print(") {")
         printer.flush()
         printer.push()
-        self.body_block.print(printer)
+        self.body_block.print(printer, opts)
         printer.pop()
         printer.print("}")
         if self.reset_type is None:
@@ -107,7 +108,7 @@ class AlwaysFFOp(MlirOp):
         printer.print(") {")
         printer.flush()
         printer.push()
-        self.reset_block.print(printer)
+        self.reset_block.print(printer, opts)
         printer.pop()
         printer.print_line("}")
 
@@ -124,11 +125,11 @@ class AlwaysCombOp(MlirOp):
     def body_block(self) -> MlirBlock:
         return self._body_block
 
-    def print(self, printer: PrinterBase):
+    def print(self, printer: PrinterBase, opts: PrintOpts):
         printer.print("sv.alwayscomb {")
         printer.flush()
         printer.push()
-        self.body_block.print(printer)
+        self.body_block.print(printer, opts)
         printer.pop()
         printer.print_line("}")
 
@@ -235,11 +236,11 @@ class IfDefOp(MlirOp):
             self._else_block = self.new_region().new_block()
         return self._else_block
 
-    def print(self, printer: PrinterBase):
+    def print(self, printer: PrinterBase, opts: PrintOpts):
         printer.print(f"sv.ifdef \"{self.cond}\" {{")
         printer.flush()
         printer.push()
-        self._then_block.print(printer)
+        self._then_block.print(printer, opts)
         printer.pop()
         printer.print("}")
         if self._else_block is None:
@@ -248,7 +249,7 @@ class IfDefOp(MlirOp):
         printer.print(" else {")
         printer.flush()
         printer.push()
-        self._else_block.print(printer)
+        self._else_block.print(printer, opts)
         printer.pop()
         printer.print_line("}")
 
@@ -274,13 +275,13 @@ class IfOp(MlirOp):
             self._else_block = self.new_region().new_block()
         return self._else_block
 
-    def print(self, printer: PrinterBase):
+    def print(self, printer: PrinterBase, opts: PrintOpts):
         printer.print(f"sv.if ")
         print_names(self.operands[0], printer)
         printer.print(" {")
         printer.flush()
         printer.push()
-        self._then_block.print(printer)
+        self._then_block.print(printer, opts)
         printer.pop()
         printer.print("}")
         if self._else_block is None:
@@ -289,7 +290,7 @@ class IfOp(MlirOp):
         printer.print(" else {")
         printer.flush()
         printer.push()
-        self._else_block.print(printer)
+        self._else_block.print(printer, opts)
         printer.pop()
         printer.print_line("}")
 

--- a/tests/test_backend/test_mlir/golds/simple_comb_location_info_style_plain.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_comb_location_info_style_plain.mlir
@@ -1,9 +1,16 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=plain"} {
     hw.module @simple_comb(%a: i16, %b: i16, %c: i16) -> (y: i16, z: i16) {
         %1 = hw.constant -1 : i16
+        loc(unknown)
         %0 = comb.xor %1, %a : i16
+        loc(unknown)
         %2 = comb.or %a, %0 : i16
+        loc(unknown)
         %3 = comb.or %2, %b : i16
+        loc(unknown)
         hw.output %3, %3 : i16, i16
+        loc(unknown)
     }
+    loc(unknown)
 }
+loc(unknown)

--- a/tests/test_backend/test_mlir/golds/simple_comb_location_info_style_plain.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_comb_location_info_style_plain.mlir
@@ -11,6 +11,6 @@ module attributes {circt.loweringOptions = "locationInfoStyle=plain"} {
         hw.output %3, %3 : i16, i16
         loc(unknown)
     }
-    loc(unknown)
+    loc("file.py":100:0)
 }
 loc(unknown)

--- a/tests/test_backend/test_mlir/golds/simple_comb_location_info_style_wrapInAtSquareBracket.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_comb_location_info_style_wrapInAtSquareBracket.mlir
@@ -1,9 +1,16 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=wrapInAtSquareBracket"} {
     hw.module @simple_comb(%a: i16, %b: i16, %c: i16) -> (y: i16, z: i16) {
         %1 = hw.constant -1 : i16
+        loc(unknown)
         %0 = comb.xor %1, %a : i16
+        loc(unknown)
         %2 = comb.or %a, %0 : i16
+        loc(unknown)
         %3 = comb.or %2, %b : i16
+        loc(unknown)
         hw.output %3, %3 : i16, i16
+        loc(unknown)
     }
+    loc(unknown)
 }
+loc(unknown)

--- a/tests/test_backend/test_mlir/golds/simple_comb_location_info_style_wrapInAtSquareBracket.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_comb_location_info_style_wrapInAtSquareBracket.mlir
@@ -11,6 +11,6 @@ module attributes {circt.loweringOptions = "locationInfoStyle=wrapInAtSquareBrac
         hw.output %3, %3 : i16, i16
         loc(unknown)
     }
-    loc(unknown)
+    loc("file.py":100:0)
 }
 loc(unknown)

--- a/tests/test_backend/test_mlir/test_compile_to_mlir_local_examples.py
+++ b/tests/test_backend/test_mlir/test_compile_to_mlir_local_examples.py
@@ -3,6 +3,7 @@ import itertools
 import pytest
 
 import magma as m
+from magma.debug import debug_info
 from magma.primitives.mux import CoreIRCommonLibMuxN
 from magma.uniquification import uniquification_pass, reset_names
 
@@ -25,6 +26,14 @@ class _simple_coreir_common_lib_mux_n_wrapper(m.Circuit):
     )
     io = m.IO(I=m.In(T), O=m.Out(m.Bits[6]))
     io.O @= CoreIRCommonLibMuxN(8, 6)()(io.I)
+
+
+@contextlib.contextmanager
+def _set_debug_info(ckt, debug_info):
+    old_debug_info = ckt.debug_info
+    ckt.debug_info = debug_info
+    yield
+    ckt.debug_info = old_debug_info
 
 
 @pytest.mark.parametrize("ckt", get_local_examples())
@@ -169,7 +178,8 @@ def test_compile_to_mlir_location_info_style(ckt, location_info_style: str):
         "gold_name": gold_name,
     }
     kwargs.update({"check_verilog": False})
-    run_test_compile_to_mlir(ckt, **kwargs)
+    with _set_debug_info(ckt, debug_info("file.py", 100, "")):
+        run_test_compile_to_mlir(ckt, **kwargs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This change adds infrastructure to pass through location info to the IR. As of now, we only pass information for HW modules (module definitions/declarations). Using this infrastructure, however, we can start to pass more information down for other ops (comb ops, instances, wires, etc.).

A few things to note:
* By default, all op's location is set to "unknown" (`builtin.UnknownLoc()`/`loc(unknown)`)
* If the `location_info_style` compilation parameter is set to `"none"`, then we do not emit location attributes into the IR *either*. In this way we can keep the IR unmodified (but we are aliasing the `location_info_style` parameter to mean both for the IR and ExportVerilog...).