### PR TITLE
[When] hotfix handling of wiring directly to when output

### DIFF
--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -663,13 +663,10 @@ class ModuleVisitor:
         output_to_index = {}
 
         def _visit(value, counter, value_to_index):
-            # NOTE(leonardt): value may already be in value_to_index, in which
-            # case we update it to a new index.  This is okay and it just means
-            # that `value` occurs as more than one input (for example, it could
-            # be used as a conditional driver for multiple values).  We could
-            # optimize the logic to always share the same argument, but for now
-            # we just use the "last" index.
             if isinstance(value.name, TupleRef) and value in value_to_index:
+                # tuples are flattened by the
+                # `visit_magma_value_or_value_wrapper_by_direction`, so we avoid
+                # adding them twice which invalidates the count logic
                 return
             for ref in value.name.root_iter(
                 stop_if=lambda ref: not isinstance(ref, (ArrayRef, TupleRef))
@@ -678,6 +675,12 @@ class ModuleVisitor:
                     # Don't add, only need its parent
                     return
 
+            # NOTE(leonardt): value may already be in value_to_index, in which
+            # case we update it to a new index.  This is okay and it just means
+            # that `value` occurs as more than one input (for example, it could
+            # be used as a conditional driver for multiple values).  We could
+            # optimize the logic to always share the same argument, but for now
+            # we just use the "last" index.
             value_to_index[value] = next(counter)
 
         counter = itertools.count()

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -57,7 +57,7 @@ from magma.primitives.when import iswhen
 from magma.primitives.wire import Wire
 from magma.primitives.xmr import XMRSink, XMRSource
 from magma.protocol_type import magma_value as get_magma_value
-from magma.ref import ArrayRef
+from magma.ref import ArrayRef, TupleRef
 from magma.t import Kind, Type
 from magma.tuple import TupleMeta, Tuple as m_Tuple
 from magma.value_utils import make_selector, TupleSelector, ArraySelector
@@ -669,10 +669,12 @@ class ModuleVisitor:
             # be used as a conditional driver for multiple values).  We could
             # optimize the logic to always share the same argument, but for now
             # we just use the "last" index.
+            if isinstance(value.name, TupleRef) and value in value_to_index:
+                return
             for ref in value.name.root_iter(
-                stop_if=lambda ref: not isinstance(ref, ArrayRef)
+                stop_if=lambda ref: not isinstance(ref, (ArrayRef, TupleRef))
             ):
-                if ref.array in value_to_index:
+                if ref.parent_value in value_to_index:
                     # Don't add, only need its parent
                     return
 

--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -726,11 +726,13 @@ class ModuleVisitor:
                 if not isinstance(ref, ArrayRef):
                     return None, None
                 try:
-                    wire = collection[to_index[ref.array]]
-                    parent = ref.array
-                    break
+                    idx = to_index[ref.array]
                 except KeyError:
                     pass  # try next parent
+                else:
+                    wire = collection[idx]
+                    parent = ref.array
+                    break
             else:
                 return None, None  # didn't find parent
 

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -155,15 +155,14 @@ class WhenBuilder(CircuitBuilder):
         which allows us to maintain bulk assignments in the eventual generated
         if statement, rather that elaborating into per-child assignments
         """
-        # root_value = get_parent_array(value)
         if not isinstance(value.name, ArrayRef):
             return None
         curr_root = None
-        curr_value = value
-        while isinstance(curr_value.name, ArrayRef):
-            curr_value = curr_value.name.parent_value
-            if curr_value in value_to_index:
-                curr_root = curr_value
+        for ref in value.name.root_iter():
+            if not isinstance(ref, ArrayRef):
+                break
+            if ref.array in value_to_index:
+                curr_root = ref.array
         if not curr_root:
             return
         root_port = getattr(self, value_to_name[curr_root])
@@ -193,7 +192,6 @@ class WhenBuilder(CircuitBuilder):
             self._add_port(port_name, type_qualifier(type(value).undirected_t))
             port = getattr(self, port_name)
             port.is_when_port = True
-            port.orig_when_value = value
 
         with no_when():
             if value.is_input() and isinstance(value, Enable):

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -158,9 +158,9 @@ class WhenBuilder(CircuitBuilder):
         if not isinstance(value.name, ArrayRef):
             return None
         curr_root = None
-        for ref in value.name.root_iter():
-            if not isinstance(ref, ArrayRef):
-                break
+        for ref in value.name.root_iter(
+            stop_if=lambda ref: not isinstance(ref, ArrayRef)
+        ):
             if ref.array in value_to_index:
                 curr_root = ref.array
         if not curr_root:

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -8,7 +8,7 @@ from magma.clock import Enable
 from magma.conversions import from_bits
 from magma.digital import Digital
 from magma.primitives.register import AbstractRegister
-from magma.ref import ArrayRef
+from magma.ref import ArrayRef, TupleRef
 from magma.t import Type, In, Out
 from magma.when import (
     BlockBase as WhenBlock,
@@ -157,10 +157,10 @@ class WhenBuilder(CircuitBuilder):
         """
         curr_root = None
         for ref in value.name.root_iter(
-            stop_if=lambda ref: not isinstance(ref, ArrayRef)
+            stop_if=lambda ref: not isinstance(ref, (ArrayRef, TupleRef))
         ):
-            if ref.array in value_to_index:
-                curr_root = ref.array
+            if ref.parent_value in value_to_index:
+                curr_root = ref.parent_value
         if not curr_root:
             return
         root_port = getattr(self, value_to_name[curr_root])

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -8,7 +8,7 @@ from magma.clock import Enable
 from magma.conversions import from_bits
 from magma.digital import Digital
 from magma.primitives.register import AbstractRegister
-from magma.ref import get_parent_array
+from magma.ref import ArrayRef
 from magma.t import Type, In, Out
 from magma.when import (
     BlockBase as WhenBlock,
@@ -155,13 +155,19 @@ class WhenBuilder(CircuitBuilder):
         which allows us to maintain bulk assignments in the eventual generated
         if statement, rather that elaborating into per-child assignments
         """
-        root_value = get_parent_array(value)
-        if root_value is None:
+        # root_value = get_parent_array(value)
+        if not isinstance(value.name, ArrayRef):
+            return None
+        curr_root = None
+        curr_value = value
+        while isinstance(curr_value.name, ArrayRef):
+            curr_value = curr_value.name.parent_value
+            if curr_value in value_to_index:
+                curr_root = curr_value
+        if not curr_root:
             return
-        if root_value not in value_to_index:
-            return
-        root_port = getattr(self, value_to_name[root_value])
-        return make_selector(value, stop_at=root_value).select(root_port)
+        root_port = getattr(self, value_to_name[curr_root])
+        return make_selector(value, stop_at=curr_root).select(root_port)
 
     def _generic_add(
             self,
@@ -186,6 +192,8 @@ class WhenBuilder(CircuitBuilder):
         if port is None:
             self._add_port(port_name, type_qualifier(type(value).undirected_t))
             port = getattr(self, port_name)
+            port.is_when_port = True
+            port.orig_when_value = value
 
         with no_when():
             if value.is_input() and isinstance(value, Enable):

--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -155,8 +155,6 @@ class WhenBuilder(CircuitBuilder):
         which allows us to maintain bulk assignments in the eventual generated
         if statement, rather that elaborating into per-child assignments
         """
-        if not isinstance(value.name, ArrayRef):
-            return None
         curr_root = None
         for ref in value.name.root_iter(
             stop_if=lambda ref: not isinstance(ref, ArrayRef)

--- a/magma/ref.py
+++ b/magma/ref.py
@@ -37,12 +37,14 @@ class Ref:
             return self
         return parent.root()
 
-    def root_iter(self) -> typing.Optional['Ref']:
+    def root_iter(self, stop_if=None) -> typing.Optional['Ref']:
+        if stop_if is not None and stop_if(self):
+            return
         yield self
         parent = self.parent()
         if parent is self:
             return
-        yield from parent.root_iter()
+        yield from parent.root_iter(stop_if=stop_if)
 
 
 class AnonRef(Ref):

--- a/magma/ref.py
+++ b/magma/ref.py
@@ -37,6 +37,13 @@ class Ref:
             return self
         return parent.root()
 
+    def root_iter(self) -> typing.Optional['Ref']:
+        yield self
+        parent = self.parent()
+        if parent is self:
+            return
+        yield from parent.root_iter()
+
 
 class AnonRef(Ref):
     def __init__(self):

--- a/magma/ref.py
+++ b/magma/ref.py
@@ -295,12 +295,3 @@ def get_ref_defn(ref):
 def is_temp_ref(ref):
     root = ref.root()
     return isinstance(root, (TempNamedRef, AnonRef))
-
-
-def get_parent_array(value):
-    if not isinstance(value.name, ArrayRef):
-        return None
-    root_value = value
-    while isinstance(root_value.name, ArrayRef):
-        root_value = root_value.name.parent_value
-    return root_value

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -355,7 +355,6 @@ class AggregateWireable(Wireable):
 
         * default_drivers: for each ctx in `wired_when_contexts`, contains the
                            default driver (if it exists) for `self`.
-        block = get_ref_inst(self.name).block
         """
         conditional_wires = []
         default_drivers = []

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -306,7 +306,7 @@ class Wireable:
             except KeyError:
                 pass
             else:
-                ctx.add_default_driver(self, default)
+                ctx.root.add_default_driver(self, default)
             for wire in ctx.get_conditional_wires_for_drivee(driving):
                 ctx.add_conditional_wire(self, wire.driver)
             self._wired_when_contexts.append(ctx)

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -302,10 +302,11 @@ class Wireable:
         driving = o.driving()[0]
         for ctx in driving._wired_when_contexts:
             try:
-                ctx.add_default_driver(self,
-                                       ctx.root.get_default_driver(driving))
+                default = ctx.root.get_default_driver(driving)
             except KeyError:
                 pass
+            else:
+                ctx.add_default_driver(self, default)
             for wire in ctx.get_conditional_wires_for_drivee(driving):
                 ctx.add_conditional_wire(self, wire.driver)
             self._wired_when_contexts.append(ctx)

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -394,7 +394,6 @@ class AggregateWireable(Wireable):
 
     def _resolve_conditional_children(self, value):
         # Save conditional wire info before unwire happens
-                # Special handling if `o` is a reference to a when output
         info = self._get_conditional_drivee_info()
 
         AggregateWireable.unwire(self, value)

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -300,16 +300,14 @@ class Wireable:
         for two different conditionally driven values, even if they have the
         same drivers)."""
         driving = o.driving()[0]
+        root = driving._wired_when_contexts[0].root
+        try:
+            default = root.get_default_driver(driving)
+        except KeyError:
+            pass
+        else:
+            root.add_default_driver(self, default)
         for ctx in driving._wired_when_contexts:
-            try:
-                ctx.root.get_default_driver(self)
-            except KeyError:
-                try:
-                    default = ctx.root.get_default_driver(driving)
-                except KeyError:
-                    pass
-                else:
-                    ctx.root.add_default_driver(self, default)
             for wire in ctx.get_conditional_wires_for_drivee(driving):
                 ctx.add_conditional_wire(self, wire.driver)
             self._wired_when_contexts.append(ctx)

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -293,6 +293,12 @@ class Wireable:
             self._remove_from_wired_when_contexts()
 
     def _when_output_wire(self, o, debug_info):
+        """In order to maintain consistency, we add a new set of conditional
+        wires corresponding to the drivers of `o` (when output) to `self`.  This
+        way, there is always a consistent set of conditional wires for every
+        value driven by a when (rather than simply sharing the same when output
+        for two different conditionally driven values, even if they have the
+        same drivers)."""
         driving = o.driving()[0]
         for ctx in driving._wired_when_contexts:
             try:
@@ -306,6 +312,7 @@ class Wireable:
 
     def _wire_impl(self, o, debug_info):
         if o.root().is_when_port and o.driving():
+            # Special handling if `o` is a reference to a when output
             return self._when_output_wire(o, debug_info)
         self._wire.connect(o._wire, debug_info)
         self.debug_info = debug_info

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -302,11 +302,14 @@ class Wireable:
         driving = o.driving()[0]
         for ctx in driving._wired_when_contexts:
             try:
-                default = ctx.root.get_default_driver(driving)
+                ctx.root.get_default_driver(self):
             except KeyError:
-                pass
-            else:
-                ctx.root.add_default_driver(self, default)
+                try:
+                    default = ctx.root.get_default_driver(driving)
+                except KeyError:
+                    pass
+                else:
+                    ctx.root.add_default_driver(self, default)
             for wire in ctx.get_conditional_wires_for_drivee(driving):
                 ctx.add_conditional_wire(self, wire.driver)
             self._wired_when_contexts.append(ctx)

--- a/magma/wire_container.py
+++ b/magma/wire_container.py
@@ -302,7 +302,7 @@ class Wireable:
         driving = o.driving()[0]
         for ctx in driving._wired_when_contexts:
             try:
-                ctx.root.get_default_driver(self):
+                ctx.root.get_default_driver(self)
             except KeyError:
                 try:
                     default = ctx.root.get_default_driver(driving)

--- a/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
+++ b/tests/gold/test_when_memory_Tuplex_Bit_y_Bits7.mlir
@@ -37,53 +37,49 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
         %11 = hw.constant 0 : i7
         %12 = hw.constant 0 : i1
         %13 = hw.constant 0 : i5
-        %18 = sv.reg : !hw.inout<i5>
-        %2 = sv.read_inout %18 : !hw.inout<i5>
+        %16 = sv.reg : !hw.inout<i5>
+        %2 = sv.read_inout %16 : !hw.inout<i5>
+        %17 = sv.reg : !hw.inout<i1>
+        %3 = sv.read_inout %17 : !hw.inout<i1>
+        %18 = sv.reg : !hw.inout<i7>
+        %4 = sv.read_inout %18 : !hw.inout<i7>
         %19 = sv.reg : !hw.inout<i1>
-        %3 = sv.read_inout %19 : !hw.inout<i1>
-        %20 = sv.reg : !hw.inout<i7>
-        %4 = sv.read_inout %20 : !hw.inout<i7>
+        %5 = sv.read_inout %19 : !hw.inout<i1>
+        %20 = sv.reg : !hw.inout<i5>
+        %1 = sv.read_inout %20 : !hw.inout<i5>
         %21 = sv.reg : !hw.inout<i1>
-        %5 = sv.read_inout %21 : !hw.inout<i1>
-        %22 = sv.reg : !hw.inout<i5>
-        %1 = sv.read_inout %22 : !hw.inout<i5>
-        %23 = sv.reg : !hw.inout<i1>
-        %14 = sv.read_inout %23 : !hw.inout<i1>
-        %24 = sv.reg : !hw.inout<i7>
-        %15 = sv.read_inout %24 : !hw.inout<i7>
-        %25 = sv.reg : !hw.inout<i1>
-        %16 = sv.read_inout %25 : !hw.inout<i1>
-        %26 = sv.reg : !hw.inout<i7>
-        %17 = sv.read_inout %26 : !hw.inout<i7>
+        %14 = sv.read_inout %21 : !hw.inout<i1>
+        %22 = sv.reg : !hw.inout<i7>
+        %15 = sv.read_inout %22 : !hw.inout<i7>
         sv.alwayscomb {
-            sv.bpassign %18, %9 : i5
+            sv.bpassign %16, %9 : i5
+            sv.bpassign %17, %12 : i1
+            sv.bpassign %18, %11 : i7
             sv.bpassign %19, %12 : i1
-            sv.bpassign %20, %11 : i7
-            sv.bpassign %21, %12 : i1
-            sv.bpassign %22, %13 : i5
+            sv.bpassign %20, %13 : i5
             sv.if %en0 {
-                sv.bpassign %18, %addr0 : i5
-                sv.bpassign %19, %data0_x : i1
-                sv.bpassign %20, %data0_y : i7
-                sv.bpassign %21, %0 : i1
-                sv.bpassign %22, %addr1 : i5
-                sv.bpassign %25, %6 : i1
-                sv.bpassign %26, %7 : i7
+                sv.bpassign %16, %addr0 : i5
+                sv.bpassign %17, %data0_x : i1
+                sv.bpassign %18, %data0_y : i7
+                sv.bpassign %19, %0 : i1
+                sv.bpassign %20, %addr1 : i5
+                sv.bpassign %21, %6 : i1
+                sv.bpassign %22, %7 : i7
             } else {
                 sv.if %en1 {
-                    sv.bpassign %18, %addr1 : i5
-                    sv.bpassign %19, %data1_x : i1
-                    sv.bpassign %20, %data1_y : i7
-                    sv.bpassign %21, %0 : i1
-                    sv.bpassign %22, %addr0 : i5
-                    sv.bpassign %25, %6 : i1
-                    sv.bpassign %26, %7 : i7
+                    sv.bpassign %16, %addr1 : i5
+                    sv.bpassign %17, %data1_x : i1
+                    sv.bpassign %18, %data1_y : i7
+                    sv.bpassign %19, %0 : i1
+                    sv.bpassign %20, %addr0 : i5
+                    sv.bpassign %21, %6 : i1
+                    sv.bpassign %22, %7 : i7
                 } else {
-                    sv.bpassign %25, %0 : i1
-                    sv.bpassign %26, %8 : i7
+                    sv.bpassign %21, %0 : i1
+                    sv.bpassign %22, %8 : i7
                 }
             }
         }
-        hw.output %16, %17 : i1, i7
+        hw.output %14, %15 : i1, i7
     }
 }

--- a/tests/gold/test_when_output_resolve.mlir
+++ b/tests/gold/test_when_output_resolve.mlir
@@ -5,36 +5,42 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
         %0 = sv.read_inout %1 : !hw.inout<i8>
         %3 = hw.constant -1 : i8
         %2 = comb.xor %3, %0 : i8
-        %5 = sv.reg : !hw.inout<i8>
-        %4 = sv.read_inout %5 : !hw.inout<i8>
+        %7 = sv.reg : !hw.inout<i8>
+        %4 = sv.read_inout %7 : !hw.inout<i8>
+        %8 = sv.reg : !hw.inout<i1>
+        %5 = sv.read_inout %8 : !hw.inout<i1>
+        %9 = sv.reg : !hw.inout<i1>
+        %6 = sv.read_inout %9 : !hw.inout<i1>
         sv.alwayscomb {
             sv.if %x {
-                %14 = comb.concat %13, %12, %11, %10, %9, %8, %7, %6 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %5, %14 : i8
+                %18 = comb.concat %17, %16, %15, %14, %13, %12, %11, %10 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %7, %18 : i8
+                sv.bpassign %8, %10 : i1
+                sv.bpassign %9, %11 : i1
             } else {
-                %23 = comb.concat %22, %21, %20, %19, %18, %17, %16, %15 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %5, %23 : i8
+                %27 = comb.concat %26, %25, %24, %23, %22, %21, %20, %19 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %7, %27 : i8
+                sv.bpassign %8, %19 : i1
+                sv.bpassign %9, %20 : i1
             }
         }
-        %6 = comb.extract %0 from 0 : (i8) -> i1
-        %7 = comb.extract %0 from 1 : (i8) -> i1
-        %8 = comb.extract %0 from 2 : (i8) -> i1
-        %9 = comb.extract %0 from 3 : (i8) -> i1
-        %10 = comb.extract %0 from 4 : (i8) -> i1
-        %11 = comb.extract %0 from 5 : (i8) -> i1
-        %12 = comb.extract %0 from 6 : (i8) -> i1
-        %13 = comb.extract %0 from 7 : (i8) -> i1
-        %15 = comb.extract %2 from 0 : (i8) -> i1
-        %16 = comb.extract %2 from 1 : (i8) -> i1
-        %17 = comb.extract %2 from 2 : (i8) -> i1
-        %18 = comb.extract %2 from 3 : (i8) -> i1
-        %19 = comb.extract %2 from 4 : (i8) -> i1
-        %20 = comb.extract %2 from 5 : (i8) -> i1
-        %21 = comb.extract %2 from 6 : (i8) -> i1
-        %22 = comb.extract %2 from 7 : (i8) -> i1
-        %24 = comb.extract %4 from 1 : (i8) -> i1
-        %25 = comb.extract %4 from 0 : (i8) -> i1
-        %26 = comb.concat %25, %24 : i1, i1
-        hw.output %4, %26 : i8, i2
+        %10 = comb.extract %0 from 0 : (i8) -> i1
+        %11 = comb.extract %0 from 1 : (i8) -> i1
+        %12 = comb.extract %0 from 2 : (i8) -> i1
+        %13 = comb.extract %0 from 3 : (i8) -> i1
+        %14 = comb.extract %0 from 4 : (i8) -> i1
+        %15 = comb.extract %0 from 5 : (i8) -> i1
+        %16 = comb.extract %0 from 6 : (i8) -> i1
+        %17 = comb.extract %0 from 7 : (i8) -> i1
+        %19 = comb.extract %2 from 0 : (i8) -> i1
+        %20 = comb.extract %2 from 1 : (i8) -> i1
+        %21 = comb.extract %2 from 2 : (i8) -> i1
+        %22 = comb.extract %2 from 3 : (i8) -> i1
+        %23 = comb.extract %2 from 4 : (i8) -> i1
+        %24 = comb.extract %2 from 5 : (i8) -> i1
+        %25 = comb.extract %2 from 6 : (i8) -> i1
+        %26 = comb.extract %2 from 7 : (i8) -> i1
+        %28 = comb.concat %5, %6 : i1, i1
+        hw.output %4, %28 : i8, i2
     }
 }

--- a/tests/gold/test_when_output_resolve2.mlir
+++ b/tests/gold/test_when_output_resolve2.mlir
@@ -2,15 +2,19 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
     hw.module @test_when_output_resolve2(%I: i8, %x: i1) -> (O0: i8, O1: i8) {
         %1 = hw.constant -1 : i8
         %0 = comb.xor %1, %I : i8
-        %3 = sv.reg : !hw.inout<i8>
-        %2 = sv.read_inout %3 : !hw.inout<i8>
+        %4 = sv.reg : !hw.inout<i8>
+        %2 = sv.read_inout %4 : !hw.inout<i8>
+        %5 = sv.reg : !hw.inout<i8>
+        %3 = sv.read_inout %5 : !hw.inout<i8>
         sv.alwayscomb {
             sv.if %x {
-                sv.bpassign %3, %I : i8
+                sv.bpassign %4, %I : i8
+                sv.bpassign %5, %I : i8
             } else {
-                sv.bpassign %3, %0 : i8
+                sv.bpassign %4, %0 : i8
+                sv.bpassign %5, %0 : i8
             }
         }
-        hw.output %2, %2 : i8, i8
+        hw.output %2, %3 : i8, i8
     }
 }

--- a/tests/gold/test_when_tuple_as_bits_resolve.mlir
+++ b/tests/gold/test_when_tuple_as_bits_resolve.mlir
@@ -1,192 +1,228 @@
-module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
-    hw.module @test_when_tuple_as_bits_resolve(%I_x_x: !hw.array<2xi8>, %I_x_y: i1, %I_x_z: i8, %S: i1) -> (O_x_x: !hw.array<2xi8>, O_x_y: i1, O_x_z: i8, X: i25) {
+module attributes {circt.loweringOptions = "locationInfoStyle=none,disallowLocalVariables"} {
+    hw.module @test_when_tuple_as_bits_resolve(%I_x_y: i1, %I_x_z_x: i8, %I_x_z_y: i1, %I_x_x: !hw.array<2xi8>, %I_y: i8, %S: i1) -> (O_x_y: i1, O_x_z_x: i8, O_x_z_y: i1, O_x_x: !hw.array<2xi8>, O_y: i8, X: i34) {
         %1 = hw.constant 0 : i1
         %0 = hw.array_get %I_x_x[%1] : !hw.array<2xi8>, i1
         %3 = hw.constant 1 : i1
         %2 = hw.array_get %I_x_x[%3] : !hw.array<2xi8>, i1
-        %5 = hw.constant -1 : i8
-        %4 = comb.xor %5, %0 : i8
-        %6 = comb.xor %5, %2 : i8
-        %8 = hw.constant -1 : i1
-        %7 = comb.xor %8, %I_x_y : i1
-        %9 = comb.xor %5, %I_x_z : i8
-        %39 = sv.reg : !hw.inout<i8>
-        %10 = sv.read_inout %39 : !hw.inout<i8>
-        %40 = sv.reg : !hw.inout<i8>
-        %11 = sv.read_inout %40 : !hw.inout<i8>
-        %41 = sv.reg : !hw.inout<i1>
-        %12 = sv.read_inout %41 : !hw.inout<i1>
-        %42 = sv.reg : !hw.inout<i8>
-        %13 = sv.read_inout %42 : !hw.inout<i8>
-        %43 = sv.reg : !hw.inout<i1>
-        %14 = sv.read_inout %43 : !hw.inout<i1>
-        %44 = sv.reg : !hw.inout<i1>
-        %15 = sv.read_inout %44 : !hw.inout<i1>
-        %45 = sv.reg : !hw.inout<i1>
-        %16 = sv.read_inout %45 : !hw.inout<i1>
-        %46 = sv.reg : !hw.inout<i1>
-        %17 = sv.read_inout %46 : !hw.inout<i1>
-        %47 = sv.reg : !hw.inout<i1>
-        %18 = sv.read_inout %47 : !hw.inout<i1>
-        %48 = sv.reg : !hw.inout<i1>
-        %19 = sv.read_inout %48 : !hw.inout<i1>
-        %49 = sv.reg : !hw.inout<i1>
-        %20 = sv.read_inout %49 : !hw.inout<i1>
+        %6 = hw.array_create %I_x_z_x, %I_x_z_x : i8
+        %4 = hw.array_get %6[%S] : !hw.array<2xi8>, i1
+        %7 = hw.array_create %I_x_z_y, %I_x_z_y : i1
+        %5 = hw.array_get %7[%S] : !hw.array<2xi1>, i1
+        %48 = sv.reg : !hw.inout<i8>
+        %8 = sv.read_inout %48 : !hw.inout<i8>
+        %49 = sv.reg : !hw.inout<i8>
+        %9 = sv.read_inout %49 : !hw.inout<i8>
         %50 = sv.reg : !hw.inout<i1>
-        %21 = sv.read_inout %50 : !hw.inout<i1>
-        %51 = sv.reg : !hw.inout<i1>
-        %22 = sv.read_inout %51 : !hw.inout<i1>
+        %10 = sv.read_inout %50 : !hw.inout<i1>
+        %51 = sv.reg : !hw.inout<i8>
+        %11 = sv.read_inout %51 : !hw.inout<i8>
         %52 = sv.reg : !hw.inout<i1>
-        %23 = sv.read_inout %52 : !hw.inout<i1>
-        %53 = sv.reg : !hw.inout<i1>
-        %24 = sv.read_inout %53 : !hw.inout<i1>
+        %12 = sv.read_inout %52 : !hw.inout<i1>
+        %53 = sv.reg : !hw.inout<i8>
+        %13 = sv.read_inout %53 : !hw.inout<i8>
         %54 = sv.reg : !hw.inout<i1>
-        %25 = sv.read_inout %54 : !hw.inout<i1>
+        %14 = sv.read_inout %54 : !hw.inout<i1>
         %55 = sv.reg : !hw.inout<i1>
-        %26 = sv.read_inout %55 : !hw.inout<i1>
+        %15 = sv.read_inout %55 : !hw.inout<i1>
         %56 = sv.reg : !hw.inout<i1>
-        %27 = sv.read_inout %56 : !hw.inout<i1>
+        %16 = sv.read_inout %56 : !hw.inout<i1>
         %57 = sv.reg : !hw.inout<i1>
-        %28 = sv.read_inout %57 : !hw.inout<i1>
+        %17 = sv.read_inout %57 : !hw.inout<i1>
         %58 = sv.reg : !hw.inout<i1>
-        %29 = sv.read_inout %58 : !hw.inout<i1>
+        %18 = sv.read_inout %58 : !hw.inout<i1>
         %59 = sv.reg : !hw.inout<i1>
-        %30 = sv.read_inout %59 : !hw.inout<i1>
+        %19 = sv.read_inout %59 : !hw.inout<i1>
         %60 = sv.reg : !hw.inout<i1>
-        %31 = sv.read_inout %60 : !hw.inout<i1>
+        %20 = sv.read_inout %60 : !hw.inout<i1>
         %61 = sv.reg : !hw.inout<i1>
-        %32 = sv.read_inout %61 : !hw.inout<i1>
+        %21 = sv.read_inout %61 : !hw.inout<i1>
         %62 = sv.reg : !hw.inout<i1>
-        %33 = sv.read_inout %62 : !hw.inout<i1>
+        %22 = sv.read_inout %62 : !hw.inout<i1>
         %63 = sv.reg : !hw.inout<i1>
-        %34 = sv.read_inout %63 : !hw.inout<i1>
+        %23 = sv.read_inout %63 : !hw.inout<i1>
         %64 = sv.reg : !hw.inout<i1>
-        %35 = sv.read_inout %64 : !hw.inout<i1>
+        %24 = sv.read_inout %64 : !hw.inout<i1>
         %65 = sv.reg : !hw.inout<i1>
-        %36 = sv.read_inout %65 : !hw.inout<i1>
+        %25 = sv.read_inout %65 : !hw.inout<i1>
         %66 = sv.reg : !hw.inout<i1>
-        %37 = sv.read_inout %66 : !hw.inout<i1>
+        %26 = sv.read_inout %66 : !hw.inout<i1>
         %67 = sv.reg : !hw.inout<i1>
-        %38 = sv.read_inout %67 : !hw.inout<i1>
+        %27 = sv.read_inout %67 : !hw.inout<i1>
+        %68 = sv.reg : !hw.inout<i1>
+        %28 = sv.read_inout %68 : !hw.inout<i1>
+        %69 = sv.reg : !hw.inout<i1>
+        %29 = sv.read_inout %69 : !hw.inout<i1>
+        %70 = sv.reg : !hw.inout<i1>
+        %30 = sv.read_inout %70 : !hw.inout<i1>
+        %71 = sv.reg : !hw.inout<i1>
+        %31 = sv.read_inout %71 : !hw.inout<i1>
+        %72 = sv.reg : !hw.inout<i1>
+        %32 = sv.read_inout %72 : !hw.inout<i1>
+        %73 = sv.reg : !hw.inout<i1>
+        %33 = sv.read_inout %73 : !hw.inout<i1>
+        %74 = sv.reg : !hw.inout<i1>
+        %34 = sv.read_inout %74 : !hw.inout<i1>
+        %75 = sv.reg : !hw.inout<i1>
+        %35 = sv.read_inout %75 : !hw.inout<i1>
+        %76 = sv.reg : !hw.inout<i1>
+        %36 = sv.read_inout %76 : !hw.inout<i1>
+        %77 = sv.reg : !hw.inout<i1>
+        %37 = sv.read_inout %77 : !hw.inout<i1>
+        %78 = sv.reg : !hw.inout<i1>
+        %38 = sv.read_inout %78 : !hw.inout<i1>
+        %79 = sv.reg : !hw.inout<i1>
+        %39 = sv.read_inout %79 : !hw.inout<i1>
+        %80 = sv.reg : !hw.inout<i1>
+        %40 = sv.read_inout %80 : !hw.inout<i1>
+        %81 = sv.reg : !hw.inout<i1>
+        %41 = sv.read_inout %81 : !hw.inout<i1>
+        %82 = sv.reg : !hw.inout<i1>
+        %42 = sv.read_inout %82 : !hw.inout<i1>
+        %83 = sv.reg : !hw.inout<i1>
+        %43 = sv.read_inout %83 : !hw.inout<i1>
+        %84 = sv.reg : !hw.inout<i1>
+        %44 = sv.read_inout %84 : !hw.inout<i1>
+        %85 = sv.reg : !hw.inout<i1>
+        %45 = sv.read_inout %85 : !hw.inout<i1>
+        %86 = sv.reg : !hw.inout<i1>
+        %46 = sv.read_inout %86 : !hw.inout<i1>
+        %87 = sv.reg : !hw.inout<i1>
+        %47 = sv.read_inout %87 : !hw.inout<i1>
         sv.alwayscomb {
+            %96 = comb.concat %95, %94, %93, %92, %91, %90, %89, %88 : i1, i1, i1, i1, i1, i1, i1, i1
+            sv.bpassign %53, %96 : i8
+            sv.bpassign %80, %88 : i1
+            sv.bpassign %81, %89 : i1
+            sv.bpassign %82, %90 : i1
+            sv.bpassign %83, %91 : i1
+            sv.bpassign %84, %92 : i1
+            sv.bpassign %85, %93 : i1
+            sv.bpassign %86, %94 : i1
+            sv.bpassign %87, %95 : i1
             sv.if %S {
-                sv.bpassign %41, %I_x_y : i1
-                %92 = comb.concat %75, %74, %73, %72, %71, %70, %69, %68 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %39, %92 : i8
-                sv.bpassign %43, %68 : i1
-                sv.bpassign %44, %69 : i1
-                sv.bpassign %45, %70 : i1
-                sv.bpassign %46, %71 : i1
-                sv.bpassign %47, %72 : i1
-                sv.bpassign %48, %73 : i1
-                sv.bpassign %49, %74 : i1
-                sv.bpassign %50, %75 : i1
-                %93 = comb.concat %83, %82, %81, %80, %79, %78, %77, %76 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %40, %93 : i8
-                sv.bpassign %51, %76 : i1
-                sv.bpassign %52, %77 : i1
-                sv.bpassign %53, %78 : i1
-                sv.bpassign %54, %79 : i1
-                sv.bpassign %55, %80 : i1
-                sv.bpassign %56, %81 : i1
-                sv.bpassign %57, %82 : i1
-                sv.bpassign %58, %83 : i1
-                sv.bpassign %59, %I_x_y : i1
-                %94 = comb.concat %91, %90, %89, %88, %87, %86, %85, %84 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %42, %94 : i8
-                sv.bpassign %60, %84 : i1
-                sv.bpassign %61, %85 : i1
-                sv.bpassign %62, %86 : i1
-                sv.bpassign %63, %87 : i1
-                sv.bpassign %64, %88 : i1
-                sv.bpassign %65, %89 : i1
-                sv.bpassign %66, %90 : i1
-                sv.bpassign %67, %91 : i1
+                sv.bpassign %50, %I_x_y : i1
+                sv.bpassign %54, %I_x_y : i1
+                sv.bpassign %52, %5 : i1
+                %121 = comb.concat %104, %103, %102, %101, %100, %99, %98, %97 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %51, %121 : i8
+                sv.bpassign %55, %97 : i1
+                sv.bpassign %56, %98 : i1
+                sv.bpassign %57, %99 : i1
+                sv.bpassign %58, %100 : i1
+                sv.bpassign %59, %101 : i1
+                sv.bpassign %60, %102 : i1
+                sv.bpassign %61, %103 : i1
+                sv.bpassign %62, %104 : i1
+                sv.bpassign %63, %5 : i1
+                %122 = comb.concat %112, %111, %110, %109, %108, %107, %106, %105 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %48, %122 : i8
+                sv.bpassign %64, %105 : i1
+                sv.bpassign %65, %106 : i1
+                sv.bpassign %66, %107 : i1
+                sv.bpassign %67, %108 : i1
+                sv.bpassign %68, %109 : i1
+                sv.bpassign %69, %110 : i1
+                sv.bpassign %70, %111 : i1
+                sv.bpassign %71, %112 : i1
+                %123 = comb.concat %120, %119, %118, %117, %116, %115, %114, %113 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %49, %123 : i8
+                sv.bpassign %72, %113 : i1
+                sv.bpassign %73, %114 : i1
+                sv.bpassign %74, %115 : i1
+                sv.bpassign %75, %116 : i1
+                sv.bpassign %76, %117 : i1
+                sv.bpassign %77, %118 : i1
+                sv.bpassign %78, %119 : i1
+                sv.bpassign %79, %120 : i1
             } else {
-                sv.bpassign %41, %7 : i1
-                %119 = comb.concat %102, %101, %100, %99, %98, %97, %96, %95 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %39, %119 : i8
-                sv.bpassign %43, %95 : i1
-                sv.bpassign %44, %96 : i1
-                sv.bpassign %45, %97 : i1
-                sv.bpassign %46, %98 : i1
-                sv.bpassign %47, %99 : i1
-                sv.bpassign %48, %100 : i1
-                sv.bpassign %49, %101 : i1
-                sv.bpassign %50, %102 : i1
-                %120 = comb.concat %110, %109, %108, %107, %106, %105, %104, %103 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %40, %120 : i8
-                sv.bpassign %51, %103 : i1
-                sv.bpassign %52, %104 : i1
-                sv.bpassign %53, %105 : i1
-                sv.bpassign %54, %106 : i1
-                sv.bpassign %55, %107 : i1
-                sv.bpassign %56, %108 : i1
-                sv.bpassign %57, %109 : i1
-                sv.bpassign %58, %110 : i1
-                sv.bpassign %59, %7 : i1
-                %121 = comb.concat %118, %117, %116, %115, %114, %113, %112, %111 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %42, %121 : i8
-                sv.bpassign %60, %111 : i1
-                sv.bpassign %61, %112 : i1
-                sv.bpassign %62, %113 : i1
-                sv.bpassign %63, %114 : i1
-                sv.bpassign %64, %115 : i1
-                sv.bpassign %65, %116 : i1
-                sv.bpassign %66, %117 : i1
-                sv.bpassign %67, %118 : i1
+                sv.bpassign %50, %I_x_y : i1
+                sv.bpassign %54, %I_x_y : i1
+                sv.bpassign %52, %I_x_z_y : i1
+                %132 = comb.concat %131, %130, %129, %128, %127, %126, %125, %124 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %51, %132 : i8
+                sv.bpassign %55, %124 : i1
+                sv.bpassign %56, %125 : i1
+                sv.bpassign %57, %126 : i1
+                sv.bpassign %58, %127 : i1
+                sv.bpassign %59, %128 : i1
+                sv.bpassign %60, %129 : i1
+                sv.bpassign %61, %130 : i1
+                sv.bpassign %62, %131 : i1
+                sv.bpassign %63, %I_x_z_y : i1
+                %133 = comb.concat %112, %111, %110, %109, %108, %107, %106, %105 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %48, %133 : i8
+                sv.bpassign %64, %105 : i1
+                sv.bpassign %65, %106 : i1
+                sv.bpassign %66, %107 : i1
+                sv.bpassign %67, %108 : i1
+                sv.bpassign %68, %109 : i1
+                sv.bpassign %69, %110 : i1
+                sv.bpassign %70, %111 : i1
+                sv.bpassign %71, %112 : i1
+                %134 = comb.concat %120, %119, %118, %117, %116, %115, %114, %113 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %49, %134 : i8
+                sv.bpassign %72, %113 : i1
+                sv.bpassign %73, %114 : i1
+                sv.bpassign %74, %115 : i1
+                sv.bpassign %75, %116 : i1
+                sv.bpassign %76, %117 : i1
+                sv.bpassign %77, %118 : i1
+                sv.bpassign %78, %119 : i1
+                sv.bpassign %79, %120 : i1
+                %135 = comb.concat %95, %94, %93, %92, %91, %90, %89, %88 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %53, %135 : i8
+                sv.bpassign %80, %88 : i1
+                sv.bpassign %81, %89 : i1
+                sv.bpassign %82, %90 : i1
+                sv.bpassign %83, %91 : i1
+                sv.bpassign %84, %92 : i1
+                sv.bpassign %85, %93 : i1
+                sv.bpassign %86, %94 : i1
+                sv.bpassign %87, %95 : i1
             }
         }
-        %68 = comb.extract %0 from 0 : (i8) -> i1
-        %69 = comb.extract %0 from 1 : (i8) -> i1
-        %70 = comb.extract %0 from 2 : (i8) -> i1
-        %71 = comb.extract %0 from 3 : (i8) -> i1
-        %72 = comb.extract %0 from 4 : (i8) -> i1
-        %73 = comb.extract %0 from 5 : (i8) -> i1
-        %74 = comb.extract %0 from 6 : (i8) -> i1
-        %75 = comb.extract %0 from 7 : (i8) -> i1
-        %76 = comb.extract %2 from 0 : (i8) -> i1
-        %77 = comb.extract %2 from 1 : (i8) -> i1
-        %78 = comb.extract %2 from 2 : (i8) -> i1
-        %79 = comb.extract %2 from 3 : (i8) -> i1
-        %80 = comb.extract %2 from 4 : (i8) -> i1
-        %81 = comb.extract %2 from 5 : (i8) -> i1
-        %82 = comb.extract %2 from 6 : (i8) -> i1
-        %83 = comb.extract %2 from 7 : (i8) -> i1
-        %84 = comb.extract %I_x_z from 0 : (i8) -> i1
-        %85 = comb.extract %I_x_z from 1 : (i8) -> i1
-        %86 = comb.extract %I_x_z from 2 : (i8) -> i1
-        %87 = comb.extract %I_x_z from 3 : (i8) -> i1
-        %88 = comb.extract %I_x_z from 4 : (i8) -> i1
-        %89 = comb.extract %I_x_z from 5 : (i8) -> i1
-        %90 = comb.extract %I_x_z from 6 : (i8) -> i1
-        %91 = comb.extract %I_x_z from 7 : (i8) -> i1
-        %95 = comb.extract %4 from 0 : (i8) -> i1
-        %96 = comb.extract %4 from 1 : (i8) -> i1
-        %97 = comb.extract %4 from 2 : (i8) -> i1
-        %98 = comb.extract %4 from 3 : (i8) -> i1
-        %99 = comb.extract %4 from 4 : (i8) -> i1
-        %100 = comb.extract %4 from 5 : (i8) -> i1
-        %101 = comb.extract %4 from 6 : (i8) -> i1
-        %102 = comb.extract %4 from 7 : (i8) -> i1
-        %103 = comb.extract %6 from 0 : (i8) -> i1
-        %104 = comb.extract %6 from 1 : (i8) -> i1
-        %105 = comb.extract %6 from 2 : (i8) -> i1
-        %106 = comb.extract %6 from 3 : (i8) -> i1
-        %107 = comb.extract %6 from 4 : (i8) -> i1
-        %108 = comb.extract %6 from 5 : (i8) -> i1
-        %109 = comb.extract %6 from 6 : (i8) -> i1
-        %110 = comb.extract %6 from 7 : (i8) -> i1
-        %111 = comb.extract %9 from 0 : (i8) -> i1
-        %112 = comb.extract %9 from 1 : (i8) -> i1
-        %113 = comb.extract %9 from 2 : (i8) -> i1
-        %114 = comb.extract %9 from 3 : (i8) -> i1
-        %115 = comb.extract %9 from 4 : (i8) -> i1
-        %116 = comb.extract %9 from 5 : (i8) -> i1
-        %117 = comb.extract %9 from 6 : (i8) -> i1
-        %118 = comb.extract %9 from 7 : (i8) -> i1
-        %122 = hw.array_create %11, %10 : i8
-        %123 = comb.concat %38, %37, %36, %35, %34, %33, %32, %31, %30, %29, %28, %27, %26, %25, %24, %23, %22, %21, %20, %19, %18, %17, %16, %15, %14 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
-        hw.output %122, %12, %13, %123 : !hw.array<2xi8>, i1, i8, i25
+        %88 = comb.extract %I_y from 0 : (i8) -> i1
+        %89 = comb.extract %I_y from 1 : (i8) -> i1
+        %90 = comb.extract %I_y from 2 : (i8) -> i1
+        %91 = comb.extract %I_y from 3 : (i8) -> i1
+        %92 = comb.extract %I_y from 4 : (i8) -> i1
+        %93 = comb.extract %I_y from 5 : (i8) -> i1
+        %94 = comb.extract %I_y from 6 : (i8) -> i1
+        %95 = comb.extract %I_y from 7 : (i8) -> i1
+        %97 = comb.extract %4 from 0 : (i8) -> i1
+        %98 = comb.extract %4 from 1 : (i8) -> i1
+        %99 = comb.extract %4 from 2 : (i8) -> i1
+        %100 = comb.extract %4 from 3 : (i8) -> i1
+        %101 = comb.extract %4 from 4 : (i8) -> i1
+        %102 = comb.extract %4 from 5 : (i8) -> i1
+        %103 = comb.extract %4 from 6 : (i8) -> i1
+        %104 = comb.extract %4 from 7 : (i8) -> i1
+        %105 = comb.extract %0 from 0 : (i8) -> i1
+        %106 = comb.extract %0 from 1 : (i8) -> i1
+        %107 = comb.extract %0 from 2 : (i8) -> i1
+        %108 = comb.extract %0 from 3 : (i8) -> i1
+        %109 = comb.extract %0 from 4 : (i8) -> i1
+        %110 = comb.extract %0 from 5 : (i8) -> i1
+        %111 = comb.extract %0 from 6 : (i8) -> i1
+        %112 = comb.extract %0 from 7 : (i8) -> i1
+        %113 = comb.extract %2 from 0 : (i8) -> i1
+        %114 = comb.extract %2 from 1 : (i8) -> i1
+        %115 = comb.extract %2 from 2 : (i8) -> i1
+        %116 = comb.extract %2 from 3 : (i8) -> i1
+        %117 = comb.extract %2 from 4 : (i8) -> i1
+        %118 = comb.extract %2 from 5 : (i8) -> i1
+        %119 = comb.extract %2 from 6 : (i8) -> i1
+        %120 = comb.extract %2 from 7 : (i8) -> i1
+        %124 = comb.extract %I_x_z_x from 0 : (i8) -> i1
+        %125 = comb.extract %I_x_z_x from 1 : (i8) -> i1
+        %126 = comb.extract %I_x_z_x from 2 : (i8) -> i1
+        %127 = comb.extract %I_x_z_x from 3 : (i8) -> i1
+        %128 = comb.extract %I_x_z_x from 4 : (i8) -> i1
+        %129 = comb.extract %I_x_z_x from 5 : (i8) -> i1
+        %130 = comb.extract %I_x_z_x from 6 : (i8) -> i1
+        %131 = comb.extract %I_x_z_x from 7 : (i8) -> i1
+        %136 = hw.array_create %9, %8 : i8
+        %137 = comb.concat %47, %46, %45, %44, %43, %42, %41, %40, %39, %38, %37, %36, %35, %34, %33, %32, %31, %30, %29, %28, %27, %26, %25, %24, %23, %22, %21, %20, %19, %18, %17, %16, %15, %14 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
+        hw.output %10, %11, %12, %136, %13, %137 : i1, i8, i1, !hw.array<2xi8>, i8, i34
     }
 }

--- a/tests/gold/test_when_tuple_as_bits_resolve.mlir
+++ b/tests/gold/test_when_tuple_as_bits_resolve.mlir
@@ -1,0 +1,192 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @test_when_tuple_as_bits_resolve(%I_x_x: !hw.array<2xi8>, %I_x_y: i1, %I_x_z: i8, %S: i1) -> (O_x_x: !hw.array<2xi8>, O_x_y: i1, O_x_z: i8, X: i25) {
+        %1 = hw.constant 0 : i1
+        %0 = hw.array_get %I_x_x[%1] : !hw.array<2xi8>, i1
+        %3 = hw.constant 1 : i1
+        %2 = hw.array_get %I_x_x[%3] : !hw.array<2xi8>, i1
+        %5 = hw.constant -1 : i8
+        %4 = comb.xor %5, %0 : i8
+        %6 = comb.xor %5, %2 : i8
+        %8 = hw.constant -1 : i1
+        %7 = comb.xor %8, %I_x_y : i1
+        %9 = comb.xor %5, %I_x_z : i8
+        %39 = sv.reg : !hw.inout<i8>
+        %10 = sv.read_inout %39 : !hw.inout<i8>
+        %40 = sv.reg : !hw.inout<i8>
+        %11 = sv.read_inout %40 : !hw.inout<i8>
+        %41 = sv.reg : !hw.inout<i1>
+        %12 = sv.read_inout %41 : !hw.inout<i1>
+        %42 = sv.reg : !hw.inout<i8>
+        %13 = sv.read_inout %42 : !hw.inout<i8>
+        %43 = sv.reg : !hw.inout<i1>
+        %14 = sv.read_inout %43 : !hw.inout<i1>
+        %44 = sv.reg : !hw.inout<i1>
+        %15 = sv.read_inout %44 : !hw.inout<i1>
+        %45 = sv.reg : !hw.inout<i1>
+        %16 = sv.read_inout %45 : !hw.inout<i1>
+        %46 = sv.reg : !hw.inout<i1>
+        %17 = sv.read_inout %46 : !hw.inout<i1>
+        %47 = sv.reg : !hw.inout<i1>
+        %18 = sv.read_inout %47 : !hw.inout<i1>
+        %48 = sv.reg : !hw.inout<i1>
+        %19 = sv.read_inout %48 : !hw.inout<i1>
+        %49 = sv.reg : !hw.inout<i1>
+        %20 = sv.read_inout %49 : !hw.inout<i1>
+        %50 = sv.reg : !hw.inout<i1>
+        %21 = sv.read_inout %50 : !hw.inout<i1>
+        %51 = sv.reg : !hw.inout<i1>
+        %22 = sv.read_inout %51 : !hw.inout<i1>
+        %52 = sv.reg : !hw.inout<i1>
+        %23 = sv.read_inout %52 : !hw.inout<i1>
+        %53 = sv.reg : !hw.inout<i1>
+        %24 = sv.read_inout %53 : !hw.inout<i1>
+        %54 = sv.reg : !hw.inout<i1>
+        %25 = sv.read_inout %54 : !hw.inout<i1>
+        %55 = sv.reg : !hw.inout<i1>
+        %26 = sv.read_inout %55 : !hw.inout<i1>
+        %56 = sv.reg : !hw.inout<i1>
+        %27 = sv.read_inout %56 : !hw.inout<i1>
+        %57 = sv.reg : !hw.inout<i1>
+        %28 = sv.read_inout %57 : !hw.inout<i1>
+        %58 = sv.reg : !hw.inout<i1>
+        %29 = sv.read_inout %58 : !hw.inout<i1>
+        %59 = sv.reg : !hw.inout<i1>
+        %30 = sv.read_inout %59 : !hw.inout<i1>
+        %60 = sv.reg : !hw.inout<i1>
+        %31 = sv.read_inout %60 : !hw.inout<i1>
+        %61 = sv.reg : !hw.inout<i1>
+        %32 = sv.read_inout %61 : !hw.inout<i1>
+        %62 = sv.reg : !hw.inout<i1>
+        %33 = sv.read_inout %62 : !hw.inout<i1>
+        %63 = sv.reg : !hw.inout<i1>
+        %34 = sv.read_inout %63 : !hw.inout<i1>
+        %64 = sv.reg : !hw.inout<i1>
+        %35 = sv.read_inout %64 : !hw.inout<i1>
+        %65 = sv.reg : !hw.inout<i1>
+        %36 = sv.read_inout %65 : !hw.inout<i1>
+        %66 = sv.reg : !hw.inout<i1>
+        %37 = sv.read_inout %66 : !hw.inout<i1>
+        %67 = sv.reg : !hw.inout<i1>
+        %38 = sv.read_inout %67 : !hw.inout<i1>
+        sv.alwayscomb {
+            sv.if %S {
+                sv.bpassign %41, %I_x_y : i1
+                %92 = comb.concat %75, %74, %73, %72, %71, %70, %69, %68 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %39, %92 : i8
+                sv.bpassign %43, %68 : i1
+                sv.bpassign %44, %69 : i1
+                sv.bpassign %45, %70 : i1
+                sv.bpassign %46, %71 : i1
+                sv.bpassign %47, %72 : i1
+                sv.bpassign %48, %73 : i1
+                sv.bpassign %49, %74 : i1
+                sv.bpassign %50, %75 : i1
+                %93 = comb.concat %83, %82, %81, %80, %79, %78, %77, %76 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %40, %93 : i8
+                sv.bpassign %51, %76 : i1
+                sv.bpassign %52, %77 : i1
+                sv.bpassign %53, %78 : i1
+                sv.bpassign %54, %79 : i1
+                sv.bpassign %55, %80 : i1
+                sv.bpassign %56, %81 : i1
+                sv.bpassign %57, %82 : i1
+                sv.bpassign %58, %83 : i1
+                sv.bpassign %59, %I_x_y : i1
+                %94 = comb.concat %91, %90, %89, %88, %87, %86, %85, %84 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %42, %94 : i8
+                sv.bpassign %60, %84 : i1
+                sv.bpassign %61, %85 : i1
+                sv.bpassign %62, %86 : i1
+                sv.bpassign %63, %87 : i1
+                sv.bpassign %64, %88 : i1
+                sv.bpassign %65, %89 : i1
+                sv.bpassign %66, %90 : i1
+                sv.bpassign %67, %91 : i1
+            } else {
+                sv.bpassign %41, %7 : i1
+                %119 = comb.concat %102, %101, %100, %99, %98, %97, %96, %95 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %39, %119 : i8
+                sv.bpassign %43, %95 : i1
+                sv.bpassign %44, %96 : i1
+                sv.bpassign %45, %97 : i1
+                sv.bpassign %46, %98 : i1
+                sv.bpassign %47, %99 : i1
+                sv.bpassign %48, %100 : i1
+                sv.bpassign %49, %101 : i1
+                sv.bpassign %50, %102 : i1
+                %120 = comb.concat %110, %109, %108, %107, %106, %105, %104, %103 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %40, %120 : i8
+                sv.bpassign %51, %103 : i1
+                sv.bpassign %52, %104 : i1
+                sv.bpassign %53, %105 : i1
+                sv.bpassign %54, %106 : i1
+                sv.bpassign %55, %107 : i1
+                sv.bpassign %56, %108 : i1
+                sv.bpassign %57, %109 : i1
+                sv.bpassign %58, %110 : i1
+                sv.bpassign %59, %7 : i1
+                %121 = comb.concat %118, %117, %116, %115, %114, %113, %112, %111 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %42, %121 : i8
+                sv.bpassign %60, %111 : i1
+                sv.bpassign %61, %112 : i1
+                sv.bpassign %62, %113 : i1
+                sv.bpassign %63, %114 : i1
+                sv.bpassign %64, %115 : i1
+                sv.bpassign %65, %116 : i1
+                sv.bpassign %66, %117 : i1
+                sv.bpassign %67, %118 : i1
+            }
+        }
+        %68 = comb.extract %0 from 0 : (i8) -> i1
+        %69 = comb.extract %0 from 1 : (i8) -> i1
+        %70 = comb.extract %0 from 2 : (i8) -> i1
+        %71 = comb.extract %0 from 3 : (i8) -> i1
+        %72 = comb.extract %0 from 4 : (i8) -> i1
+        %73 = comb.extract %0 from 5 : (i8) -> i1
+        %74 = comb.extract %0 from 6 : (i8) -> i1
+        %75 = comb.extract %0 from 7 : (i8) -> i1
+        %76 = comb.extract %2 from 0 : (i8) -> i1
+        %77 = comb.extract %2 from 1 : (i8) -> i1
+        %78 = comb.extract %2 from 2 : (i8) -> i1
+        %79 = comb.extract %2 from 3 : (i8) -> i1
+        %80 = comb.extract %2 from 4 : (i8) -> i1
+        %81 = comb.extract %2 from 5 : (i8) -> i1
+        %82 = comb.extract %2 from 6 : (i8) -> i1
+        %83 = comb.extract %2 from 7 : (i8) -> i1
+        %84 = comb.extract %I_x_z from 0 : (i8) -> i1
+        %85 = comb.extract %I_x_z from 1 : (i8) -> i1
+        %86 = comb.extract %I_x_z from 2 : (i8) -> i1
+        %87 = comb.extract %I_x_z from 3 : (i8) -> i1
+        %88 = comb.extract %I_x_z from 4 : (i8) -> i1
+        %89 = comb.extract %I_x_z from 5 : (i8) -> i1
+        %90 = comb.extract %I_x_z from 6 : (i8) -> i1
+        %91 = comb.extract %I_x_z from 7 : (i8) -> i1
+        %95 = comb.extract %4 from 0 : (i8) -> i1
+        %96 = comb.extract %4 from 1 : (i8) -> i1
+        %97 = comb.extract %4 from 2 : (i8) -> i1
+        %98 = comb.extract %4 from 3 : (i8) -> i1
+        %99 = comb.extract %4 from 4 : (i8) -> i1
+        %100 = comb.extract %4 from 5 : (i8) -> i1
+        %101 = comb.extract %4 from 6 : (i8) -> i1
+        %102 = comb.extract %4 from 7 : (i8) -> i1
+        %103 = comb.extract %6 from 0 : (i8) -> i1
+        %104 = comb.extract %6 from 1 : (i8) -> i1
+        %105 = comb.extract %6 from 2 : (i8) -> i1
+        %106 = comb.extract %6 from 3 : (i8) -> i1
+        %107 = comb.extract %6 from 4 : (i8) -> i1
+        %108 = comb.extract %6 from 5 : (i8) -> i1
+        %109 = comb.extract %6 from 6 : (i8) -> i1
+        %110 = comb.extract %6 from 7 : (i8) -> i1
+        %111 = comb.extract %9 from 0 : (i8) -> i1
+        %112 = comb.extract %9 from 1 : (i8) -> i1
+        %113 = comb.extract %9 from 2 : (i8) -> i1
+        %114 = comb.extract %9 from 3 : (i8) -> i1
+        %115 = comb.extract %9 from 4 : (i8) -> i1
+        %116 = comb.extract %9 from 5 : (i8) -> i1
+        %117 = comb.extract %9 from 6 : (i8) -> i1
+        %118 = comb.extract %9 from 7 : (i8) -> i1
+        %122 = hw.array_create %11, %10 : i8
+        %123 = comb.concat %38, %37, %36, %35, %34, %33, %32, %31, %30, %29, %28, %27, %26, %25, %24, %23, %22, %21, %20, %19, %18, %17, %16, %15, %14 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
+        hw.output %122, %12, %13, %123 : !hw.array<2xi8>, i1, i8, i25
+    }
+}

--- a/tests/gold/test_when_tuple_bulk_resolve.mlir
+++ b/tests/gold/test_when_tuple_bulk_resolve.mlir
@@ -47,119 +47,99 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
         }
         %10 = sv.read_inout %19 : !hw.inout<i8>
         %21 = comb.extract %S from 1 : (i2) -> i1
-        %42 = sv.reg : !hw.inout<i8>
-        %27 = sv.read_inout %42 : !hw.inout<i8>
-        %43 = sv.reg : !hw.inout<i8>
-        %28 = sv.read_inout %43 : !hw.inout<i8>
-        %44 = sv.reg : !hw.inout<i8>
-        %29 = sv.read_inout %44 : !hw.inout<i8>
-        %45 = sv.reg : !hw.inout<i8>
-        %30 = sv.read_inout %45 : !hw.inout<i8>
-        %46 = sv.reg : !hw.inout<i8>
-        %31 = sv.read_inout %46 : !hw.inout<i8>
-        %47 = sv.reg : !hw.inout<i8>
-        %32 = sv.read_inout %47 : !hw.inout<i8>
-        %48 = sv.reg : !hw.inout<i8>
-        %33 = sv.read_inout %48 : !hw.inout<i8>
-        %49 = sv.reg : !hw.inout<i8>
-        %34 = sv.read_inout %49 : !hw.inout<i8>
-        %50 = sv.reg : !hw.inout<i8>
-        %35 = sv.read_inout %50 : !hw.inout<i8>
-        %51 = sv.reg : !hw.inout<i8>
-        %36 = sv.read_inout %51 : !hw.inout<i8>
-        %52 = sv.reg : !hw.inout<i8>
-        %37 = sv.read_inout %52 : !hw.inout<i8>
-        %53 = sv.reg : !hw.inout<i8>
-        %38 = sv.read_inout %53 : !hw.inout<i8>
-        %54 = sv.reg : !hw.inout<i8>
-        %39 = sv.read_inout %54 : !hw.inout<i8>
-        %55 = sv.reg : !hw.inout<i8>
-        %40 = sv.read_inout %55 : !hw.inout<i8>
-        %56 = sv.reg : !hw.inout<i8>
-        %41 = sv.read_inout %56 : !hw.inout<i8>
-        %57 = sv.reg : !hw.inout<i8>
-        %1 = sv.read_inout %57 : !hw.inout<i8>
-        %58 = sv.reg : !hw.inout<i8>
-        %2 = sv.read_inout %58 : !hw.inout<i8>
-        %59 = sv.reg : !hw.inout<i8>
-        %3 = sv.read_inout %59 : !hw.inout<i8>
-        %60 = sv.reg : !hw.inout<i8>
-        %4 = sv.read_inout %60 : !hw.inout<i8>
-        %61 = sv.reg : !hw.inout<i8>
-        %5 = sv.read_inout %61 : !hw.inout<i8>
+        %32 = sv.reg : !hw.inout<i8>
+        %27 = sv.read_inout %32 : !hw.inout<i8>
+        %33 = sv.reg : !hw.inout<i8>
+        %28 = sv.read_inout %33 : !hw.inout<i8>
+        %34 = sv.reg : !hw.inout<i8>
+        %29 = sv.read_inout %34 : !hw.inout<i8>
+        %35 = sv.reg : !hw.inout<i8>
+        %30 = sv.read_inout %35 : !hw.inout<i8>
+        %36 = sv.reg : !hw.inout<i8>
+        %31 = sv.read_inout %36 : !hw.inout<i8>
+        %37 = sv.reg : !hw.inout<i8>
+        %1 = sv.read_inout %37 : !hw.inout<i8>
+        %38 = sv.reg : !hw.inout<i8>
+        %2 = sv.read_inout %38 : !hw.inout<i8>
+        %39 = sv.reg : !hw.inout<i8>
+        %3 = sv.read_inout %39 : !hw.inout<i8>
+        %40 = sv.reg : !hw.inout<i8>
+        %4 = sv.read_inout %40 : !hw.inout<i8>
+        %41 = sv.reg : !hw.inout<i8>
+        %5 = sv.read_inout %41 : !hw.inout<i8>
         sv.alwayscomb {
             sv.if %0 {
-                sv.bpassign %52, %22 : i8
-                sv.bpassign %53, %23 : i8
-                sv.bpassign %54, %24 : i8
-                sv.bpassign %55, %25 : i8
-                sv.bpassign %56, %26 : i8
-                sv.bpassign %57, %6 : i8
-                sv.bpassign %58, %7 : i8
-                sv.bpassign %59, %8 : i8
-                sv.bpassign %60, %9 : i8
-                sv.bpassign %61, %10 : i8
+                sv.bpassign %32, %22 : i8
+                sv.bpassign %33, %23 : i8
+                sv.bpassign %34, %24 : i8
+                sv.bpassign %35, %25 : i8
+                sv.bpassign %36, %26 : i8
+                sv.bpassign %37, %6 : i8
+                sv.bpassign %38, %7 : i8
+                sv.bpassign %39, %8 : i8
+                sv.bpassign %40, %9 : i8
+                sv.bpassign %41, %10 : i8
             } else {
-                sv.bpassign %57, %22 : i8
-                sv.bpassign %58, %23 : i8
-                sv.bpassign %59, %24 : i8
-                sv.bpassign %60, %25 : i8
-                sv.bpassign %61, %26 : i8
+                sv.bpassign %37, %22 : i8
+                sv.bpassign %38, %23 : i8
+                sv.bpassign %39, %24 : i8
+                sv.bpassign %40, %25 : i8
+                sv.bpassign %41, %26 : i8
                 sv.if %21 {
-                    sv.bpassign %52, %I_x : i8
-                    sv.bpassign %53, %I_y_x_x : i8
-                    sv.bpassign %54, %I_y_x_y : i8
-                    sv.bpassign %55, %I_y_y_x : i8
-                    sv.bpassign %56, %I_y_y_y : i8
+                    sv.bpassign %32, %I_x : i8
+                    sv.bpassign %33, %I_y_x_x : i8
+                    sv.bpassign %34, %I_y_x_y : i8
+                    sv.bpassign %35, %I_y_y_x : i8
+                    sv.bpassign %36, %I_y_y_y : i8
                 } else {
-                    sv.bpassign %52, %22 : i8
-                    sv.bpassign %53, %23 : i8
-                    sv.bpassign %54, %24 : i8
-                    sv.bpassign %55, %25 : i8
-                    sv.bpassign %56, %26 : i8
+                    sv.bpassign %32, %22 : i8
+                    sv.bpassign %33, %23 : i8
+                    sv.bpassign %34, %24 : i8
+                    sv.bpassign %35, %25 : i8
+                    sv.bpassign %36, %26 : i8
                 }
             }
         }
-        %62 = sv.reg {name = "x"} : !hw.inout<i8>
+        %42 = sv.reg {name = "x"} : !hw.inout<i8>
         sv.alwaysff(posedge %CLK) {
-            sv.passign %62, %37 : i8
+            sv.passign %42, %27 : i8
         }
         sv.initial {
-            sv.bpassign %62, %12 : i8
+            sv.bpassign %42, %12 : i8
         }
-        %22 = sv.read_inout %62 : !hw.inout<i8>
-        %63 = sv.reg {name = "x"} : !hw.inout<i8>
+        %22 = sv.read_inout %42 : !hw.inout<i8>
+        %43 = sv.reg {name = "x"} : !hw.inout<i8>
         sv.alwaysff(posedge %CLK) {
-            sv.passign %63, %38 : i8
+            sv.passign %43, %28 : i8
         }
         sv.initial {
-            sv.bpassign %63, %14 : i8
+            sv.bpassign %43, %14 : i8
         }
-        %23 = sv.read_inout %63 : !hw.inout<i8>
-        %64 = sv.reg {name = "x"} : !hw.inout<i8>
+        %23 = sv.read_inout %43 : !hw.inout<i8>
+        %44 = sv.reg {name = "x"} : !hw.inout<i8>
         sv.alwaysff(posedge %CLK) {
-            sv.passign %64, %39 : i8
+            sv.passign %44, %29 : i8
         }
         sv.initial {
-            sv.bpassign %64, %16 : i8
+            sv.bpassign %44, %16 : i8
         }
-        %24 = sv.read_inout %64 : !hw.inout<i8>
-        %65 = sv.reg {name = "x"} : !hw.inout<i8>
+        %24 = sv.read_inout %44 : !hw.inout<i8>
+        %45 = sv.reg {name = "x"} : !hw.inout<i8>
         sv.alwaysff(posedge %CLK) {
-            sv.passign %65, %40 : i8
+            sv.passign %45, %30 : i8
         }
         sv.initial {
-            sv.bpassign %65, %18 : i8
+            sv.bpassign %45, %18 : i8
         }
-        %25 = sv.read_inout %65 : !hw.inout<i8>
-        %66 = sv.reg {name = "x"} : !hw.inout<i8>
+        %25 = sv.read_inout %45 : !hw.inout<i8>
+        %46 = sv.reg {name = "x"} : !hw.inout<i8>
         sv.alwaysff(posedge %CLK) {
-            sv.passign %66, %41 : i8
+            sv.passign %46, %31 : i8
         }
         sv.initial {
-            sv.bpassign %66, %20 : i8
+            sv.bpassign %46, %20 : i8
         }
-        %26 = sv.read_inout %66 : !hw.inout<i8>
+        %26 = sv.read_inout %46 : !hw.inout<i8>
         hw.output %22, %23, %24, %25, %26 : i8, i8, i8, i8, i8
     }
 }

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -1451,7 +1451,7 @@ def test_when_tuple_as_bits_resolve():
         io.X @= m.as_bits(io.O.value())
 
     m.compile("build/test_when_tuple_as_bits_resolve",
-              test_when_tuple_as_bits_resolve, output="mlir-verilog",
+              test_when_tuple_as_bits_resolve, output="mlir",
               flatten_all_tuples=True, disallow_local_variables=True)
     assert check_gold(__file__, "test_when_tuple_as_bits_resolve.mlir")
 

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -1076,7 +1076,7 @@ def test_when_output_resolve():
         io.O1[1] @= io.O0.value()[0]  # direct reference to when builder output
         io.O1[0] @= io.O0.value()[1]  # direct reference to when builder output
 
-    m.compile(f"build/{_Test.name}", _Test, output="mlir-verilog")
+    m.compile(f"build/{_Test.name}", _Test, output="mlir")
     assert check_gold(__file__, f"{_Test.name}.mlir")
 
 


### PR DESCRIPTION
Currently the when logic assumes that a when output only drives a single value, this invariant is broken when a user calls `.value()` on a conditionally driven value, getting a handle to a when output and wiring it as they'd wish.

This change preserves the invariant by:
1. Marking when output values with a flag which will trigger different wiring behavior
2. When directly wiring a when output to a new drivee, it behaves as if the new drivee was driven by same drivers as the current drivee.  This is done by adding the conditional wires corresponding to the current drivee to the appropriate when contexts (essentially replaying the wiring of the current drivee, except with the new drivee).

In this process, I discovered a related issue in which the parent array logic assumes that the root array is assigned in the when.  Instead, we may have an ancestor that is not the root (e.g. we could bulk assign elements of a 2d array).  This updates the root logic to instead iterate over the ancestors towards the root until the appropriate value is found.