### PR TITLE
[Bind2] Output bind statements to separate file (MLIR backend)

### DIFF
--- a/magma/backend/mlir/sv.py
+++ b/magma/backend/mlir/sv.py
@@ -7,7 +7,11 @@ from magma.backend.mlir.mlir import (
     begin_dialect, end_dialect,
     print_location,
 )
-from magma.backend.mlir.mlir_printer_utils import print_names, print_types
+from magma.backend.mlir.mlir_printer_utils import (
+    print_attr_dict,
+    print_names,
+    print_types,
+)
 from magma.backend.mlir.print_opts import PrintOpts
 from magma.backend.mlir.printer_base import PrinterBase
 
@@ -220,6 +224,9 @@ class BindOp(MlirOp):
 
     def print_op(self, printer: PrinterBase):
         printer.print(f"sv.bind {self.instance.emit()}")
+        if self.attr_dict:
+            printer.print(" ")
+            print_attr_dict(self.attr_dict, printer)
 
 
 @dataclasses.dataclass

--- a/magma/common.py
+++ b/magma/common.py
@@ -343,3 +343,23 @@ def epilogue(epilogue_fn):
 
 def assert_false(*args, **kwargs):
     assert False
+
+
+def is_(x: Any, y: Any):
+    return x is y
+
+
+def find_by_value(
+        dct: Dict[Any, Any],
+        value: Any,
+        eq: Callable[[Any, Any], bool] = None,
+) -> Iterable[Any]:
+    """Performs a reverse lookup on @dct given @value, i.e. returns any key k
+    for which @eq(@dct[k], @value), where @eq is an optional equality
+    function. By default `is` is used.
+    """
+    if eq is None:
+        eq = is_
+    for k, v in dct.items():
+        if eq(v, value):
+            yield k

--- a/tests/gold/test_bind2_basic_split_verilog.mlir.tpl
+++ b/tests/gold/test_bind2_basic_split_verilog.mlir.tpl
@@ -7,5 +7,5 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
         hw.instance "TopBasicAsserts_mlir_inst0" sym @Top.TopBasicAsserts_mlir_inst0 @TopBasicAsserts_mlir(I: %I: i1, O: %0: i1, other: %I: i1) -> () {doNotPrint = true}
         hw.output %0 : i1
     }
-    sv.bind #hw.innerNameRef<@Top::@Top.TopBasicAsserts_mlir_inst0>
+    sv.bind #hw.innerNameRef<@Top::@Top.TopBasicAsserts_mlir_inst0> {output_file = #hw.output_file<"$cwd/build/TopBasicAsserts_mlir.v">}
 }


### PR DESCRIPTION
In the case that split_verilog is enabled, '`bind' statements are also output to the corresponding monitor file.