### PR TITLE
[When] Remove invalid assertion

### DIFF
--- a/magma/primitives/when.py
+++ b/magma/primitives/when.py
@@ -316,7 +316,6 @@ class WhenBuilder(CircuitBuilder):
             temp = Wire(type(port).undirected_t, flatten=False)(name=name)
             for value in port.driving():
                 _rewire_driven_value_or_values(value, temp.O)
-            assert not port.driving()
             temp.I @= port
             self._when_assert_wires[port] = temp.O
         return self._when_assert_wires[port]


### PR DESCRIPTION
This assertion does not always hold True because `port.driving()` could be empty, but represented as `[[], [], []]` if the value is resolved.  We could improve the logic to check arbitrarily flattened values, but I don't think it's worth the cost/complexity since this was originally used as part of the debugging/development process rather than useful for the end user.