### PR TITLE
[MLIR] Add locations to HW module signatures

### DIFF
--- a/magma/backend/mlir/builtin.py
+++ b/magma/backend/mlir/builtin.py
@@ -1,12 +1,19 @@
 import dataclasses
 import pathlib
 
-from magma.backend.mlir.mlir import MlirDialect, begin_dialect, end_dialect
-from magma.backend.mlir.mlir import MlirLocation
-from magma.backend.mlir.mlir import MlirAttribute
-from magma.backend.mlir.mlir import MlirOp, MlirRegion, MlirBlock
-from magma.backend.mlir.mlir import MlirType
+from magma.backend.mlir.mlir import (
+    begin_dialect,
+    end_dialect,
+    MlirAttribute,
+    MlirBlock,
+    MlirDialect,
+    MlirLocation,
+    MlirOp,
+    MlirRegion,
+    MlirType,
+)
 from magma.backend.mlir.mlir_printer_utils import print_attr_dict
+from magma.backend.mlir.print_opts import PrintOpts
 from magma.backend.mlir.printer_base import PrinterBase
 from magma.config import config, RuntimeConfig
 
@@ -81,7 +88,7 @@ class ModuleOp(MlirOp):
     def add_operation(self, operation: MlirOp):
         self._block.add_operation(operation)
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         printer.print("module")
         if self.attr_dict:
             printer.print(" attributes ")

--- a/magma/backend/mlir/comb.py
+++ b/magma/backend/mlir/comb.py
@@ -4,6 +4,7 @@ from typing import List
 from magma.backend.mlir.mlir import MlirDialect, begin_dialect, end_dialect
 from magma.backend.mlir.mlir_printer_utils import print_names, print_types
 from magma.backend.mlir.mlir import MlirValue, MlirOp
+from magma.backend.mlir.print_opts import PrintOpts
 from magma.backend.mlir.printer_base import PrinterBase
 
 
@@ -17,7 +18,7 @@ class BaseOp(MlirOp):
     results: List[MlirValue]
     op_name: str
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(f" = comb.{self.op_name} ")
         print_names(self.operands, printer)
@@ -30,7 +31,7 @@ class ConcatOp(MlirOp):
     operands: List[MlirValue]
     results: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(f" = comb.concat ")
         print_names(self.operands, printer)
@@ -44,7 +45,7 @@ class ExtractOp(MlirOp):
     results: List[MlirValue]
     lo: int
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(" = comb.extract ")
         print_names(self.operands, printer)
@@ -60,7 +61,7 @@ class ICmpOp(MlirOp):
     results: List[MlirValue]
     predicate: str
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(f" = comb.icmp {self.predicate} ")
         print_names(self.operands, printer)
@@ -73,7 +74,7 @@ class ParityOp(MlirOp):
     operands: List[MlirValue]
     results: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(f" = comb.parity ")
         print_names(self.operands, printer)

--- a/magma/backend/mlir/hw.py
+++ b/magma/backend/mlir/hw.py
@@ -3,10 +3,22 @@ from typing import Any, ClassVar, List, Mapping, Optional, Tuple
 
 from magma.backend.mlir.common import default_field
 from magma.backend.mlir.mlir import (
-    MlirDialect, MlirOp, MlirValue, MlirType, MlirSymbol, MlirAttribute,
-    begin_dialect, end_dialect)
+    begin_dialect,
+    end_dialect,
+    MlirAttribute,
+    MlirDialect,
+    MlirOp,
+    MlirSymbol,
+    MlirType,
+    MlirValue,
+)
 from magma.backend.mlir.mlir_printer_utils import (
-    print_names, print_types, print_signature, print_attr_dict)
+    print_attr_dict,
+    print_names,
+    print_signature,
+    print_types,
+)
+from magma.backend.mlir.print_opts import PrintOpts
 from magma.backend.mlir.printer_base import PrinterBase
 
 
@@ -93,7 +105,7 @@ class ModuleOpBase(MlirOp):
     name: MlirSymbol
     parameters: List[ParamDeclAttr] = default_field(list)
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         printer.print(f"hw.{self.op_name} {self.name.name}")
         if self.parameters:
             printer.print("<")
@@ -129,7 +141,7 @@ class ModuleExternOp(ModuleOpBase):
 class OutputOp(MlirOp):
     operands: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         printer.print(f"hw.output ")
         print_names(self.operands, printer)
         printer.print(" : ")
@@ -141,7 +153,7 @@ class ConstantOp(MlirOp):
     results: List[MlirValue]
     value: int
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(f" = hw.constant {self.value} : ")
         print_types(self.results, printer)
@@ -156,7 +168,7 @@ class InstanceOp(MlirOp):
     parameters: List[ParamDeclAttr] = default_field(list)
     sym: Optional[MlirSymbol] = None
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         if self.results:
             print_names(self.results, printer)
             printer.print(" = ")
@@ -191,7 +203,7 @@ class ArrayGetOp(MlirOp):
     operands: List[MlirValue]
     results: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(" = hw.array_get ")
         print_names(self.operands[0], printer)
@@ -206,7 +218,7 @@ class ArraySliceOp(MlirOp):
     operands: List[MlirValue]
     results: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(" = hw.array_slice ")
         print_names(self.operands[0], printer)
@@ -223,7 +235,7 @@ class ArrayCreateOp(MlirOp):
     operands: List[MlirValue]
     results: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(" = hw.array_create ")
         print_names(self.operands, printer)
@@ -236,7 +248,7 @@ class ArrayConcatOp(MlirOp):
     operands: List[MlirValue]
     results: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(" = hw.array_concat ")
         print_names(self.operands, printer)
@@ -250,7 +262,7 @@ class StructExtractOp(MlirOp):
     results: List[MlirValue]
     field: str
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(" = hw.struct_extract ")
         print_names(self.operands, printer)
@@ -263,7 +275,7 @@ class StructCreateOp(MlirOp):
     operands: List[MlirValue]
     results: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(" = hw.struct_create (")
         print_names(self.operands, printer)

--- a/magma/backend/mlir/hw.py
+++ b/magma/backend/mlir/hw.py
@@ -112,9 +112,9 @@ class ModuleOpBase(MlirOp):
             printer.print(", ".join(param.emit() for param in self.parameters))
             printer.print(">")
         printer.print("(")
-        print_signature(self.operands, printer)
+        print_signature(self.operands, printer, print_opts)
         printer.print(") -> (")
-        print_signature(self.results, printer, raw_names=True)
+        print_signature(self.results, printer, print_opts, raw_names=True)
         printer.print(")")
         if self.attr_dict:
             printer.print(" attributes ")

--- a/magma/backend/mlir/mlir.py
+++ b/magma/backend/mlir/mlir.py
@@ -91,6 +91,7 @@ class MlirType(metaclass=MlirTypeMeta):
 class MlirValue:
     type: MlirType
     raw_name: str
+    location: MlirLocation = default_field(_default_location, init=False)
 
     @property
     def name(self) -> str:

--- a/magma/backend/mlir/mlir.py
+++ b/magma/backend/mlir/mlir.py
@@ -27,36 +27,6 @@ class DialectKind(abc.ABCMeta):
         return cls
 
 
-class MlirTypeMeta(DialectKind):
-    def _register_(cls, dialect):
-        dialect.register_type(cls)
-
-
-class MlirType(metaclass=MlirTypeMeta):
-    @abc.abstractmethod
-    def emit(self) -> str:
-        raise NotImplementedError()
-
-
-@dataclasses.dataclass(frozen=True)
-class MlirValue:
-    type: MlirType
-    raw_name: str
-
-    @property
-    def name(self) -> str:
-        return f"%{self.raw_name}"
-
-
-@dataclasses.dataclass(frozen=True)
-class MlirSymbol:
-    raw_name: str
-
-    @property
-    def name(self) -> str:
-        return f"@{self.raw_name}"
-
-
 class MlirAttributeMeta(DialectKind):
     def _register_(cls, dialect):
         dialect.register_attribute(cls)
@@ -104,6 +74,36 @@ def _print_location_epilogue(this, printer, opts):
 
 
 print_location = epilogue(_print_location_epilogue)
+
+
+class MlirTypeMeta(DialectKind):
+    def _register_(cls, dialect):
+        dialect.register_type(cls)
+
+
+class MlirType(metaclass=MlirTypeMeta):
+    @abc.abstractmethod
+    def emit(self) -> str:
+        raise NotImplementedError()
+
+
+@dataclasses.dataclass(frozen=True)
+class MlirValue:
+    type: MlirType
+    raw_name: str
+
+    @property
+    def name(self) -> str:
+        return f"%{self.raw_name}"
+
+
+@dataclasses.dataclass(frozen=True)
+class MlirSymbol:
+    raw_name: str
+
+    @property
+    def name(self) -> str:
+        return f"@{self.raw_name}"
 
 
 @dataclasses.dataclass

--- a/magma/backend/mlir/mlir.py
+++ b/magma/backend/mlir/mlir.py
@@ -199,7 +199,7 @@ class MlirOp(WithId, metaclass=MlirOpMeta):
 
     @print_location
     def print(self, printer: PrinterBase, opts: PrintOpts):
-        self.print_op(printer)
+        self.print_op(printer, opts)
         if not self.regions:
             printer.flush()
             return
@@ -212,7 +212,7 @@ class MlirOp(WithId, metaclass=MlirOpMeta):
         printer.print_line("}")
 
     @abc.abstractmethod
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, opts: PrintOpts):
         raise NotImplementedError()
 
 

--- a/magma/backend/mlir/mlir_printer_utils.py
+++ b/magma/backend/mlir/mlir_printer_utils.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, List, Mapping, Union
 
 from magma.backend.mlir.mlir import MlirAttribute, MlirValue
+from magma.backend.mlir.print_opts import PrintOpts
 from magma.backend.mlir.printer_base import PrinterBase
 
 
@@ -39,11 +40,19 @@ def print_types(
 def print_signature(
         value_or_value_list: MlirValueOrMlirValueList,
         printer: PrinterBase,
-        raw_names: bool = False):
+        print_opts: PrintOpts,
+        raw_names: bool = False,
+):
     value_list = _maybe_wrap_value_or_value_list(value_or_value_list)
     get_name = get_name_fn(raw_names)
-    signatures = (f"{get_name(v)}: {v.type.emit()}" for v in value_list)
-    printer.print(", ".join(signatures))
+
+    def _make_signature(value: MlirValue) -> str:
+        signature = f"{get_name(value)}: {value.type.emit()}"
+        if print_opts.print_locations:
+            signature += f" {value.location.emit()}"
+        return signature
+
+    printer.print(", ".join(map(_make_signature, value_list)))
 
 
 def _attr_to_string(value: Any) -> str:

--- a/magma/backend/mlir/sv.py
+++ b/magma/backend/mlir/sv.py
@@ -3,8 +3,13 @@ from typing import List, Optional
 
 from magma.backend.mlir.hw import hw
 from magma.backend.mlir.mlir import (
-    MlirDialect, MlirOp, MlirBlock, MlirValue, MlirSymbol,
-    begin_dialect, end_dialect,
+    begin_dialect,
+    end_dialect,
+    MlirBlock,
+    MlirDialect,
+    MlirOp,
+    MlirSymbol,
+    MlirValue,
     print_location,
 )
 from magma.backend.mlir.mlir_printer_utils import (
@@ -25,7 +30,7 @@ class RegOp(MlirOp):
     results: List[MlirValue]
     name: Optional[str] = None
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(f" = sv.reg ")
         if self.name is not None:
@@ -39,7 +44,7 @@ class ReadInOutOp(MlirOp):
     operands: List[MlirValue]
     results: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(f" = sv.read_inout ")
         print_names(self.operands, printer)
@@ -51,7 +56,7 @@ class ReadInOutOp(MlirOp):
 class AssignBaseOp(MlirOp):
     operands: List[MlirValue]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         printer.print(f"sv.{self.op_name} ")
         print_names(self.operands, printer)
         printer.print(" : ")
@@ -119,7 +124,7 @@ class AlwaysFFOp(MlirOp):
         printer.pop()
         printer.print_line("}")
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         raise NotImplementedError()
 
 
@@ -141,7 +146,7 @@ class AlwaysCombOp(MlirOp):
         printer.pop()
         printer.print_line("}")
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         raise NotImplementedError()
 
 
@@ -153,7 +158,7 @@ class InitialOp(MlirOp):
     def add_operation(self, operation: MlirOp):
         self._block.add_operation(operation)
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         printer.print("sv.initial")
 
 
@@ -163,7 +168,7 @@ class WireOp(MlirOp):
     name: Optional[str] = None
     sym: Optional[MlirSymbol] = None
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(" = sv.wire ")
         if self.sym is not None:
@@ -189,7 +194,7 @@ class VerbatimOp(MlirOp):
     operands: List[MlirOp]
     string: str
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         string = _esacpe_string(self.string)
         printer.print(f"sv.verbatim \"{string}\"")
         if self.operands:
@@ -205,7 +210,7 @@ class VerbatimExprOp(MlirOp):
     results: List[MlirOp]
     expr: str
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         expr = _esacpe_string(self.expr)
         print_names(self.results, printer)
         printer.print(f" = sv.verbatim.expr \"{expr}\"")
@@ -222,7 +227,7 @@ class VerbatimExprOp(MlirOp):
 class BindOp(MlirOp):
     instance: hw.InnerRefAttr
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         printer.print(f"sv.bind {self.instance.emit()}")
         if self.attr_dict:
             printer.print(" ")
@@ -265,7 +270,7 @@ class IfDefOp(MlirOp):
         printer.pop()
         printer.print_line("}")
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         raise NotImplementedError()
 
 
@@ -307,7 +312,7 @@ class IfOp(MlirOp):
         printer.pop()
         printer.print_line("}")
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         raise NotImplementedError()
 
 
@@ -317,7 +322,7 @@ class XMROp(MlirOp):
     is_rooted: bool
     path: List[str]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(f" = sv.xmr ")
         if self.is_rooted:
@@ -333,7 +338,7 @@ class ArrayIndexInOutOp(MlirOp):
     operands: List[MlirOp]
     results: List[MlirOp]
 
-    def print_op(self, printer: PrinterBase):
+    def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         print_names(self.results, printer)
         printer.print(f" = sv.array_index_inout ")
         print_names(self.operands[0], printer)

--- a/tests/test_backend/test_mlir/golds/simple_structural_location_info_style_plain.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_structural_location_info_style_plain.mlir
@@ -1,5 +1,5 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=plain"} {
-    hw.module @simple_structural(%a: i16, %b: i16, %c: i16, %CLK: i1) -> (y: i16, z: i16) {
+    hw.module @simple_structural(%a: i16 loc(unknown), %b: i16 loc(unknown), %c: i16 loc(unknown), %CLK: i1 loc(unknown)) -> (y: i16 loc(unknown), z: i16 loc(unknown)) {
         %1 = sv.reg name "a_reg" : !hw.inout<i16>
         loc("file.py":100:0)
         sv.alwaysff(posedge %CLK) {

--- a/tests/test_backend/test_mlir/golds/simple_structural_location_info_style_wrapInAtSquareBracket.mlir
+++ b/tests/test_backend/test_mlir/golds/simple_structural_location_info_style_wrapInAtSquareBracket.mlir
@@ -1,5 +1,5 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=wrapInAtSquareBracket"} {
-    hw.module @simple_structural(%a: i16, %b: i16, %c: i16, %CLK: i1) -> (y: i16, z: i16) {
+    hw.module @simple_structural(%a: i16 loc(unknown), %b: i16 loc(unknown), %c: i16 loc(unknown), %CLK: i1 loc(unknown)) -> (y: i16 loc(unknown), z: i16 loc(unknown)) {
         %1 = sv.reg name "a_reg" : !hw.inout<i16>
         loc("file.py":100:0)
         sv.alwaysff(posedge %CLK) {


### PR DESCRIPTION
Due to https://github.com/llvm/circt/pull/4540, module ports now are also given a location. We need to explicitly set their location (as we do for all op's) so that they don't print `<stdin>...`.