### PR TITLE
[MLIR] Add option to split verilog

### DIFF
--- a/magma/backend/mlir/compile_to_mlir_opts.py
+++ b/magma/backend/mlir/compile_to_mlir_opts.py
@@ -6,6 +6,7 @@ from typing import Optional
 class CompileToMlirOpts:
     flatten_all_tuples: bool = False
     basename: Optional[str] = None
+    suffix: Optional[str] = None
     use_native_bind_processor: bool = False
     verilog_prefix: Optional[str] = None
     user_namespace: Optional[str] = None
@@ -17,3 +18,4 @@ class CompileToMlirOpts:
     explicit_bitcast: bool = False
     disallow_expression_inlining_in_ports: bool = False
     disallow_local_variables: bool = False
+    split_verilog: bool = False

--- a/magma/backend/mlir/compile_to_mlir_opts.py
+++ b/magma/backend/mlir/compile_to_mlir_opts.py
@@ -6,7 +6,7 @@ from typing import Optional
 class CompileToMlirOpts:
     flatten_all_tuples: bool = False
     basename: Optional[str] = None
-    suffix: Optional[str] = None
+    sv: bool = False
     use_native_bind_processor: bool = False
     verilog_prefix: Optional[str] = None
     user_namespace: Optional[str] = None

--- a/magma/backend/mlir/hw.py
+++ b/magma/backend/mlir/hw.py
@@ -63,6 +63,21 @@ class ParamDeclAttr(MlirAttribute):
         return f"{s} = {self.value.emit()}"
 
 
+@dataclasses.dataclass(frozen=True)
+class OutputFileAttr(MlirAttribute):
+    filename: str
+    exclude_from_file_list: bool = False
+    include_replicated_ops: bool = False
+
+    def emit(self) -> str:
+        s = f"#hw.output_file<\"{self.filename}\""
+        if self.exclude_from_file_list:
+            s += f", excludeFromFileList"
+        if self.include_replicated_ops:
+            s += f", includeReplicatedOps"
+        return f"{s}>"
+
+
 @dataclasses.dataclass
 class ModuleOpBase(MlirOp):
     operands: List[MlirValue]
@@ -81,6 +96,9 @@ class ModuleOpBase(MlirOp):
         printer.print(") -> (")
         print_signature(self.results, printer, raw_names=True)
         printer.print(")")
+        if self.attr_dict:
+            printer.print(" attributes ")
+            print_attr_dict(self.attr_dict, printer)
 
 
 @dataclasses.dataclass

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict
 
 from magma.backend.coreir.insert_coreir_wires import insert_coreir_wires
@@ -67,6 +68,11 @@ class MlirCompiler(Compiler):
                 self.main, sout=f, opts=self._compile_to_mlir_opts)
         if not self.opts.get("output_verilog", False):
             return
+        outfile = (
+            os.devnull
+            if self.opts.get("split_verilog", False)
+            else f"{self.basename}.{self.suffix()}"
+        )
         with open(f"{self.basename}.mlir", "rb") as fi:
-            with open(f"{self.basename}.{self.suffix()}", "wb") as fo:
+            with open(outfile, "wb") as fo:
                 mlir_to_verilog(fi, fo, opts=self._mlir_to_verilog_opts)

--- a/magma/backend/mlir/mlir_compiler.py
+++ b/magma/backend/mlir/mlir_compiler.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict
+from typing import Dict
 
 from magma.backend.coreir.insert_coreir_wires import insert_coreir_wires
 from magma.backend.mlir.compile_to_mlir import compile_to_mlir
@@ -17,24 +17,11 @@ from magma.passes.finalize_whens import finalize_whens
 from magma.passes.raise_logs_as_exceptions import raise_logs_as_exceptions_pass
 
 
-def _get_suffix(opts: dict) -> str:
-    if opts.get("output_verilog", False):
-        if opts.get("sv", False):
-            return "sv"
-        return "v"
-    return "mlir"
-
-
-def _set_or_die(dct: Dict, key: Any, value: Any):
-    if key in dct:
-        raise KeyError(key)
-    dct[key] = value
-
-
 class MlirCompiler(Compiler):
     def __init__(self, main: DefineCircuitKind, basename: str, opts: Dict):
-        _set_or_die(opts, "basename", basename)
-        _set_or_die(opts, "suffix", _get_suffix(opts))
+        # TODO(rsetaluri): Make this a better error.
+        assert "basename" not in opts
+        opts["basename"] = basename
         self._compile_to_mlir_opts = slice_opts(
             opts, CompileToMlirOpts, keep=True
         )
@@ -44,7 +31,11 @@ class MlirCompiler(Compiler):
         super().__init__(main, basename, opts)
 
     def suffix(self):
-        return _get_suffix(self.opts)
+        if self.opts.get("output_verilog", False):
+            if self.opts.get("sv", False):
+                return "sv"
+            return "v"
+        return "mlir"
 
     def run_pre_uniquification_passes(self):
         if self.opts.get("flatten_all_tuples", False):

--- a/magma/backend/mlir/mlir_printer_utils.py
+++ b/magma/backend/mlir/mlir_printer_utils.py
@@ -1,6 +1,6 @@
-from typing import Callable, List, Mapping, Union
+from typing import Any, Callable, List, Mapping, Union
 
-from magma.backend.mlir.mlir import MlirValue
+from magma.backend.mlir.mlir import MlirAttribute, MlirValue
 from magma.backend.mlir.printer_base import PrinterBase
 
 
@@ -44,6 +44,12 @@ def print_signature(
     get_name = get_name_fn(raw_names)
     signatures = (f"{get_name(v)}: {v.type.emit()}" for v in value_list)
     printer.print(", ".join(signatures))
+
+
+def _attr_to_string(value: Any) -> str:
+    if isinstance(value, MlirAttribute):
+        return value.emit()
+    return str(value)
 
 
 def print_attr_dict(attr_dict: Mapping, printer: PrinterBase):

--- a/magma/backend/mlir/mlir_to_verilog.py
+++ b/magma/backend/mlir/mlir_to_verilog.py
@@ -23,7 +23,7 @@ class MlirToVerilogError(MlirCompilerError):
 
 @dataclasses.dataclass
 class MlirToVerilogOpts:
-    pass
+    split_verilog: bool = False
 
 
 def _circt_home() -> Optional[pathlib.Path]:
@@ -49,12 +49,15 @@ def _circt_opt_cmd(
         opts: MlirToVerilogOpts,
 ) -> List[str]:
     bin_ = f"{_circt_opt_binary(circt_home)}"
+    export_verilog_pass = (
+        "--export-split-verilog" if opts.split_verilog else "--export-verilog"
+    )
     passes = [
         "--lower-seq-to-sv",
         "--canonicalize",
         "--hw-cleanup",
         "--prettify-verilog",
-        "--export-verilog",
+        export_verilog_pass,
     ]
     extra_opts = [
         "-o=/dev/null",

--- a/magma/backend/mlir/translation_unit.py
+++ b/magma/backend/mlir/translation_unit.py
@@ -122,13 +122,14 @@ class TranslationUnit:
                 if hardware_module.hw_module:
                     self.set_hardware_module(dep, hardware_module)
         if self._opts.split_verilog:
-            if self._opts.basename is None or self._opts.suffix is None:
+            if self._opts.basename is None:
                 raise ValueError(
-                    "Must specify basename and suffix if split_verilog is set"
+                    "Must specify basename if split_verilog is set"
                 )
+            suffix = "sv" if self._opts.sv else "v"
             _prepare_for_split_verilog(
                 self._hardware_modules.values(),
-                f"{self._opts.basename}.{self._opts.suffix}",
+                f"{self._opts.basename}.{suffix}",
             )
         self._write_listings_file()
 

--- a/tests/test_backend/test_mlir/golds/simple_hierarchy_split_verilog.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_hierarchy_split_verilog.mlir
@@ -1,12 +1,12 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
-    hw.module @simple_comb(%a: i16, %b: i16, %c: i16) -> (y: i16, z: i16) attributes {output_file = #hw.output_file<"simple_hierarchy.v">} {
+    hw.module @simple_comb(%a: i16, %b: i16, %c: i16) -> (y: i16, z: i16) attributes {output_file = #hw.output_file<"tests/test_backend/test_mlir/build/simple_hierarchy.v">} {
         %1 = hw.constant -1 : i16
         %0 = comb.xor %1, %a : i16
         %2 = comb.or %a, %0 : i16
         %3 = comb.or %2, %b : i16
         hw.output %3, %3 : i16, i16
     }
-    hw.module @simple_hierarchy(%a: i16, %b: i16, %c: i16) -> (y: i16, z: i16) attributes {output_file = #hw.output_file<"simple_hierarchy.v">} {
+    hw.module @simple_hierarchy(%a: i16, %b: i16, %c: i16) -> (y: i16, z: i16) attributes {output_file = #hw.output_file<"tests/test_backend/test_mlir/build/simple_hierarchy.v">} {
         %0, %1 = hw.instance "simple_comb_inst0" @simple_comb(a: %a: i16, b: %b: i16, c: %c: i16) -> (y: i16, z: i16)
         hw.output %0, %1 : i16, i16
     }

--- a/tests/test_backend/test_mlir/golds/simple_hierarchy_split_verilog.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_hierarchy_split_verilog.mlir
@@ -1,0 +1,13 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @simple_comb(%a: i16, %b: i16, %c: i16) -> (y: i16, z: i16) attributes {output_file = #hw.output_file<"simple_hierarchy.v">} {
+        %1 = hw.constant -1 : i16
+        %0 = comb.xor %1, %a : i16
+        %2 = comb.or %a, %0 : i16
+        %3 = comb.or %2, %b : i16
+        hw.output %3, %3 : i16, i16
+    }
+    hw.module @simple_hierarchy(%a: i16, %b: i16, %c: i16) -> (y: i16, z: i16) attributes {output_file = #hw.output_file<"simple_hierarchy.v">} {
+        %0, %1 = hw.instance "simple_comb_inst0" @simple_comb(a: %a: i16, b: %b: i16, c: %c: i16) -> (y: i16, z: i16)
+        hw.output %0, %1 : i16, i16
+    }
+}

--- a/tests/test_backend/test_mlir/golds/simple_hierarchy_split_verilog_real.v
+++ b/tests/test_backend/test_mlir/golds/simple_hierarchy_split_verilog_real.v
@@ -1,0 +1,27 @@
+module simple_comb(
+  input  [15:0] a,
+                b,
+                c,
+  output [15:0] y,
+                z);
+
+  assign y = 16'hFFFF;
+  assign z = 16'hFFFF;
+endmodule
+
+module simple_hierarchy(
+  input  [15:0] a,
+                b,
+                c,
+  output [15:0] y,
+                z);
+
+  simple_comb simple_comb_inst0 (
+    .a (a),
+    .b (b),
+    .c (c),
+    .y (y),
+    .z (z)
+  );
+endmodule
+

--- a/tests/test_backend/test_mlir/test_compile_to_mlir_local_examples.py
+++ b/tests/test_backend/test_mlir/test_compile_to_mlir_local_examples.py
@@ -271,7 +271,7 @@ def test_compile_to_mlir_split_verilog(ckt):
         "split_verilog": True,
         "gold_name": gold_name,
         "basename": basename,
-        "suffix": "v",
+        "sv": False,
     }
     run_test_compile_to_mlir(ckt, **kwargs)
     if config.test_mlir_check_verilog:

--- a/tests/test_backend/test_mlir/test_compile_to_mlir_local_examples.py
+++ b/tests/test_backend/test_mlir/test_compile_to_mlir_local_examples.py
@@ -15,6 +15,7 @@ from examples import (
     complex_register_wrapper,
     complex_bind,
     simple_comb,
+    simple_hierarchy,
     simple_register_wrapper,
 )
 from test_utils import get_local_examples, run_test_compile_to_mlir
@@ -252,4 +253,17 @@ def test_compile_to_mlir_disallow_local_variables(disallow_local_variables: bool
         "disallow_local_variables": disallow_local_variables,
         "gold_name": gold_name,
     }
+    run_test_compile_to_mlir(ckt, **kwargs)
+
+
+@pytest.mark.parametrize("ckt", (simple_hierarchy,))
+def test_compile_to_mlir_split_verilog(ckt):
+    gold_name = ckt.name + "_split_verilog"
+    kwargs = {
+        "split_verilog": True,
+        "gold_name": gold_name,
+        "basename": ckt.name,
+        "suffix": "v",
+    }
+    kwargs.update({"check_verilog": False})
     run_test_compile_to_mlir(ckt, **kwargs)


### PR DESCRIPTION
The `split_verilog` option of the MLIR compiler annotates the output IR to directly output Verilog to specific files using the `hw.output_file` attribute.

This change is in preparation for separating monitor modules into separate Verilog files for bind2.