### PR TITLE
[Wire] Fix bug in insert_wire conversion logic

### DIFF
--- a/magma/backend/coreir/insert_coreir_wires.py
+++ b/magma/backend/coreir/insert_coreir_wires.py
@@ -1,6 +1,6 @@
 from magma.array import Array
-from magma.digital import Digital
 from magma.bits import Bits
+from magma.digital import Digital
 from magma.clock import AsyncReset, AsyncResetN, Clock, _ClockType
 from magma.conversions import as_bits, from_bits, bit, convertbit, convertbits
 from magma.digital import Digital
@@ -73,8 +73,10 @@ class InsertCoreIRWires(DefinitionPass):
             if isinstance(value, Digital):
                 wire_output = convertbit(wire_output, value_T)
             elif isinstance(value, Array):
-                wire_output = convertbits(wire_output, len(value_T), value_T,
-                                          issubclass(T, Bits))
+                wire_output = convertbits(
+                    wire_output, len(value_T), value_T,
+                    issubclass(value_T, Bits)
+                )
         value @= wire_output
 
     def _insert_wire(self, value, definition):

--- a/magma/backend/coreir/insert_coreir_wires.py
+++ b/magma/backend/coreir/insert_coreir_wires.py
@@ -65,21 +65,15 @@ class InsertCoreIRWires(DefinitionPass):
         # Could be already wired for fanout cases
         if not wire_input.driven():
             wire_input @= driver
-        recast = (
-            self._flatten
-            and (
-                isinstance(value, _ClockType)
-                and not isinstance(wire_output, type(value))
-            )
-        )
-        if not isinstance(wire_output, type(value)):
+
+        value_T = type(value)
+        if not isinstance(wire_output, value_T):
             # This mean it was cast by the user (e.g. m.clock(value)), so we
             # need to "recast" the wire output
-            T = type(value)
             if isinstance(value, Digital):
-                wire_output = convertbit(wire_output, T)
+                wire_output = convertbit(wire_output, value_T)
             elif isinstance(value, Array):
-                wire_output = convertbits(wire_output, len(T), T,
+                wire_output = convertbits(wire_output, len(value_T), value_T,
                                           issubclass(T, Bits))
         value @= wire_output
 

--- a/magma/backend/coreir/insert_coreir_wires.py
+++ b/magma/backend/coreir/insert_coreir_wires.py
@@ -1,6 +1,8 @@
 from magma.array import Array
+from magma.digital import Digital
+from magma.bits import Bits
 from magma.clock import AsyncReset, AsyncResetN, Clock, _ClockType
-from magma.conversions import as_bits, from_bits, bit, convertbit
+from magma.conversions import as_bits, from_bits, bit, convertbit, convertbits
 from magma.digital import Digital
 from magma.generator import Generator2
 from magma.passes.passes import DefinitionPass, pass_lambda
@@ -70,10 +72,15 @@ class InsertCoreIRWires(DefinitionPass):
                 and not isinstance(wire_output, type(value))
             )
         )
-        if recast:
+        if not isinstance(wire_output, type(value)):
             # This mean it was cast by the user (e.g. m.clock(value)), so we
             # need to "recast" the wire output
-            wire_output = convertbit(wire_output, type(value))
+            T = type(value)
+            if isinstance(value, Digital):
+                wire_output = convertbit(wire_output, T)
+            elif isinstance(value, Array):
+                wire_output = convertbits(wire_output, len(T), T,
+                                          issubclass(T, Bits))
         value @= wire_output
 
     def _insert_wire(self, value, definition):

--- a/tests/test_passes/test_insert_coreir_wires.py
+++ b/tests/test_passes/test_insert_coreir_wires.py
@@ -255,6 +255,7 @@ def test_insert_coreir_wires_temp_array_not_whole_anon():
 
 
 def test_insert_coreir_wires_recast():
+
     class Main(m.Circuit):
         io = m.IO(I=m.In(m.SInt[8]), O=m.Out(m.UInt[8]))
 
@@ -262,5 +263,5 @@ def test_insert_coreir_wires_recast():
         x @= io.I - 1
         io.O @= m.uint(x) + 1
 
-    # Should not raise an error
+    # Check that compilation succeeds without error.
     m.compile(f"build/insert_coreir_wires_recast", Main, output="mlir")

--- a/tests/test_passes/test_insert_coreir_wires.py
+++ b/tests/test_passes/test_insert_coreir_wires.py
@@ -252,3 +252,15 @@ def test_insert_coreir_wires_temp_array_not_whole_anon():
     assert check_files_equal(__file__,
                              f"build/insert_coreir_wires_temp_array_not_whole_anon.v",
                              f"gold/insert_coreir_wires_temp_array_not_whole_anon.v")
+
+
+def test_insert_coreir_wires_recast():
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(m.SInt[8]), O=m.Out(m.UInt[8]))
+
+        x = m.SInt[8](name="x")
+        x @= io.I - 1
+        io.O @= m.uint(x) + 1
+
+    # Should not raise an error
+    m.compile(f"build/insert_coreir_wires_recast", Main, output="mlir")


### PR DESCRIPTION
There's a certain case where we need to recast even though we haven't flattened, added a test to cover it and updated the logic to simply disptach on the type signature to determine when recast is necessary.