### PR TITLE
[Bind2] Refactor XMR references

### DIFF
--- a/tests/test_bind2.py
+++ b/tests/test_bind2.py
@@ -58,13 +58,14 @@ def test_basic(backend, split_verilog):
 
 
 @pytest.mark.parametrize(
-    "backend,flatten_all_tuples",
+    "backend,flatten_all_tuples,inst_attr",
     (
-        ("mlir", True),
-        ("mlir", False),
+        ("mlir", False, False),
+        ("mlir", True, False),
+        ("mlir", True, True),
     )
 )
-def test_xmr(backend, flatten_all_tuples):
+def test_xmr(backend, flatten_all_tuples, inst_attr):
 
     class T(m.Product):
         x = m.Bit
@@ -80,8 +81,12 @@ def test_xmr(backend, flatten_all_tuples):
 
     class Top(m.Circuit):
         io = m.IO(I=m.In(T), O=m.Out(T))
-        middle = Middle(name="middle")
-        io.O @= middle(io.I)
+        if inst_attr:
+            middle = Middle(name="middle")
+            O = middle(io.I)
+        else:
+            O = Middle(name="middle")(io.I)
+        io.O @= O
 
     class TopXMRAsserts(m.Circuit):
         name = f"TopXMRAsserts_{backend}"

--- a/tests/test_circuit/test_instance.py
+++ b/tests/test_circuit/test_instance.py
@@ -1,6 +1,7 @@
 import pytest
 
 import magma as m
+from magma.common import only
 
 
 def test_callback_basic():
@@ -36,3 +37,34 @@ def test_callback_registered():
     m.register_instance_callback(_Test.reg, lambda _, __: None)
     with pytest.raises(AttributeError):
         m.register_instance_callback(_Test.reg, lambda _, __: None)
+
+
+def test_getattr_instance_name():
+    Bar = m.Register(m.Bit)  # just any module
+
+    class Foo(m.Circuit):
+        my_placeholder_var = Bar(name="my_instance_name")
+
+    assert Foo.my_placeholder_var is Foo.my_instance_name
+
+
+def test_getattr_instance_name_overwritten():
+    Bar = m.Register(m.Bit)  # just any module
+
+    class Foo(m.Circuit):
+        my_placeholder_var = Bar(name="my_instance_name")
+        my_instance_name = None
+
+    assert Foo.my_instance_name is None
+    assert Foo.my_placeholder_var is only(Foo.instances)
+
+
+def test_getattr_attribute_error():
+
+    class Foo(m.Circuit):
+        pass
+
+    with pytest.raises(AttributeError) as e:
+        Foo.bar
+
+    assert "has no attribute 'bar'" in str(e)


### PR DESCRIPTION
Avoids requiring setting instances as attributes on circuits to refer to them (similarly with `self.` for Generator2's). Instead getting the attribute will retrieve the instance by name.

For example,

```python
class Foo(m.Circuit):
    my_placeholder_var = Bar(name="my_instance_name")

assert Foo.my_placeholder_var is Foo.my_instance_name
```