### PR TITLE
[When] Revert hotfix handling of wiring directly to when output (#1237)

### DIFF
--- a/tests/gold/test_when_output_resolve.mlir
+++ b/tests/gold/test_when_output_resolve.mlir
@@ -5,42 +5,36 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
         %0 = sv.read_inout %1 : !hw.inout<i8>
         %3 = hw.constant -1 : i8
         %2 = comb.xor %3, %0 : i8
-        %7 = sv.reg : !hw.inout<i8>
-        %4 = sv.read_inout %7 : !hw.inout<i8>
-        %8 = sv.reg : !hw.inout<i1>
-        %5 = sv.read_inout %8 : !hw.inout<i1>
-        %9 = sv.reg : !hw.inout<i1>
-        %6 = sv.read_inout %9 : !hw.inout<i1>
+        %5 = sv.reg : !hw.inout<i8>
+        %4 = sv.read_inout %5 : !hw.inout<i8>
         sv.alwayscomb {
             sv.if %x {
-                %18 = comb.concat %17, %16, %15, %14, %13, %12, %11, %10 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %7, %18 : i8
-                sv.bpassign %8, %10 : i1
-                sv.bpassign %9, %11 : i1
+                %14 = comb.concat %13, %12, %11, %10, %9, %8, %7, %6 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %5, %14 : i8
             } else {
-                %27 = comb.concat %26, %25, %24, %23, %22, %21, %20, %19 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %7, %27 : i8
-                sv.bpassign %8, %19 : i1
-                sv.bpassign %9, %20 : i1
+                %23 = comb.concat %22, %21, %20, %19, %18, %17, %16, %15 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %5, %23 : i8
             }
         }
-        %10 = comb.extract %0 from 0 : (i8) -> i1
-        %11 = comb.extract %0 from 1 : (i8) -> i1
-        %12 = comb.extract %0 from 2 : (i8) -> i1
-        %13 = comb.extract %0 from 3 : (i8) -> i1
-        %14 = comb.extract %0 from 4 : (i8) -> i1
-        %15 = comb.extract %0 from 5 : (i8) -> i1
-        %16 = comb.extract %0 from 6 : (i8) -> i1
-        %17 = comb.extract %0 from 7 : (i8) -> i1
-        %19 = comb.extract %2 from 0 : (i8) -> i1
-        %20 = comb.extract %2 from 1 : (i8) -> i1
-        %21 = comb.extract %2 from 2 : (i8) -> i1
-        %22 = comb.extract %2 from 3 : (i8) -> i1
-        %23 = comb.extract %2 from 4 : (i8) -> i1
-        %24 = comb.extract %2 from 5 : (i8) -> i1
-        %25 = comb.extract %2 from 6 : (i8) -> i1
-        %26 = comb.extract %2 from 7 : (i8) -> i1
-        %28 = comb.concat %5, %6 : i1, i1
-        hw.output %4, %28 : i8, i2
+        %6 = comb.extract %0 from 0 : (i8) -> i1
+        %7 = comb.extract %0 from 1 : (i8) -> i1
+        %8 = comb.extract %0 from 2 : (i8) -> i1
+        %9 = comb.extract %0 from 3 : (i8) -> i1
+        %10 = comb.extract %0 from 4 : (i8) -> i1
+        %11 = comb.extract %0 from 5 : (i8) -> i1
+        %12 = comb.extract %0 from 6 : (i8) -> i1
+        %13 = comb.extract %0 from 7 : (i8) -> i1
+        %15 = comb.extract %2 from 0 : (i8) -> i1
+        %16 = comb.extract %2 from 1 : (i8) -> i1
+        %17 = comb.extract %2 from 2 : (i8) -> i1
+        %18 = comb.extract %2 from 3 : (i8) -> i1
+        %19 = comb.extract %2 from 4 : (i8) -> i1
+        %20 = comb.extract %2 from 5 : (i8) -> i1
+        %21 = comb.extract %2 from 6 : (i8) -> i1
+        %22 = comb.extract %2 from 7 : (i8) -> i1
+        %24 = comb.extract %4 from 1 : (i8) -> i1
+        %25 = comb.extract %4 from 0 : (i8) -> i1
+        %26 = comb.concat %25, %24 : i1, i1
+        hw.output %4, %26 : i8, i2
     }
 }

--- a/tests/gold/test_when_output_resolve2.mlir
+++ b/tests/gold/test_when_output_resolve2.mlir
@@ -2,19 +2,15 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
     hw.module @test_when_output_resolve2(%I: i8, %x: i1) -> (O0: i8, O1: i8) {
         %1 = hw.constant -1 : i8
         %0 = comb.xor %1, %I : i8
-        %4 = sv.reg : !hw.inout<i8>
-        %2 = sv.read_inout %4 : !hw.inout<i8>
-        %5 = sv.reg : !hw.inout<i8>
-        %3 = sv.read_inout %5 : !hw.inout<i8>
+        %3 = sv.reg : !hw.inout<i8>
+        %2 = sv.read_inout %3 : !hw.inout<i8>
         sv.alwayscomb {
             sv.if %x {
-                sv.bpassign %4, %I : i8
-                sv.bpassign %5, %I : i8
+                sv.bpassign %3, %I : i8
             } else {
-                sv.bpassign %4, %0 : i8
-                sv.bpassign %5, %0 : i8
+                sv.bpassign %3, %0 : i8
             }
         }
-        hw.output %2, %3 : i8, i8
+        hw.output %2, %2 : i8, i8
     }
 }

--- a/tests/gold/test_when_tuple_as_bits_resolve.mlir
+++ b/tests/gold/test_when_tuple_as_bits_resolve.mlir
@@ -8,221 +8,117 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none,disallowLocal
         %4 = hw.array_get %6[%S] : !hw.array<2xi8>, i1
         %7 = hw.array_create %I_x_z_y, %I_x_z_y : i1
         %5 = hw.array_get %7[%S] : !hw.array<2xi1>, i1
-        %48 = sv.reg : !hw.inout<i8>
-        %8 = sv.read_inout %48 : !hw.inout<i8>
-        %49 = sv.reg : !hw.inout<i8>
-        %9 = sv.read_inout %49 : !hw.inout<i8>
-        %50 = sv.reg : !hw.inout<i1>
-        %10 = sv.read_inout %50 : !hw.inout<i1>
-        %51 = sv.reg : !hw.inout<i8>
-        %11 = sv.read_inout %51 : !hw.inout<i8>
-        %52 = sv.reg : !hw.inout<i1>
-        %12 = sv.read_inout %52 : !hw.inout<i1>
-        %53 = sv.reg : !hw.inout<i8>
-        %13 = sv.read_inout %53 : !hw.inout<i8>
-        %54 = sv.reg : !hw.inout<i1>
-        %14 = sv.read_inout %54 : !hw.inout<i1>
-        %55 = sv.reg : !hw.inout<i1>
-        %15 = sv.read_inout %55 : !hw.inout<i1>
-        %56 = sv.reg : !hw.inout<i1>
-        %16 = sv.read_inout %56 : !hw.inout<i1>
-        %57 = sv.reg : !hw.inout<i1>
-        %17 = sv.read_inout %57 : !hw.inout<i1>
-        %58 = sv.reg : !hw.inout<i1>
-        %18 = sv.read_inout %58 : !hw.inout<i1>
-        %59 = sv.reg : !hw.inout<i1>
-        %19 = sv.read_inout %59 : !hw.inout<i1>
-        %60 = sv.reg : !hw.inout<i1>
-        %20 = sv.read_inout %60 : !hw.inout<i1>
-        %61 = sv.reg : !hw.inout<i1>
-        %21 = sv.read_inout %61 : !hw.inout<i1>
-        %62 = sv.reg : !hw.inout<i1>
-        %22 = sv.read_inout %62 : !hw.inout<i1>
-        %63 = sv.reg : !hw.inout<i1>
-        %23 = sv.read_inout %63 : !hw.inout<i1>
-        %64 = sv.reg : !hw.inout<i1>
-        %24 = sv.read_inout %64 : !hw.inout<i1>
-        %65 = sv.reg : !hw.inout<i1>
-        %25 = sv.read_inout %65 : !hw.inout<i1>
-        %66 = sv.reg : !hw.inout<i1>
-        %26 = sv.read_inout %66 : !hw.inout<i1>
-        %67 = sv.reg : !hw.inout<i1>
-        %27 = sv.read_inout %67 : !hw.inout<i1>
-        %68 = sv.reg : !hw.inout<i1>
-        %28 = sv.read_inout %68 : !hw.inout<i1>
-        %69 = sv.reg : !hw.inout<i1>
-        %29 = sv.read_inout %69 : !hw.inout<i1>
-        %70 = sv.reg : !hw.inout<i1>
-        %30 = sv.read_inout %70 : !hw.inout<i1>
-        %71 = sv.reg : !hw.inout<i1>
-        %31 = sv.read_inout %71 : !hw.inout<i1>
-        %72 = sv.reg : !hw.inout<i1>
-        %32 = sv.read_inout %72 : !hw.inout<i1>
-        %73 = sv.reg : !hw.inout<i1>
-        %33 = sv.read_inout %73 : !hw.inout<i1>
-        %74 = sv.reg : !hw.inout<i1>
-        %34 = sv.read_inout %74 : !hw.inout<i1>
-        %75 = sv.reg : !hw.inout<i1>
-        %35 = sv.read_inout %75 : !hw.inout<i1>
-        %76 = sv.reg : !hw.inout<i1>
-        %36 = sv.read_inout %76 : !hw.inout<i1>
-        %77 = sv.reg : !hw.inout<i1>
-        %37 = sv.read_inout %77 : !hw.inout<i1>
-        %78 = sv.reg : !hw.inout<i1>
-        %38 = sv.read_inout %78 : !hw.inout<i1>
-        %79 = sv.reg : !hw.inout<i1>
-        %39 = sv.read_inout %79 : !hw.inout<i1>
-        %80 = sv.reg : !hw.inout<i1>
-        %40 = sv.read_inout %80 : !hw.inout<i1>
-        %81 = sv.reg : !hw.inout<i1>
-        %41 = sv.read_inout %81 : !hw.inout<i1>
-        %82 = sv.reg : !hw.inout<i1>
-        %42 = sv.read_inout %82 : !hw.inout<i1>
-        %83 = sv.reg : !hw.inout<i1>
-        %43 = sv.read_inout %83 : !hw.inout<i1>
-        %84 = sv.reg : !hw.inout<i1>
-        %44 = sv.read_inout %84 : !hw.inout<i1>
-        %85 = sv.reg : !hw.inout<i1>
-        %45 = sv.read_inout %85 : !hw.inout<i1>
-        %86 = sv.reg : !hw.inout<i1>
-        %46 = sv.read_inout %86 : !hw.inout<i1>
-        %87 = sv.reg : !hw.inout<i1>
-        %47 = sv.read_inout %87 : !hw.inout<i1>
+        %14 = sv.reg : !hw.inout<i8>
+        %8 = sv.read_inout %14 : !hw.inout<i8>
+        %15 = sv.reg : !hw.inout<i8>
+        %9 = sv.read_inout %15 : !hw.inout<i8>
+        %16 = sv.reg : !hw.inout<i1>
+        %10 = sv.read_inout %16 : !hw.inout<i1>
+        %17 = sv.reg : !hw.inout<i8>
+        %11 = sv.read_inout %17 : !hw.inout<i8>
+        %18 = sv.reg : !hw.inout<i1>
+        %12 = sv.read_inout %18 : !hw.inout<i1>
+        %19 = sv.reg : !hw.inout<i8>
+        %13 = sv.read_inout %19 : !hw.inout<i8>
         sv.alwayscomb {
-            %96 = comb.concat %95, %94, %93, %92, %91, %90, %89, %88 : i1, i1, i1, i1, i1, i1, i1, i1
-            sv.bpassign %53, %96 : i8
-            sv.bpassign %80, %88 : i1
-            sv.bpassign %81, %89 : i1
-            sv.bpassign %82, %90 : i1
-            sv.bpassign %83, %91 : i1
-            sv.bpassign %84, %92 : i1
-            sv.bpassign %85, %93 : i1
-            sv.bpassign %86, %94 : i1
-            sv.bpassign %87, %95 : i1
+            %28 = comb.concat %27, %26, %25, %24, %23, %22, %21, %20 : i1, i1, i1, i1, i1, i1, i1, i1
+            sv.bpassign %19, %28 : i8
             sv.if %S {
-                sv.bpassign %50, %I_x_y : i1
-                sv.bpassign %54, %I_x_y : i1
-                sv.bpassign %52, %5 : i1
-                %121 = comb.concat %104, %103, %102, %101, %100, %99, %98, %97 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %51, %121 : i8
-                sv.bpassign %55, %97 : i1
-                sv.bpassign %56, %98 : i1
-                sv.bpassign %57, %99 : i1
-                sv.bpassign %58, %100 : i1
-                sv.bpassign %59, %101 : i1
-                sv.bpassign %60, %102 : i1
-                sv.bpassign %61, %103 : i1
-                sv.bpassign %62, %104 : i1
-                sv.bpassign %63, %5 : i1
-                %122 = comb.concat %112, %111, %110, %109, %108, %107, %106, %105 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %48, %122 : i8
-                sv.bpassign %64, %105 : i1
-                sv.bpassign %65, %106 : i1
-                sv.bpassign %66, %107 : i1
-                sv.bpassign %67, %108 : i1
-                sv.bpassign %68, %109 : i1
-                sv.bpassign %69, %110 : i1
-                sv.bpassign %70, %111 : i1
-                sv.bpassign %71, %112 : i1
-                %123 = comb.concat %120, %119, %118, %117, %116, %115, %114, %113 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %49, %123 : i8
-                sv.bpassign %72, %113 : i1
-                sv.bpassign %73, %114 : i1
-                sv.bpassign %74, %115 : i1
-                sv.bpassign %75, %116 : i1
-                sv.bpassign %76, %117 : i1
-                sv.bpassign %77, %118 : i1
-                sv.bpassign %78, %119 : i1
-                sv.bpassign %79, %120 : i1
+                sv.bpassign %16, %I_x_y : i1
+                sv.bpassign %18, %5 : i1
+                %53 = comb.concat %36, %35, %34, %33, %32, %31, %30, %29 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %17, %53 : i8
+                %54 = comb.concat %44, %43, %42, %41, %40, %39, %38, %37 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %14, %54 : i8
+                %55 = comb.concat %52, %51, %50, %49, %48, %47, %46, %45 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %15, %55 : i8
             } else {
-                sv.bpassign %50, %I_x_y : i1
-                sv.bpassign %54, %I_x_y : i1
-                sv.bpassign %52, %I_x_z_y : i1
-                %132 = comb.concat %131, %130, %129, %128, %127, %126, %125, %124 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %51, %132 : i8
-                sv.bpassign %55, %124 : i1
-                sv.bpassign %56, %125 : i1
-                sv.bpassign %57, %126 : i1
-                sv.bpassign %58, %127 : i1
-                sv.bpassign %59, %128 : i1
-                sv.bpassign %60, %129 : i1
-                sv.bpassign %61, %130 : i1
-                sv.bpassign %62, %131 : i1
-                sv.bpassign %63, %I_x_z_y : i1
-                %133 = comb.concat %112, %111, %110, %109, %108, %107, %106, %105 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %48, %133 : i8
-                sv.bpassign %64, %105 : i1
-                sv.bpassign %65, %106 : i1
-                sv.bpassign %66, %107 : i1
-                sv.bpassign %67, %108 : i1
-                sv.bpassign %68, %109 : i1
-                sv.bpassign %69, %110 : i1
-                sv.bpassign %70, %111 : i1
-                sv.bpassign %71, %112 : i1
-                %134 = comb.concat %120, %119, %118, %117, %116, %115, %114, %113 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %49, %134 : i8
-                sv.bpassign %72, %113 : i1
-                sv.bpassign %73, %114 : i1
-                sv.bpassign %74, %115 : i1
-                sv.bpassign %75, %116 : i1
-                sv.bpassign %76, %117 : i1
-                sv.bpassign %77, %118 : i1
-                sv.bpassign %78, %119 : i1
-                sv.bpassign %79, %120 : i1
-                %135 = comb.concat %95, %94, %93, %92, %91, %90, %89, %88 : i1, i1, i1, i1, i1, i1, i1, i1
-                sv.bpassign %53, %135 : i8
-                sv.bpassign %80, %88 : i1
-                sv.bpassign %81, %89 : i1
-                sv.bpassign %82, %90 : i1
-                sv.bpassign %83, %91 : i1
-                sv.bpassign %84, %92 : i1
-                sv.bpassign %85, %93 : i1
-                sv.bpassign %86, %94 : i1
-                sv.bpassign %87, %95 : i1
+                sv.bpassign %16, %I_x_y : i1
+                sv.bpassign %18, %I_x_z_y : i1
+                %64 = comb.concat %63, %62, %61, %60, %59, %58, %57, %56 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %17, %64 : i8
+                %65 = comb.concat %44, %43, %42, %41, %40, %39, %38, %37 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %14, %65 : i8
+                %66 = comb.concat %52, %51, %50, %49, %48, %47, %46, %45 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %15, %66 : i8
+                %67 = comb.concat %27, %26, %25, %24, %23, %22, %21, %20 : i1, i1, i1, i1, i1, i1, i1, i1
+                sv.bpassign %19, %67 : i8
             }
         }
-        %88 = comb.extract %I_y from 0 : (i8) -> i1
-        %89 = comb.extract %I_y from 1 : (i8) -> i1
-        %90 = comb.extract %I_y from 2 : (i8) -> i1
-        %91 = comb.extract %I_y from 3 : (i8) -> i1
-        %92 = comb.extract %I_y from 4 : (i8) -> i1
-        %93 = comb.extract %I_y from 5 : (i8) -> i1
-        %94 = comb.extract %I_y from 6 : (i8) -> i1
-        %95 = comb.extract %I_y from 7 : (i8) -> i1
-        %97 = comb.extract %4 from 0 : (i8) -> i1
-        %98 = comb.extract %4 from 1 : (i8) -> i1
-        %99 = comb.extract %4 from 2 : (i8) -> i1
-        %100 = comb.extract %4 from 3 : (i8) -> i1
-        %101 = comb.extract %4 from 4 : (i8) -> i1
-        %102 = comb.extract %4 from 5 : (i8) -> i1
-        %103 = comb.extract %4 from 6 : (i8) -> i1
-        %104 = comb.extract %4 from 7 : (i8) -> i1
-        %105 = comb.extract %0 from 0 : (i8) -> i1
-        %106 = comb.extract %0 from 1 : (i8) -> i1
-        %107 = comb.extract %0 from 2 : (i8) -> i1
-        %108 = comb.extract %0 from 3 : (i8) -> i1
-        %109 = comb.extract %0 from 4 : (i8) -> i1
-        %110 = comb.extract %0 from 5 : (i8) -> i1
-        %111 = comb.extract %0 from 6 : (i8) -> i1
-        %112 = comb.extract %0 from 7 : (i8) -> i1
-        %113 = comb.extract %2 from 0 : (i8) -> i1
-        %114 = comb.extract %2 from 1 : (i8) -> i1
-        %115 = comb.extract %2 from 2 : (i8) -> i1
-        %116 = comb.extract %2 from 3 : (i8) -> i1
-        %117 = comb.extract %2 from 4 : (i8) -> i1
-        %118 = comb.extract %2 from 5 : (i8) -> i1
-        %119 = comb.extract %2 from 6 : (i8) -> i1
-        %120 = comb.extract %2 from 7 : (i8) -> i1
-        %124 = comb.extract %I_x_z_x from 0 : (i8) -> i1
-        %125 = comb.extract %I_x_z_x from 1 : (i8) -> i1
-        %126 = comb.extract %I_x_z_x from 2 : (i8) -> i1
-        %127 = comb.extract %I_x_z_x from 3 : (i8) -> i1
-        %128 = comb.extract %I_x_z_x from 4 : (i8) -> i1
-        %129 = comb.extract %I_x_z_x from 5 : (i8) -> i1
-        %130 = comb.extract %I_x_z_x from 6 : (i8) -> i1
-        %131 = comb.extract %I_x_z_x from 7 : (i8) -> i1
-        %136 = hw.array_create %9, %8 : i8
-        %137 = comb.concat %47, %46, %45, %44, %43, %42, %41, %40, %39, %38, %37, %36, %35, %34, %33, %32, %31, %30, %29, %28, %27, %26, %25, %24, %23, %22, %21, %20, %19, %18, %17, %16, %15, %14 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
-        hw.output %10, %11, %12, %136, %13, %137 : i1, i8, i1, !hw.array<2xi8>, i8, i34
+        %20 = comb.extract %I_y from 0 : (i8) -> i1
+        %21 = comb.extract %I_y from 1 : (i8) -> i1
+        %22 = comb.extract %I_y from 2 : (i8) -> i1
+        %23 = comb.extract %I_y from 3 : (i8) -> i1
+        %24 = comb.extract %I_y from 4 : (i8) -> i1
+        %25 = comb.extract %I_y from 5 : (i8) -> i1
+        %26 = comb.extract %I_y from 6 : (i8) -> i1
+        %27 = comb.extract %I_y from 7 : (i8) -> i1
+        %29 = comb.extract %4 from 0 : (i8) -> i1
+        %30 = comb.extract %4 from 1 : (i8) -> i1
+        %31 = comb.extract %4 from 2 : (i8) -> i1
+        %32 = comb.extract %4 from 3 : (i8) -> i1
+        %33 = comb.extract %4 from 4 : (i8) -> i1
+        %34 = comb.extract %4 from 5 : (i8) -> i1
+        %35 = comb.extract %4 from 6 : (i8) -> i1
+        %36 = comb.extract %4 from 7 : (i8) -> i1
+        %37 = comb.extract %0 from 0 : (i8) -> i1
+        %38 = comb.extract %0 from 1 : (i8) -> i1
+        %39 = comb.extract %0 from 2 : (i8) -> i1
+        %40 = comb.extract %0 from 3 : (i8) -> i1
+        %41 = comb.extract %0 from 4 : (i8) -> i1
+        %42 = comb.extract %0 from 5 : (i8) -> i1
+        %43 = comb.extract %0 from 6 : (i8) -> i1
+        %44 = comb.extract %0 from 7 : (i8) -> i1
+        %45 = comb.extract %2 from 0 : (i8) -> i1
+        %46 = comb.extract %2 from 1 : (i8) -> i1
+        %47 = comb.extract %2 from 2 : (i8) -> i1
+        %48 = comb.extract %2 from 3 : (i8) -> i1
+        %49 = comb.extract %2 from 4 : (i8) -> i1
+        %50 = comb.extract %2 from 5 : (i8) -> i1
+        %51 = comb.extract %2 from 6 : (i8) -> i1
+        %52 = comb.extract %2 from 7 : (i8) -> i1
+        %56 = comb.extract %I_x_z_x from 0 : (i8) -> i1
+        %57 = comb.extract %I_x_z_x from 1 : (i8) -> i1
+        %58 = comb.extract %I_x_z_x from 2 : (i8) -> i1
+        %59 = comb.extract %I_x_z_x from 3 : (i8) -> i1
+        %60 = comb.extract %I_x_z_x from 4 : (i8) -> i1
+        %61 = comb.extract %I_x_z_x from 5 : (i8) -> i1
+        %62 = comb.extract %I_x_z_x from 6 : (i8) -> i1
+        %63 = comb.extract %I_x_z_x from 7 : (i8) -> i1
+        %68 = hw.array_create %9, %8 : i8
+        %69 = comb.extract %11 from 0 : (i8) -> i1
+        %70 = comb.extract %11 from 1 : (i8) -> i1
+        %71 = comb.extract %11 from 2 : (i8) -> i1
+        %72 = comb.extract %11 from 3 : (i8) -> i1
+        %73 = comb.extract %11 from 4 : (i8) -> i1
+        %74 = comb.extract %11 from 5 : (i8) -> i1
+        %75 = comb.extract %11 from 6 : (i8) -> i1
+        %76 = comb.extract %11 from 7 : (i8) -> i1
+        %77 = comb.extract %8 from 0 : (i8) -> i1
+        %78 = comb.extract %8 from 1 : (i8) -> i1
+        %79 = comb.extract %8 from 2 : (i8) -> i1
+        %80 = comb.extract %8 from 3 : (i8) -> i1
+        %81 = comb.extract %8 from 4 : (i8) -> i1
+        %82 = comb.extract %8 from 5 : (i8) -> i1
+        %83 = comb.extract %8 from 6 : (i8) -> i1
+        %84 = comb.extract %8 from 7 : (i8) -> i1
+        %85 = comb.extract %9 from 0 : (i8) -> i1
+        %86 = comb.extract %9 from 1 : (i8) -> i1
+        %87 = comb.extract %9 from 2 : (i8) -> i1
+        %88 = comb.extract %9 from 3 : (i8) -> i1
+        %89 = comb.extract %9 from 4 : (i8) -> i1
+        %90 = comb.extract %9 from 5 : (i8) -> i1
+        %91 = comb.extract %9 from 6 : (i8) -> i1
+        %92 = comb.extract %9 from 7 : (i8) -> i1
+        %93 = comb.extract %13 from 0 : (i8) -> i1
+        %94 = comb.extract %13 from 1 : (i8) -> i1
+        %95 = comb.extract %13 from 2 : (i8) -> i1
+        %96 = comb.extract %13 from 3 : (i8) -> i1
+        %97 = comb.extract %13 from 4 : (i8) -> i1
+        %98 = comb.extract %13 from 5 : (i8) -> i1
+        %99 = comb.extract %13 from 6 : (i8) -> i1
+        %100 = comb.extract %13 from 7 : (i8) -> i1
+        %101 = comb.concat %100, %99, %98, %97, %96, %95, %94, %93, %92, %91, %90, %89, %88, %87, %86, %85, %84, %83, %82, %81, %80, %79, %78, %77, %12, %76, %75, %74, %73, %72, %71, %70, %69, %10 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
+        hw.output %10, %11, %12, %68, %13, %101 : i1, i8, i1, !hw.array<2xi8>, i8, i34
     }
 }


### PR DESCRIPTION
This change duplicated when output targets when a user directly wires the output of a when primitive.  This avoided an inconsistency that occured when a when output was directly wired by the user and then resolved after the direct wiring.  Since the reference to the direct wiring wasn't stored, the direct wiring wasn't updated to match the resolved value.  This was a problem when resolving values elaborated the children as separate primitive outputs (rewiring the conditionally driven value to new outputs).

Now that we are elaborating when outputs using the children of the output (instead of creating new outputs for each child) we no longer have the issue of needing to track additional values driven by a when output (the standard resolve logic now handles this since we maintain the origin when output as the driver).

This simplifies the generated code by avoiding duplication in the generated verilog and reusing the same target variable (although it does introduce some extracts where in previous cases it was a bit-blasted assignment inside the always block)