### PR TITLE
[MLIR] Fix compilation of unflattened tuple wires

### DIFF
--- a/tests/test_passes/gold/insert_coreir_wires_product.mlir
+++ b/tests/test_passes/gold/insert_coreir_wires_product.mlir
@@ -1,0 +1,11 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @Main(%I_x: i1, %I_y: i1) -> (O_x: i1, O_y: i1) {
+        %2 = sv.wire sym @Main.x_x {name="x_x"} : !hw.inout<i1>
+        sv.assign %2, %I_x : i1
+        %0 = sv.read_inout %2 : !hw.inout<i1>
+        %3 = sv.wire sym @Main.x_y {name="x_y"} : !hw.inout<i1>
+        sv.assign %3, %I_y : i1
+        %1 = sv.read_inout %3 : !hw.inout<i1>
+        hw.output %0, %1 : i1, i1
+    }
+}

--- a/tests/test_passes/test_insert_coreir_wires.py
+++ b/tests/test_passes/test_insert_coreir_wires.py
@@ -265,3 +265,23 @@ def test_insert_coreir_wires_recast():
 
     # Check that compilation succeeds without error.
     m.compile(f"build/insert_coreir_wires_recast", Main, output="mlir")
+
+
+def test_insert_coreir_wires_product():
+
+    class T(m.Product):
+        x = m.Bit
+        y = m.Bit
+
+    class Main(m.Circuit):
+        io = m.IO(I=m.In(T), O=m.Out(T))
+
+        x = T(name="x")
+        x @= io.I
+        io.O @= x
+
+    m.compile(f"build/insert_coreir_wires_product", Main, output="mlir",
+              flatten_all_tuples=True)
+    assert check_files_equal(__file__,
+                             "build/insert_coreir_wires_product.mlir",
+                             "gold/insert_coreir_wires_product.mlir")


### PR DESCRIPTION
With unflattened wires, we need to add the visitor logic to handle tuples that are now flattened in the backend.