### PR TITLE
[Debug] Add magma helper function annotation

### DIFF
--- a/magma/__init__.py
+++ b/magma/__init__.py
@@ -125,6 +125,7 @@ import magma.math
 from magma.when import when, elsewhen, otherwise
 from magma.value_utils import fill
 from magma.bind2 import bind2, make_bind_ports
+from magma.debug import magma_helper_function
 
 ################################################################################
 # BEGIN ALIASES

--- a/magma/bit.py
+++ b/magma/bit.py
@@ -13,7 +13,7 @@ from .digital import Digital, DigitalMeta
 from .digital import VCC, GND  # TODO(rsetaluri): only here for b.c.
 
 from magma.compatibility import IntegerTypes
-from magma.debug import debug_wire
+from magma.debug import debug_wire, magma_helper_function
 from magma.family import get_family
 from magma.interface import IO
 from magma.language_utils import primitive_to_python
@@ -66,10 +66,12 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
     def direction(self):
         return type(self).direction
 
+    @magma_helper_function
     def __invert__(self):
         # CoreIR uses not instead of invert name
         return type(self).undirected_t._declare_unary_op("not")()(self)
 
+    @magma_helper_function
     @bit_cast
     @output_only("Cannot use == on an input")
     def __eq__(self, other):
@@ -78,36 +80,44 @@ class Bit(Digital, AbstractBit, metaclass=DigitalMeta):
         # CoreIR doesn't define an eq primitive for bits
         return ~(self ^ other)
 
+    @magma_helper_function
     @bit_cast
     @output_only("Cannot use != on an input")
     def __ne__(self, other):
         # CoreIR doesn't define an ne primitive for bits
         return self ^ other
 
+    @magma_helper_function
     @bit_cast
     def __and__(self, other):
         return type(self).undirected_t._declare_binary_op("and")()(self, other)
 
+    @magma_helper_function
     @bit_cast
     def __rand__(self, other):
         return type(self).undirected_t._declare_binary_op("and")()(other, self)
 
+    @magma_helper_function
     @bit_cast
     def __or__(self, other):
         return type(self).undirected_t._declare_binary_op("or")()(self, other)
 
+    @magma_helper_function
     @bit_cast
     def __ror__(self, other):
         return type(self).undirected_t._declare_binary_op("or")()(other, self)
 
+    @magma_helper_function
     @bit_cast
     def __xor__(self, other):
         return type(self).undirected_t._declare_binary_op("xor")()(self, other)
 
+    @magma_helper_function
     @bit_cast
     def __rxor__(self, other):
         return type(self).undirected_t._declare_binary_op("xor")()(other, self)
 
+    @magma_helper_function
     def ite(self, t_branch, f_branch):
         if isinstance(t_branch, list) and isinstance(f_branch, list):
             if not len(t_branch) == len(f_branch):

--- a/magma/bit_primitives.py
+++ b/magma/bit_primitives.py
@@ -9,6 +9,7 @@ import operator
 import hwtypes as ht
 
 from magma.bit import Bit
+from magma.debug import magma_helper_function
 from magma.digital import Digital
 from magma.circuit import Circuit, coreir_port_mapping
 from magma.interface import IO
@@ -95,6 +96,7 @@ DefineUndriven = make_Define("undriven", "O", Out)
 DefineUnused = make_Define("term", "I", In)
 
 
+@magma_helper_function
 def unused(self):
     if self.is_input() or self.is_inout():
         raise TypeError("unused cannot be used with input/inout")
@@ -104,6 +106,7 @@ def unused(self):
         self._magma_unused_ = True
 
 
+@magma_helper_function
 def undriven(self):
     if self.is_output() or self.is_inout():
         raise TypeError("undriven cannot be used with output/inout")

--- a/magma/bits.py
+++ b/magma/bits.py
@@ -16,6 +16,7 @@ from .bit import Bit
 from .array import ArrayMeta, Array
 from .t import Type, Direction, In, Out
 from magma.circuit import Circuit, coreir_port_mapping
+from magma.debug import magma_helper_function
 from magma.bitutils import seq2int, int2seq
 from magma.family import get_family
 from magma.interface import IO
@@ -366,25 +367,31 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
 
         return _MagmBitsOp
 
+    @magma_helper_function
     def bvnot(self) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_unary_op("not")()(self)
 
+    @magma_helper_function
     @bits_cast
     def bvand(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("and")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvor(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("or")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvxor(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("xor")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvshl(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("shl")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvlshr(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("lshr")()(self, other)
@@ -401,14 +408,17 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def bvcomp(self, other) -> 'AbstractBitVector[1]':
         return Bits[1](self == other)
 
+    @magma_helper_function
     @bits_cast
     def bveq(self, other) -> AbstractBit:
         return type(self).undirected_t._declare_compare_op("eq")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvult(self, other) -> AbstractBit:
         return type(self).undirected_t._declare_compare_op("ult")()(self, other)
 
+    @magma_helper_function
     def bvule(self, other) -> AbstractBit:
         # For wiring
         if self.is_input():
@@ -420,10 +430,12 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return NotImplemented
         return type(self).undirected_t._declare_compare_op("ule")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvugt(self, other) -> AbstractBit:
         return type(self).undirected_t._declare_compare_op("ugt")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvuge(self, other) -> AbstractBit:
         return type(self).undirected_t._declare_compare_op("uge")()(self, other)
@@ -440,9 +452,11 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
     def bvsge(self, other) -> AbstractBit:
         raise NotImplementedError()
 
+    @magma_helper_function
     def bvneg(self) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_unary_op("neg")()(self)
 
+    @magma_helper_function
     def adc(self, other: 'Bits', carry: Bit) -> tp.Tuple['Bits', Bit]:
         """
         add with carry
@@ -459,6 +473,7 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
         res = a + b + c
         return res[0:-1], res[-1]
 
+    @magma_helper_function
     def ite(self, t_branch, f_branch) -> 'AbstractBitVector':
         type_ = type(t_branch)
         if type_ != type(f_branch):
@@ -466,22 +481,27 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
         return type(self).undirected_t._declare_ite(type_)()(
             t_branch, f_branch, self != self.make_constant(0))
 
+    @magma_helper_function
     @bits_cast
     def bvadd(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("add")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvsub(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("sub")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvmul(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("mul")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvudiv(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("udiv")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvurem(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("urem")()(self, other)
@@ -518,82 +538,102 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
         T = type(self).unsized_t
         return self.concat(T[ext](0))
 
+    @magma_helper_function
     def __invert__(self):
         return self.bvnot()
 
+    @magma_helper_function
     @_error_handler
     def __and__(self, other):
         return self.bvand(other)
 
+    @magma_helper_function
     @_error_handler
     def __rand__(self, other):
         return self.bvand(other)
 
+    @magma_helper_function
     @_error_handler
     def __or__(self, other):
         return self.bvor(other)
 
+    @magma_helper_function
     @_error_handler
     def __ror__(self, other):
         return self.bvor(other)
 
+    @magma_helper_function
     @_error_handler
     def __xor__(self, other):
         return self.bvxor(other)
 
+    @magma_helper_function
     @_error_handler
     def __rxor__(self, other):
         return self.bvxor(other)
 
+    @magma_helper_function
     @_error_handler
     def __lshift__(self, other):
         return self.bvshl(other)
 
+    @magma_helper_function
     @_error_handler
     def __rlshift__(self, other):
         return type(self)(other) << self
 
+    @magma_helper_function
     @_error_handler
     def __rshift__(self, other):
         return self.bvlshr(other)
 
+    @magma_helper_function
     @_error_handler
     def __rrshift__(self, other):
         return type(self)(other) >> self
 
+    @magma_helper_function
     @output_only("Cannot use == on an input")
     @_error_handler
     def __eq__(self, other):
         return self.bveq(other)
 
+    @magma_helper_function
     @output_only("Cannot use != on an input")
     @_error_handler
     def __ne__(self, other):
         return self.bvne(other)
 
+    @magma_helper_function
     def __neg__(self):
         return self.bvneg()
 
+    @magma_helper_function
     @_error_handler
     def __add__(self, other):
         return self.bvadd(other)
 
+    @magma_helper_function
     @_error_handler
     def __radd__(self, other):
         return self.bvadd(other)
 
+    @magma_helper_function
     @_error_handler
     def __sub__(self, other):
         return self.bvsub(other)
 
+    @magma_helper_function
     @_error_handler
     def __rsub__(self, other):
         return type(self)(other) - self
 
+    @magma_helper_function
     @_error_handler
     def __mul__(self, other):
         return self.bvmul(other)
 
+    @magma_helper_function
     @_error_handler
     def __rmul__(self, other):
         return self.bvmul(other)
@@ -637,12 +677,15 @@ class Bits(Array, AbstractBitVector, metaclass=BitsMeta):
             return type(self)[len(result)](result)
         return super().__getitem__(index)
 
+    @magma_helper_function
     def reduce_or(self):
         return reduce(operator.or_, self)
 
+    @magma_helper_function
     def reduce_xor(self):
         return reduce(operator.xor, self)
 
+    @magma_helper_function
     def reduce_and(self):
         return reduce(operator.and_, self)
 
@@ -684,14 +727,17 @@ class Int(Bits):
     """
     Defines shared right-hand operators for UInt/SInt
     """
+    @magma_helper_function
     @_error_handler
     def __rfloordiv__(self, other):
         return type(self)(other) // self
 
+    @magma_helper_function
     @_error_handler
     def __rtruediv__(self, other):
         return type(self)(other) / self
 
+    @magma_helper_function
     @_error_handler
     def __rmod__(self, other):
         return type(self)(other) % self
@@ -700,30 +746,37 @@ class Int(Bits):
 class UInt(Int):
     hwtypes_T = ht.UIntVector
 
+    @magma_helper_function
     @_error_handler
     def __floordiv__(self, other):
         return self.bvudiv(other)
 
+    @magma_helper_function
     @_error_handler
     def __truediv__(self, other):
         return self.bvudiv(other)
 
+    @magma_helper_function
     @_error_handler
     def __mod__(self, other):
         return self.bvurem(other)
 
+    @magma_helper_function
     @_error_handler
     def __ge__(self, other):
         return self.bvuge(other)
 
+    @magma_helper_function
     @_error_handler
     def __gt__(self, other):
         return self.bvugt(other)
 
+    @magma_helper_function
     @_error_handler
     def __le__(self, other):
         return self.bvule(other)
 
+    @magma_helper_function
     @_error_handler
     def __lt__(self, other):
         return self.bvult(other)
@@ -736,10 +789,12 @@ class SInt(Int):
     def _extend(cls, args):
         return args + [args[-1] for _ in range(cls.N - len(args))]
 
+    @magma_helper_function
     @bits_cast
     def bvslt(self, other) -> AbstractBit:
         return type(self).undirected_t._declare_compare_op("slt")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvsle(self, other) -> AbstractBit:
         # For wiring
@@ -747,58 +802,72 @@ class SInt(Int):
             return Type.__le__(self, other)
         return type(self).undirected_t._declare_compare_op("sle")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvsgt(self, other) -> AbstractBit:
         return type(self).undirected_t._declare_compare_op("sgt")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvsge(self, other) -> AbstractBit:
         return type(self).undirected_t._declare_compare_op("sge")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvsdiv(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("sdiv")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvsrem(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("srem")()(self, other)
 
+    @magma_helper_function
     @bits_cast
     def bvashr(self, other) -> 'AbstractBitVector':
         return type(self).undirected_t._declare_binary_op("ashr")()(self, other)
 
+    @magma_helper_function
     @_error_handler
     def __mod__(self, other):
         return self.bvsrem(other)
 
+    @magma_helper_function
     @_error_handler
     def __floordiv__(self, other):
         return self.bvsdiv(other)
 
+    @magma_helper_function
     @_error_handler
     def __truediv__(self, other):
         return self.bvsdiv(other)
 
+    @magma_helper_function
     @_error_handler
     def __ge__(self, other):
         return self.bvsge(other)
 
+    @magma_helper_function
     @_error_handler
     def __gt__(self, other):
         return self.bvsgt(other)
 
+    @magma_helper_function
     @_error_handler
     def __le__(self, other):
         return self.bvsle(other)
 
+    @magma_helper_function
     @_error_handler
     def __lt__(self, other):
         return self.bvslt(other)
 
+    @magma_helper_function
     @_error_handler
     def __rshift__(self, other):
         return self.bvashr(other)
 
+    @magma_helper_function
     def adc(self, other: 'Bits', carry: Bit) -> tp.Tuple['Bits', Bit]:
         """
         add with carry
@@ -860,6 +929,7 @@ _OP_MAP = {
 }
 
 
+@magma_helper_function
 def reduce(operator, bits: Bits):
     if not isinstance(bits, Bits):
         raise TypeError("m.reduce only works with Bits")

--- a/magma/circuit.py
+++ b/magma/circuit.py
@@ -328,7 +328,8 @@ class CircuitKind(type):
         return cls
 
     def __call__(cls, *largs, **kwargs):
-        kwargs["debug_info"] = get_debug_info(3)
+        if "debug_info" not in kwargs:
+            kwargs["debug_info"] = get_debug_info(3)
         self = super(CircuitKind, cls).__call__(*largs, **kwargs)
         if hasattr(cls, 'IO'):
             interface = cls.IO(inst=self, renamed_ports=cls.renamed_ports)

--- a/magma/common.py
+++ b/magma/common.py
@@ -22,6 +22,12 @@ class Stack:
     def peek(self):
         return self._stack[-1]
 
+    def peek_default(self, default: Any) -> Any:
+        try:
+            return self._stack[-1]
+        except IndexError:
+            return default
+
     def __bool__(self) -> bool:
         return bool(self._stack)
 

--- a/magma/debug.py
+++ b/magma/debug.py
@@ -1,11 +1,13 @@
-from dataclasses import dataclass
-import uinspect
 import collections
+import dataclasses
+import functools
+import uinspect
 
+from magma.common import Stack
 from magma.config import config, RuntimeConfig
 
 
-@dataclass
+@dataclasses.dataclass
 class _DebugInfo:
     filename: str
     lineno: int
@@ -18,7 +20,17 @@ debug_info = _DebugInfo
 config.register(use_uinspect=RuntimeConfig(True))
 
 
+_extra_frames_to_skip_stack = Stack()
+
+
+def _get_extra_frames_to_skip_stack():
+    global _extra_frames_to_skip_stack
+    return _extra_frames_to_skip_stack
+
+
 def get_debug_info(frames_to_skip):
+    extra_frames_to_skip = _get_extra_frames_to_skip_stack().peek_default(0)
+    frames_to_skip += extra_frames_to_skip
     if config.use_uinspect:
         filename, lineno = uinspect.get_location(frames_to_skip)
     else:
@@ -44,3 +56,30 @@ def debug_unwire(fn):
             debug_info = get_debug_info(3)
         return fn(i, o, debug_info, keep_wired_when_contexts)
     return unwire
+
+
+def _helper_function(fn):
+
+    @functools.wraps(fn)
+    def _wrapper(*args, **kwargs):
+        extra_frames_to_skip_stack = _get_extra_frames_to_skip_stack()
+        # We keep track of the previous frames_to_skip value since the stack is
+        # additive.
+        try:
+            offset = extra_frames_to_skip_stack.peek()
+        except IndexError:
+            offset = 0
+        # NOTE(rsetaluri): We need to skip an extra frame (1 + 1 = 2) since we
+        # are returning a wrapped function (decorated).
+        extra_frames_to_skip_stack.push(2 + offset)
+        try:
+            return fn(*args, **kwargs)
+        except:
+            raise
+        finally:
+            extra_frames_to_skip_stack.pop()
+
+    return _wrapper
+
+
+magma_helper_function = _helper_function

--- a/magma/generator.py
+++ b/magma/generator.py
@@ -7,6 +7,7 @@ from .circuit import (DefineCircuitKind, Circuit, DebugCircuit,
 from . import cache_definition
 from magma.common import ParamDict
 from magma.config import config
+from magma.debug import get_debug_info
 from hwtypes import BitVector
 
 
@@ -138,6 +139,8 @@ class Generator2(metaclass=_Generator2Meta):
         return type.__new__(metacls, name, bases, dct)
 
     def __call__(cls, *args, **kwargs):
+        if "debug_info" not in kwargs:
+            kwargs["debug_info"] = get_debug_info(4)
         return type(cls)._base_metacls_.__call__(cls, *args, **kwargs)
 
     @classmethod

--- a/magma/primitives/mux.py
+++ b/magma/primitives/mux.py
@@ -9,6 +9,7 @@ from magma.bits import Bits, UInt, SInt
 from magma.bitutils import clog2, seq2int
 from magma.circuit import coreir_port_mapping
 from magma.common import is_int
+from magma.debug import magma_helper_function
 from magma.generator import Generator2
 from magma.interface import IO
 from magma.protocol_type import MagmaProtocol, magma_type
@@ -142,6 +143,7 @@ def _infer_mux_type(args):
 infer_mux_type = _infer_mux_type
 
 
+@magma_helper_function
 def mux(I: Union[Sequence, Array], S, **kwargs):
     """
     How type inference works on I:
@@ -180,6 +182,7 @@ Bit._mux = staticmethod(mux)
 # NOTE(rsetaluri): We monkeypatch this function on to Array due to the circular
 # dependency between Mux and Array. See the discussion on
 # https://github.com/phanrahan/magma/pull/658.
+@magma_helper_function
 def _dynamic_mux_select(this, key):
     return mux(this.ts, key)
 
@@ -187,6 +190,7 @@ def _dynamic_mux_select(this, key):
 Array.dynamic_mux_select = _dynamic_mux_select
 
 
+@magma_helper_function
 def dict_lookup(dict_, select, default=0):
     """
     Use `select` as an index into `dict` (similar to a case statement)
@@ -200,6 +204,7 @@ def dict_lookup(dict_, select, default=0):
     return output
 
 
+@magma_helper_function
 def list_lookup(list_, select, default=0):
     """
     Use `select` as an index into `list` (similar to a case statement)

--- a/magma/primitives/register.py
+++ b/magma/primitives/register.py
@@ -10,6 +10,7 @@ from magma.common import ParamDict
 from magma.bits import Bits, UInt, SInt
 from magma.circuit import coreir_port_mapping, Circuit
 from magma.conversions import as_bits, from_bits, bit
+from magma.debug import magma_helper_function
 from magma.interface import IO
 from magma.generator import Generator2
 from magma.t import Type, Kind, In, Out, Direction
@@ -239,6 +240,7 @@ class Register(AbstractRegister):
         return getattr(inst, self.CE_name, None)
 
 
+@magma_helper_function
 def register(value, **kwargs):
     T = type(value).qualify(Direction.Undirected)
     inst_kwargs = {}

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -21,6 +21,7 @@ def test_magma_debug_ext():
         lambda: ~(m.Bit()),
         lambda: ~(m.Bits[8]()),
         lambda: m.mux([m.Bit(), m.Bit()], m.Bit()),
+        lambda: m.register(m.Bit()),
     )
 )
 def test_primitive_debug_info(op):

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -15,11 +15,18 @@ def test_magma_debug_ext():
     )
 
 
-@pytest.mark.parametrize('T', (m.Bit, m.Bits[8],))
-def test_primitive_debug_info(T):
+@pytest.mark.parametrize(
+    'op',
+    (
+        lambda: ~(m.Bit()),
+        lambda: ~(m.Bits[8]()),
+        lambda: m.mux([m.Bit(), m.Bit()], m.Bit()),
+    )
+)
+def test_primitive_debug_info(op):
 
     class Foo(m.Circuit):
-        ~(T())  # just to instance some primitive
+        op()  # just to instance some primitive
 
     inst = Foo.instances[0]
     assert inst.debug_info.filename == __file__

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,5 +1,8 @@
 import os
+import pathlib
+import pytest
 
+import magma as m
 from magma.debug import get_debug_info, debug_info
 
 
@@ -7,6 +10,18 @@ def test_magma_debug_ext():
     filedir = os.path.realpath(os.path.dirname(__file__))
     assert get_debug_info(2) == debug_info(
         f"{filedir}/test_debug.py",
-        8,
+        11,
         None
     )
+
+
+@pytest.mark.parametrize('T,name', ((m.Bit, "bit"), (m.Bits[8], "bits")))
+def test_primitive_debug_info(T, name):
+
+    class Foo(m.Circuit):
+        ~(T())  # just to instance some primitive
+
+    inst = Foo.instances[0]
+    filename = pathlib.Path(inst.debug_info.filename)
+    filename = pathlib.Path("/".join(filename.parts[-2:]))
+    assert str(filename) == f"magma/{name}.py"

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -15,16 +15,14 @@ def test_magma_debug_ext():
     )
 
 
-@pytest.mark.parametrize('T,name', ((m.Bit, "bit"), (m.Bits[8], "bits")))
-def test_primitive_debug_info(T, name):
+@pytest.mark.parametrize('T', (m.Bit, m.Bits[8],))
+def test_primitive_debug_info(T):
 
     class Foo(m.Circuit):
         ~(T())  # just to instance some primitive
 
     inst = Foo.instances[0]
-    filename = pathlib.Path(inst.debug_info.filename)
-    filename = pathlib.Path("/".join(filename.parts[-2:]))
-    assert str(filename) == f"magma/{name}.py"
+    assert inst.debug_info.filename == __file__
 
 
 def test_helper_function():


### PR DESCRIPTION
This introduces the `@magma_helper_function` annotation (decorator) which can be used to mark functions which instantiate magma circuits. Such functions will then defer to the caller to retrieve debug information (for source location annotations in generated code).