### PR TITLE
[Bind2] Add support for compile guard around bind

### DIFF
--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -45,11 +45,7 @@ from magma.backend.mlir.scoped_name_generator import ScopedNameGenerator
 from magma.backend.mlir.sv import sv
 from magma.backend.mlir.when_utils import WhenCompiler
 from magma.backend.mlir.xmr_utils import get_xmr_paths
-from magma.bind2 import (
-    get_bound_instance_info,
-    is_bound_instance,
-    UnboundInstanceError,
-)
+from magma.bind2 import maybe_get_bound_instance_info, is_bound_instance
 from magma.bit import Bit
 from magma.bits import Bits, BitsMeta
 from magma.bitutils import clog2, clog2safe
@@ -1140,9 +1136,8 @@ class NativeBindProcessor(BindProcessorInterface):
             instance = hw.InnerRefAttr(defn_sym, sym)
             sv.BindOp(instance=instance)
         for instance in self._defn.instances:
-            try:
-                bound_instance_info = get_bound_instance_info(instance)
-            except UnboundInstanceError:
+            bound_instance_info = maybe_get_bound_instance_info(instance)
+            if bound_instance_info is None:
                 continue
             inst_sym = self._ctx.parent.get_mapped_symbol(instance)
             ref = hw.InnerRefAttr(defn_sym, inst_sym)

--- a/magma/backend/mlir/mlir.py
+++ b/magma/backend/mlir/mlir.py
@@ -198,11 +198,9 @@ class MlirOp(WithId, metaclass=MlirOpMeta):
         self.parent = weakref.ref(parent)
 
     def parent_op(self) -> Optional['MlirOp']:
-        block = maybe_dereference(self.parent)
-        if block is None:
+        if (block := maybe_dereference(self.parent)) is None:
             return None
-        region = maybe_dereference(block.parent)
-        if region is None:
+        if (region := maybe_dereference(block.parent)) is None:
             return None
         return maybe_dereference(region.parent)
 

--- a/magma/backend/mlir/mlir.py
+++ b/magma/backend/mlir/mlir.py
@@ -8,7 +8,7 @@ import weakref
 from magma.backend.mlir.common import WithId, default_field, constant
 from magma.backend.mlir.print_opts import PrintOpts
 from magma.backend.mlir.printer_base import PrinterBase
-from magma.common import Stack, epilogue
+from magma.common import Stack, epilogue, maybe_dereference
 
 
 OptionalWeakRef = Optional[weakref.ReferenceType]
@@ -196,6 +196,15 @@ class MlirOp(WithId, metaclass=MlirOpMeta):
 
     def set_parent(self, parent: MlirBlock):
         self.parent = weakref.ref(parent)
+
+    def parent_op(self) -> Optional['MlirOp']:
+        block = maybe_dereference(self.parent)
+        if block is None:
+            return None
+        region = maybe_dereference(block.parent)
+        if region is None:
+            return None
+        return maybe_dereference(region.parent)
 
     @print_location
     def print(self, printer: PrinterBase, opts: PrintOpts):

--- a/magma/backend/mlir/mlir_passes.py
+++ b/magma/backend/mlir/mlir_passes.py
@@ -1,9 +1,10 @@
 import abc
+from typing import Any
 
 from magma.backend.mlir.mlir import MlirOp
 
 
-class MlirOpPass:
+class MlirOpPass(abc.ABC):
     def __init__(self, root: MlirOp):
         self._root = root
         self._callable = callable(self)
@@ -13,8 +14,11 @@ class MlirOpPass:
             for block in region.blocks:
                 for op in block.operations:
                     yield from self._run_on_op(op)
-                    if self._callable:
-                        yield self(op)
+                    yield self(op)
+
+    @abc.abstractmethod
+    def __call__(self, op: MlirOp) -> Any:
+        raise NotImplementedError()
 
     def run(self):
         yield from self._run_on_op(self._root)

--- a/magma/backend/mlir/mlir_passes.py
+++ b/magma/backend/mlir/mlir_passes.py
@@ -1,0 +1,25 @@
+import abc
+
+from magma.backend.mlir.mlir import MlirOp
+
+
+class MlirOpPass:
+    def __init__(self, root: MlirOp):
+        self._root = root
+        self._callable = callable(self)
+
+    def _run_on_op(self, op: MlirOp):
+        for region in op.regions:
+            for block in region.blocks:
+                for op in block.operations:
+                    yield from self._run_on_op(op)
+                    if self._callable:
+                        yield self(op)
+
+    def run(self):
+        yield from self._run_on_op(self._root)
+
+
+class CollectMlirOpsPass(MlirOpPass):
+    def __call__(self, op: MlirOp):
+        return op

--- a/magma/backend/mlir/sv.py
+++ b/magma/backend/mlir/sv.py
@@ -261,14 +261,21 @@ class IfDefOp(MlirOp):
         printer.pop()
         printer.print("}")
         if self._else_block is None:
-            printer.flush()
+            self._print_close(printer)
             return
         printer.print(" else {")
         printer.flush()
         printer.push()
         self._else_block.print(printer, opts)
         printer.pop()
-        printer.print_line("}")
+        printer.print("}")
+        self._print_close(printer)
+
+    def _print_close(self, printer: PrinterBase):
+        if self.attr_dict:
+            printer.print(" ")
+            print_attr_dict(self.attr_dict, printer)
+        printer.flush()
 
     def print_op(self, printer: PrinterBase, print_opts: PrintOpts):
         raise NotImplementedError()

--- a/magma/backend/mlir/translation_unit.py
+++ b/magma/backend/mlir/translation_unit.py
@@ -7,7 +7,8 @@ from magma.backend.mlir.compile_to_mlir_opts import CompileToMlirOpts
 from magma.backend.mlir.errors import MlirCompilerInternalError
 from magma.backend.mlir.hardware_module import HardwareModule
 from magma.backend.mlir.hw import hw
-from magma.backend.mlir.mlir import MlirSymbol, push_block
+from magma.backend.mlir.mlir import MlirOp, MlirSymbol, push_block
+from magma.backend.mlir.mlir_passes import CollectMlirOpsPass
 from magma.backend.mlir.scoped_name_generator import ScopedNameGenerator
 from magma.backend.mlir.sv import sv
 from magma.bind2 import is_bound_module
@@ -60,10 +61,15 @@ def _prepare_for_split_verilog(
         )
     for bind_op in bind_ops:
         magma_inst = only(find_by_value(symbol_map, bind_op.instance.name))
-        output_filename = bound_module_to_filename[type(magma_inst)]
-        bind_op.attr_dict["output_file"] = (
-            hw.OutputFileAttr(str(output_filename))
-        )
+        output_filename = str(bound_module_to_filename[type(magma_inst)])
+        curr_op = bind_op
+        while True:
+            curr_op.attr_dict["output_file"] = (
+                hw.OutputFileAttr(output_filename)
+            )
+            curr_op = curr_op.parent_op()
+            if curr_op is None or not isinstance(curr_op, sv.IfDefOp):
+                break
 
 
 class TranslationUnit:
@@ -156,7 +162,7 @@ class TranslationUnit:
                 self._hardware_modules.values(),
                 filter(
                     lambda op: isinstance(op, sv.BindOp),
-                    self._mlir_module.block.operations
+                    CollectMlirOpsPass(self._mlir_module).run(),
                 ),
                 self._symbol_map,
                 self._opts.basename,

--- a/magma/bind2.py
+++ b/magma/bind2.py
@@ -105,11 +105,13 @@ def bind2(
                 "Expected no arguments for binding generators. "
                 "Implement bind_arguments() instead."
             )
-        return _bind_generator_impl(dut, bind_module)
+        _bind_generator_impl(dut, bind_module)
+        return
     are_modules = (
         isinstance(dut, DefineCircuitKind) and
         isinstance(dut, CircuitKind)
     )
     if are_modules:
-        return _bind_impl(dut, bind_module, args, compile_guard)
+        _bind_impl(dut, bind_module, args, compile_guard)
+        return
     raise TypeError(dut, bind_module)

--- a/magma/bind2.py
+++ b/magma/bind2.py
@@ -25,29 +25,20 @@ class BoundInstanceInfo:
     compile_guards: List[CompileGuardInfo]
 
 
-class UnboundInstanceError(TypeError):
-    pass
-
-
 def set_bound_instance_info(inst: CircuitType, info: BoundInstanceInfo):
     global _BOUND_INSTANCE_INFO_KEY
     setattr(inst, _BOUND_INSTANCE_INFO_KEY, info)
 
 
-def get_bound_instance_info(inst: CircuitType) -> BoundInstanceInfo:
+def maybe_get_bound_instance_info(
+        inst: CircuitType
+) -> Optional[BoundInstanceInfo]:
     global _BOUND_INSTANCE_INFO_KEY
-    try:
-        return getattr(inst, _BOUND_INSTANCE_INFO_KEY)
-    except AttributeError:
-        raise UnboundInstanceError(inst) from None
+    return getattr(inst, _BOUND_INSTANCE_INFO_KEY, None)
 
 
 def is_bound_instance(inst: CircuitType) -> bool:
-    try:
-        get_bound_instance_info(inst)
-    except UnboundInstanceError:
-        return False
-    return True
+    return maybe_get_bound_instance_info(inst) is not None
 
 
 def set_is_bound_module(defn: CircuitKind, value: bool = True):

--- a/magma/bind2.py
+++ b/magma/bind2.py
@@ -1,6 +1,8 @@
+import dataclasses
 from typing import Dict, List, Optional, Union
 
 from magma.circuit import DefineCircuitKind, CircuitKind, CircuitType
+from magma.compile_guard import get_active_compile_guard_info, CompileGuardInfo
 from magma.generator import Generator2Kind, Generator2
 from magma.passes.passes import DefinitionPass, pass_lambda
 from magma.view import PortView
@@ -17,27 +19,49 @@ BindModuleType = Union[CircuitKind, Generator2Kind]
 ArgumentType = Union[Type, PortView]
 
 
-def set_bound_instance_info(inst: CircuitType, info: Dict):
+@dataclasses.dataclass(frozen=True)
+class BoundInstanceInfo:
+    args: List[ArgumentType]
+    compile_guards: List[CompileGuardInfo]
+
+
+class UnboundInstanceError(TypeError):
+    pass
+
+
+def set_bound_instance_info(inst: CircuitType, info: BoundInstanceInfo):
+    global _BOUND_INSTANCE_INFO_KEY
     setattr(inst, _BOUND_INSTANCE_INFO_KEY, info)
 
 
-def get_bound_instance_info(inst: CircuitType) -> Dict:
-    return getattr(inst, _BOUND_INSTANCE_INFO_KEY, None)
+def get_bound_instance_info(inst: CircuitType) -> BoundInstanceInfo:
+    global _BOUND_INSTANCE_INFO_KEY
+    try:
+        return getattr(inst, _BOUND_INSTANCE_INFO_KEY)
+    except AttributeError:
+        raise UnboundInstanceError(inst) from None
 
 
 def is_bound_instance(inst: CircuitType) -> bool:
-    return get_bound_instance_info(inst) is not None
+    try:
+        get_bound_instance_info(inst)
+    except UnboundInstanceError:
+        return False
+    return True
 
 
 def set_is_bound_module(defn: CircuitKind, value: bool = True):
+    global _IS_BOUND_MODULE_KEY
     setattr(defn, _IS_BOUND_MODULE_KEY, value)
 
 
 def is_bound_module(defn: CircuitKind) -> bool:
+    global _IS_BOUND_MODULE_KEY
     return getattr(defn, _IS_BOUND_MODULE_KEY, False)
 
 
 def get_bound_generator_info(inst: CircuitType) -> List[Generator2Kind]:
+    global _BOUND_GENERATOR_INFO_KEY
     try:
         info = getattr(inst, _BOUND_GENERATOR_INFO_KEY)
     except AttributeError:
@@ -76,13 +100,14 @@ def _bind_impl(
         dut: DefineCircuitKind,
         bind_module: CircuitKind,
         args: List[ArgumentType],
+        compile_guards: List[CompileGuardInfo],
 ):
     arguments = list(dut.interface.ports.values()) + args
     with dut.open():
         inst = bind_module()
         for param, arg in zip(inst.interface.ports.values(), arguments):
             wire_value_or_port_view(param, arg)
-        info = {"args": args}
+        info = BoundInstanceInfo(args, compile_guards)
         set_bound_instance_info(inst, info)
         set_is_bound_module(bind_module, True)
 
@@ -93,6 +118,7 @@ def bind2(
         *args,
 ):
     args = list(args)
+    compile_guards = list(get_active_compile_guard_info())
     are_generators = (
         isinstance(dut, Generator2Kind) and
         isinstance(bind_module, Generator2Kind)
@@ -110,6 +136,6 @@ def bind2(
         isinstance(dut, CircuitKind)
     )
     if are_modules:
-        _bind_impl(dut, bind_module, args)
+        _bind_impl(dut, bind_module, args, compile_guards)
         return
     raise TypeError(dut, bind_module)

--- a/magma/bind2.py
+++ b/magma/bind2.py
@@ -76,14 +76,13 @@ def _bind_impl(
         dut: DefineCircuitKind,
         bind_module: CircuitKind,
         args: List[ArgumentType],
-        compile_guard: str,
 ):
     arguments = list(dut.interface.ports.values()) + args
     with dut.open():
         inst = bind_module()
         for param, arg in zip(inst.interface.ports.values(), arguments):
             wire_value_or_port_view(param, arg)
-        info = {"args": args, "compile_guard": compile_guard}
+        info = {"args": args}
         set_bound_instance_info(inst, info)
         set_is_bound_module(bind_module, True)
 
@@ -92,7 +91,6 @@ def bind2(
         dut: DutType,
         bind_module: BindModuleType,
         *args,
-        compile_guard: Optional[str] = None,
 ):
     args = list(args)
     are_generators = (
@@ -112,6 +110,6 @@ def bind2(
         isinstance(dut, CircuitKind)
     )
     if are_modules:
-        _bind_impl(dut, bind_module, args, compile_guard)
+        _bind_impl(dut, bind_module, args)
         return
     raise TypeError(dut, bind_module)

--- a/magma/common.py
+++ b/magma/common.py
@@ -20,12 +20,12 @@ class Stack:
     def pop(self):
         return self._stack.pop()
 
-    def peek(self):
-        return self._stack[-1]
+    def peek(self, offset: int = 0):
+        return self._stack[-1 - offset]
 
-    def peek_default(self, default: Any) -> Any:
+    def peek_default(self, default: Any, offset: int = 0) -> Any:
         try:
-            return self._stack[-1]
+            return self._stack[-1 - offset]
         except IndexError:
             return default
 

--- a/magma/common.py
+++ b/magma/common.py
@@ -5,8 +5,9 @@ import dataclasses
 from functools import wraps, partial, reduce
 import hashlib
 import operator
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable, Optional
 import warnings
+import weakref
 
 
 class Stack:
@@ -370,3 +371,9 @@ def hash_expr(expr: str) -> str:
     hasher = hashlib.shake_128()
     hasher.update(expr.encode())
     return hasher.hexdigest(8)
+
+
+def maybe_dereference(ref: Optional[weakref.ReferenceType]) -> Optional:
+    if ref is None:
+        return None
+    return ref()

--- a/magma/common.py
+++ b/magma/common.py
@@ -21,14 +21,17 @@ class Stack:
     def pop(self):
         return self._stack.pop()
 
-    def peek(self, offset: int = 0):
-        return self._stack[-1 - offset]
+    def peek(self):
+        return self._stack[-1]
 
-    def peek_default(self, default: Any, offset: int = 0) -> Any:
+    def peek_default(self, default: Any) -> Any:
         try:
-            return self._stack[-1 - offset]
+            return self._stack[-1]
         except IndexError:
             return default
+
+    def __iter__(self) -> Iterable[Any]:
+        return iter(reversed(self._stack))
 
     def __bool__(self) -> bool:
         return bool(self._stack)

--- a/magma/compile_guard.py
+++ b/magma/compile_guard.py
@@ -35,15 +35,8 @@ def _push_compile_guard_builder_stack(builder: '_CompileGuardBuilder'):
 
 
 def get_active_compile_guard_info() -> Iterable['CompileGuardInfo']:
-    stack = _get_compile_guard_builder_stack()
-    offset = 0
-    while True:
-        try:
-            builder = stack.peek(offset=offset)
-        except IndexError:
-            break
+    for builder in _get_compile_guard_builder_stack():
         yield builder.info
-        offset += 1
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/gold/test_bind2_compile_guard.mlir.tpl
+++ b/tests/gold/test_bind2_compile_guard.mlir.tpl
@@ -1,0 +1,13 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @TopCompileGuardAsserts_mlir(%I: i1, %O: i1, %other: i1) -> () attributes {output_filelist = #hw.output_filelist<"$cwd/build/test_bind2_compile_guard_bind_files.list">} {
+    }
+    hw.module @Top(%I: i1) -> (O: i1) {
+        %1 = hw.constant -1 : i1
+        %0 = comb.xor %1, %I : i1
+        hw.instance "TopCompileGuardAsserts_mlir_inst0" sym @Top.TopCompileGuardAsserts_mlir_inst0 @TopCompileGuardAsserts_mlir(I: %I: i1, O: %0: i1, other: %I: i1) -> () {doNotPrint = true}
+        hw.output %0 : i1
+    }
+    sv.ifdef "ASSERT_ON" {
+        sv.bind #hw.innerNameRef<@Top::@Top.TopCompileGuardAsserts_mlir_inst0>
+    }
+}

--- a/tests/gold/test_bind2_compile_guard.mlir.tpl
+++ b/tests/gold/test_bind2_compile_guard.mlir.tpl
@@ -1,4 +1,4 @@
-module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+module attributes {circt.loweringOptions = "locationInfoStyle=none,omitVersionComment"} {
     hw.module @TopCompileGuardAsserts_mlir(%I: i1, %O: i1, %other: i1) -> () attributes {output_filelist = #hw.output_filelist<"$cwd/build/test_bind2_compile_guard_bind_files.list">} {
     }
     hw.module @Top(%I: i1) -> (O: i1) {

--- a/tests/gold/test_bind2_compile_guard_split_verilog.mlir.tpl
+++ b/tests/gold/test_bind2_compile_guard_split_verilog.mlir.tpl
@@ -1,4 +1,4 @@
-module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+module attributes {circt.loweringOptions = "locationInfoStyle=none,omitVersionComment"} {
     hw.module @TopCompileGuardAsserts_mlir(%I: i1, %O: i1, %other: i1) -> () attributes {output_file = #hw.output_file<"$cwd/build/TopCompileGuardAsserts_mlir.v">, output_filelist = #hw.output_filelist<"$cwd/build/test_bind2_compile_guard_split_verilog_bind_files.list">} {
     }
     hw.module @Top(%I: i1) -> (O: i1) attributes {output_file = #hw.output_file<"$cwd/build/test_bind2_compile_guard_split_verilog.v">} {

--- a/tests/gold/test_bind2_compile_guard_split_verilog.mlir.tpl
+++ b/tests/gold/test_bind2_compile_guard_split_verilog.mlir.tpl
@@ -1,0 +1,13 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none"} {
+    hw.module @TopCompileGuardAsserts_mlir(%I: i1, %O: i1, %other: i1) -> () attributes {output_file = #hw.output_file<"$cwd/build/TopCompileGuardAsserts_mlir.v">, output_filelist = #hw.output_filelist<"$cwd/build/test_bind2_compile_guard_split_verilog_bind_files.list">} {
+    }
+    hw.module @Top(%I: i1) -> (O: i1) attributes {output_file = #hw.output_file<"$cwd/build/test_bind2_compile_guard_split_verilog.v">} {
+        %1 = hw.constant -1 : i1
+        %0 = comb.xor %1, %I : i1
+        hw.instance "TopCompileGuardAsserts_mlir_inst0" sym @Top.TopCompileGuardAsserts_mlir_inst0 @TopCompileGuardAsserts_mlir(I: %I: i1, O: %0: i1, other: %I: i1) -> () {doNotPrint = true}
+        hw.output %0 : i1
+    }
+    sv.ifdef "ASSERT_ON" {
+        sv.bind #hw.innerNameRef<@Top::@Top.TopCompileGuardAsserts_mlir_inst0> {output_file = #hw.output_file<"$cwd/build/TopCompileGuardAsserts_mlir.v">}
+    } {output_file = #hw.output_file<"$cwd/build/TopCompileGuardAsserts_mlir.v">}
+}

--- a/tests/gold/test_compile_guard_basic_vcc.json
+++ b/tests/gold/test_compile_guard_basic_vcc.json
@@ -2,7 +2,7 @@
 "namespaces":{
   "global":{
     "modules":{
-      "CompileGuardCircuit_0":{
+      "COND_compile_guard":{
         "type":["Record",[
           ["port_0",["Named","coreir.clkIn"]],
           ["port_1","BitIn"]
@@ -52,14 +52,14 @@
           ["CLK",["Named","coreir.clkIn"]]
         ]],
         "instances":{
-          "CompileGuardCircuit_0":{
-            "modref":"global.CompileGuardCircuit_0",
+          "COND_compile_guard":{
+            "modref":"global.COND_compile_guard",
             "metadata":{"compile_guard":{"condition_str":"COND","type":"defined"}}
           }
         },
         "connections":[
-          ["self.CLK","CompileGuardCircuit_0.port_0"],
-          ["self.I","CompileGuardCircuit_0.port_1"],
+          ["self.CLK","COND_compile_guard.port_0"],
+          ["self.I","COND_compile_guard.port_1"],
           ["self.O","self.I"]
         ]
       }

--- a/tests/test_bind2.py
+++ b/tests/test_bind2.py
@@ -4,7 +4,11 @@ import pytest
 import string
 
 import magma as m
-from magma.bind2 import is_bound_module
+from magma.bind2 import (
+    is_bound_module,
+    is_bound_instance,
+    get_bound_instance_info,
+)
 from magma.passes.passes import CircuitPass
 import magma.testing
 
@@ -148,3 +152,43 @@ def test_generator():
 
     assert not is_bound_module(Top)
     _CheckLogicAssertsAreBoundModulesPass(Top).run()
+
+
+@pytest.mark.parametrize(
+    "backend,split_verilog",
+    itertools.product(("mlir",), (False, True))
+)
+def test_compile_guard(backend, split_verilog):
+
+    class Top(m.Circuit):
+        io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit))
+        io.O @= ~io.I
+
+    class TopCompileGuardAsserts(m.Circuit):
+        name = f"TopCompileGuardAsserts_{backend}"
+        io = m.IO(I=m.In(m.Bit), O=m.In(m.Bit), other=m.In(m.Bit))
+        io.I.unused()
+        io.O.unused()
+        io.other.unused()
+
+    with m.compile_guard("ASSERT_ON"):
+        m.bind2(Top, TopCompileGuardAsserts, Top.I)
+
+    assert not is_bound_module(Top)
+    assert is_bound_module(TopCompileGuardAsserts)
+    inst = Top.instances[-1]
+    assert is_bound_instance(inst)
+    compile_guard_infos = get_bound_instance_info(inst).compile_guards
+    assert len(compile_guard_infos) == 1
+    assert compile_guard_infos[0].condition_str == "ASSERT_ON"
+
+    basename = f"test_bind2_compile_guard"
+    suffix = "mlir" if backend == "mlir" else "v"
+    opts = {
+        "output": backend,
+        "use_native_bind_processor": True,
+    }
+    if split_verilog:
+        opts.update({"split_verilog": True})
+        basename = basename + "_split_verilog"
+    _assert_compilation(Top, basename, suffix, opts)

--- a/tests/test_bind2.py
+++ b/tests/test_bind2.py
@@ -7,7 +7,7 @@ import magma as m
 from magma.bind2 import (
     is_bound_module,
     is_bound_instance,
-    get_bound_instance_info,
+    maybe_get_bound_instance_info,
 )
 from magma.passes.passes import CircuitPass
 import magma.testing
@@ -178,8 +178,9 @@ def test_compile_guard(backend, split_verilog):
     assert is_bound_module(TopCompileGuardAsserts)
     inst = Top.instances[-1]
     assert is_bound_instance(inst)
-    compile_guard_infos = get_bound_instance_info(inst).compile_guards
+    compile_guard_infos = maybe_get_bound_instance_info(inst).compile_guards
     assert len(compile_guard_infos) == 1
+    assert compile_guard_infos[0] is not None
     assert compile_guard_infos[0].condition_str == "ASSERT_ON"
 
     basename = f"test_bind2_compile_guard"

--- a/tests/test_compile_guard.py
+++ b/tests/test_compile_guard.py
@@ -215,7 +215,7 @@ def test_vcc():
     class _Top(m.Circuit):
         io = m.IO(I=m.In(m.Bit), O=m.Out(m.Bit)) + m.ClockIO()
 
-        with m.compile_guard("COND"):
+        with m.compile_guard("COND", defn_name="COND_compile_guard"):
             out = m.Register(m.Bit)()(io.I ^ 1)
 
         io.O @= io.I


### PR DESCRIPTION
Adds support for emitting `ifdef` around `bind` calls. The syntax for this is:

```python
with m.compile_guard(...):
    m.bind2(...)
```

which emits MLIR like:

```MLIR
sv.ifdef ... {
  sv.bind ...
}
```

```Verilog
`ifdef ...
  bind ...
`endif
```

One important thing to note is that in the case of split verilog, the output file attribute annotation has to be applied up the compile guard stack, i.e. the `sv.ifdef` surrounding the `sv.bind` also needs the `hw.OutputFileAttr` attached.