### PR TITLE
[CI] Remove egg build

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -4,6 +4,6 @@ export PATH=$TRAVIS_BUILD_DIR/miniconda/bin:$PATH
 source activate test-env
 
 pip install twine
-python setup.py sdist build
+python setup.py sdist
 
 twine upload dist/* -u leonardt -p $PYPI_PASSWORD


### PR DESCRIPTION
I got a notice from PYPI that we're uploading `.egg` distributions which are deprecated and will be unsupported after August 1st.  We should be using `wheel` instead, see https://packaging.python.org/en/latest/discussions/wheel-vs-egg/.  However, since we're not actually including any binaries in our distribution, I think for now we should just revert to providing an `sdist` (source distribution) that people can compile into a python binary wheel on their machine if they'd like (avoids us having to maintaining wheels for different platforms).