### PR TITLE
[Types] Fix bug in digital.is_wireable logic

### DIFF
--- a/magma/digital.py
+++ b/magma/digital.py
@@ -136,9 +136,8 @@ class DigitalMeta(ABCMeta, Kind):
             return True
         rhs = magma_type(rhs)
         # allows undirected types to match (e.g. for temporary values)
-        return (issubclass(rhs.flip(), cls) or issubclass(cls, rhs.flip()) or
-                cls.qualify(Direction.Undirected) is rhs or
-                rhs.qualify(Direction.Undirected) is cls)
+        return (issubclass(rhs.undirected_t, cls.undirected_t) or
+                issubclass(cls.undirected_t, rhs.undirected_t))
 
     def is_bindable(cls, rhs):
         return issubclass(cls, magma_type(rhs))

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -136,8 +136,10 @@ class DigitalMeta(ABCMeta, Kind):
             return True
         rhs = magma_type(rhs)
         # allows undirected types to match (e.g. for temporary values)
-        return (issubclass(rhs.undirected_t, cls.undirected_t) or
-                issubclass(cls.undirected_t, rhs.undirected_t))
+        return (
+            issubclass(rhs.undirected_t, cls.undirected_t)
+            or issubclass(cls.undirected_t, rhs.undirected_t)
+        )
 
     def is_bindable(cls, rhs):
         return issubclass(cls, magma_type(rhs))

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -136,8 +136,12 @@ class DigitalMeta(ABCMeta, Kind):
             return True
         rhs = magma_type(rhs)
         # allows undirected types to match (e.g. for temporary values)
-        return (issubclass(rhs.undirected_t, cls.undirected_t) or
-                issubclass(cls.undirected_t, rhs.undirected_t))
+        return (
+            issubclass(rhs.flip(), cls) or
+            issubclass(cls, rhs.flip()) or
+            issubclass(rhs, cls.qualify(Direction.Undirected)) or
+            issubclass(cls, rhs.qualify(Direction.Undirected))
+        )
 
     def is_bindable(cls, rhs):
         return issubclass(cls, magma_type(rhs))

--- a/magma/digital.py
+++ b/magma/digital.py
@@ -136,12 +136,8 @@ class DigitalMeta(ABCMeta, Kind):
             return True
         rhs = magma_type(rhs)
         # allows undirected types to match (e.g. for temporary values)
-        return (
-            issubclass(rhs.flip(), cls) or
-            issubclass(cls, rhs.flip()) or
-            issubclass(rhs, cls.qualify(Direction.Undirected)) or
-            issubclass(cls, rhs.qualify(Direction.Undirected))
-        )
+        return (issubclass(rhs.undirected_t, cls.undirected_t) or
+                issubclass(cls.undirected_t, rhs.undirected_t))
 
     def is_bindable(cls, rhs):
         return issubclass(cls, magma_type(rhs))

--- a/tests/test_circuit/test_new_style_syntax.py
+++ b/tests/test_circuit/test_new_style_syntax.py
@@ -107,7 +107,7 @@ def test_defn_wiring_error(caplog):
     assert not m.isdefinition(_Foo)
     assert has_error(caplog,
                      """\
-tests/test_circuit/test_new_style_syntax.py:104: Cannot wire _Foo.I (Out(Bit)) to _Foo.O (Out(Bit))
+tests/test_circuit/test_new_style_syntax.py:104: Using `_Foo.O` (an output) as an input
 >>         m.wire(io.I, io.O)\
 """)
     assert has_error(caplog,

--- a/tests/test_type/test_product.py
+++ b/tests/test_type/test_product.py
@@ -2,9 +2,7 @@ import magma as m
 
 
 def test_anon_product_literal():
-    class Foo(m.Circuit):
-        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
-
-        x = m.AnonProduct[{"I": m.Bit, "CE": m.Bit}]()
-        x @= m.product(I=io.I, CE=False)
-    assert Foo.x.CE.value() is m.GND
+    I = m.Bit()
+    x = m.AnonProduct[{"I": m.Bit, "CE": m.Bit}]()
+    x @= m.product(I=I, CE=False)
+    assert x.CE.value() is m.GND

--- a/tests/test_type/test_product.py
+++ b/tests/test_type/test_product.py
@@ -1,0 +1,10 @@
+import magma as m
+
+
+def test_anon_product_literal():
+    class Foo(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+
+        x = m.AnonProduct[{"I": m.Bit, "CE": m.Bit}]()
+        x @= m.product(I=io.I, CE=False)
+    assert Foo.x.CE.value() is m.GND

--- a/tests/test_wire/test_errors.py
+++ b/tests/test_wire/test_errors.py
@@ -20,7 +20,7 @@ def test_input_as_output(caplog):
         buf = Buf()
         wire(io.O, buf.I)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:21\033[0m: Cannot wire main.O (In(Bit)) to main.buf.I (In(Bit))
+\033[1mtests/test_wire/test_errors.py:21\033[0m: Using `main.O` (an input) as an output
 >>         wire(io.O, buf.I)"""
     assert has_error(caplog, msg)
     magma.config.set_debug_mode(False)
@@ -38,7 +38,7 @@ def test_output_as_input(caplog):
         a = A()
         wire(io.I, a.O)
     msg = """\
-\033[1mtests/test_wire/test_errors.py:39\033[0m: Cannot wire main.I (Out(Bit)) to main.a.O (Out(Bit))
+\033[1mtests/test_wire/test_errors.py:39\033[0m: Using `main.a.O` (an output) as an input
 >>         wire(io.I, a.O)"""
     assert has_error(caplog, msg)
     magma.config.set_debug_mode(False)


### PR DESCRIPTION
The existing logic did not handle the case when the undirected types were subclases of each other.  This fixes it by simplifying the logic to just check whether the undirected types are compatible.