### PR TITLE
[SmartBits] Add constant constructor

### DIFF
--- a/magma/smart/smart_bits.py
+++ b/magma/smart/smart_bits.py
@@ -2,7 +2,7 @@ import abc
 import dataclasses
 import inspect
 import operator
-from typing import Callable, Union
+from typing import Any, Callable, Optional, Union
 
 from magma.bit import Bit
 from magma.bits import Bits, BitsMeta, SInt, reduce as bits_reduce
@@ -416,12 +416,23 @@ class SmartBitsMeta(SmartExprMeta):
         return f"SmartBits[{len(cls._T_)}, {cls._signed_}]"
 
 
+def _make_initializer(
+        value: Optional[Any],
+        T: SmartBitsMeta,
+        name: Optional[str]
+) -> Bits:
+    if value is None:
+        return T._to_magma_()(name=name)
+    size = len(T._T_)
+    if isinstance(value, Bits[size]):
+        return value
+    return Bits[size](value)
+
+
 class SmartBits(SmartBitsExpr, metaclass=SmartBitsMeta):
     def __init__(self, value=None, name=None):
         super().__init__(self)
-        if value is None:
-            value = type(self)._to_magma_()(name=name)
-        self._value = value
+        self._value = _make_initializer(value, type(self), name)
 
     def __len__(self):
         return len(type(self)._T_)

--- a/tests/test_smart/test_smart_bits.py
+++ b/tests/test_smart/test_smart_bits.py
@@ -578,3 +578,16 @@ def test_concat_subnode():
         io.O0 @= O0
 
     return _Test, _Gold
+
+
+def test_constant_constructor():
+    t = m.smart.SmartBits[8](10)
+    value = t.untyped_value()
+    assert isinstance(value, m.Bits[8])
+    assert value.const()
+    assert int(value) == 10
+
+
+def test_bad_constructor():
+    with pytest.raises(TypeError):
+        m.smart.SmartBits[8](object())


### PR DESCRIPTION
Previously, we assumed values passed into the constructor of `SmartBits[n]()` were already of `Bits` type. Now we explicitly check and try to convert/promote to `Bits` if not. Useful to construct smart constants directly, e.g. `SmartBits[n](0)`, rather than having to indirectly construct from `Bits` (e.g. `SmartBits[n](Bits[n](0))` or `make_smart(Bits[n](0))`).