### PR TITLE
[Types] Add recursive wiring key ordering check

### DIFF
--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -163,7 +163,8 @@ class TupleKind(TupleMeta, Kind):
         if not isinstance(rhs, TupleKind) or len(cls.fields) != len(rhs.fields):
             return False
         for idx, T in enumerate(cls.fields):
-            if not T.is_wireable(rhs[idx]):
+            T = magma_type(T)
+            if not T.is_wireable(magma_type(rhs[idx])):
                 return False
         return True
 
@@ -172,7 +173,8 @@ class TupleKind(TupleMeta, Kind):
         if not isinstance(rhs, TupleKind) or len(cls.fields) != len(rhs.fields):
             return False
         for idx, T in enumerate(cls.fields):
-            if not T.is_bindable(rhs[idx]):
+            T = magma_type(T)
+            if not T.is_bindable(magma_type(rhs[idx])):
                 return False
         return True
 
@@ -597,11 +599,12 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
         rhs = magma_type(rhs)
         if (
             not isinstance(rhs, AnonProductKind) or
-            list(cls.fields) != list(rhs.fields)
+            list(cls.field_dict.keys()) != list(rhs.field_dict.keys())
         ):
             return False
         for k, v in cls.field_dict.items():
-            if k not in rhs.field_dict or not v.is_wireable(rhs.field_dict[k]):
+            v = magma_type(v)
+            if not v.is_wireable(magma_type(rhs.field_dict[k])):
                 return False
         return True
 
@@ -609,11 +612,12 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
         rhs = magma_type(rhs)
         if (
             not isinstance(rhs, AnonProductKind) or
-            list(cls.fields) != list(rhs.fields)
+            list(cls.field_dict.keys()) != list(rhs.field_dict.keys())
         ):
             return False
         for k, v in cls.field_dict.items():
-            if k not in rhs.field_dict or not v.is_bindable(rhs.field_dict[k]):
+            v = magma_type(v)
+            if not v.is_bindable(magma_type(rhs.field_dict[k])):
                 return False
         return True
 

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -330,6 +330,18 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
                 debug_info=debug_info
             )
             return
+
+        for k in self.keys():
+            if not type(self[k]).is_wireable(type(o[k])):
+                _logger.error(
+                    WiringLog(f"Cannot wire {{}} (type={type(o)}, to "
+                              f" {{}} (type={type(self)})"
+                              f"because the key {k} is not wireable",
+                              o, self),
+                    debug_info=debug_info
+                )
+                return
+
         if self._should_wire_children(o):
             for self_elem, o_elem in zip(self, o):
                 self_elem = magma_value(self_elem)
@@ -585,7 +597,7 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
         rhs = magma_type(rhs)
         if (
             not isinstance(rhs, AnonProductKind) or
-            len(cls.fields) != len(rhs.fields)
+            list(cls.fields) != list(rhs.fields)
         ):
             return False
         for k, v in cls.field_dict.items():
@@ -597,7 +609,7 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
         rhs = magma_type(rhs)
         if (
             not isinstance(rhs, AnonProductKind) or
-            len(cls.fields) != len(rhs.fields)
+            list(cls.fields) != list(rhs.fields)
         ):
             return False
         for k, v in cls.field_dict.items():

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -163,8 +163,7 @@ class TupleKind(TupleMeta, Kind):
         if not isinstance(rhs, TupleKind) or len(cls.fields) != len(rhs.fields):
             return False
         for idx, T in enumerate(cls.fields):
-            T = magma_type(T)
-            if not T.is_wireable(magma_type(rhs[idx])):
+            if not magma_type(T).is_wireable(rhs[idx]):
                 return False
         return True
 
@@ -336,10 +335,13 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
         for i, k in enumerate(self.keys()):
             if not type(self).fields[i].is_wireable(type(o).fields[i]):
                 _logger.error(
-                    WiringLog(f"Cannot wire {{}} (type={type(o)}, to "
-                              f" {{}} (type={type(self)})"
-                              f"because the key {k} is not wireable",
-                              o, self),
+                    WiringLog(
+                        f"Cannot wire {{}} (type={type(o)}, to "
+                        f" {{}} (type={type(self)})"
+                        f"because the key {k} is not wireable",
+                        o,
+                        self
+                    ),
                     debug_info=debug_info
                 )
                 return
@@ -603,8 +605,7 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
         ):
             return False
         for k, v in cls.field_dict.items():
-            v = magma_type(v)
-            if not v.is_wireable(magma_type(rhs.field_dict[k])):
+            if not magma_type(v).is_wireable(rhs.field_dict[k]):
                 return False
         return True
 

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -334,7 +334,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
             return
 
         for i, k in enumerate(self.keys()):
-            if not type(self)[i].is_wireable(type(o)[i]):
+            if not type(self).fields[i].is_wireable(type(o).fields[i]):
                 _logger.error(
                     WiringLog(f"Cannot wire {{}} (type={type(o)}, to "
                               f" {{}} (type={type(self)})"

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -333,8 +333,8 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
             )
             return
 
-        for k in self.keys():
-            if not type(self)[k].is_wireable(type(o)[k]):
+        for i, k in enumerate(self.keys()):
+            if not type(self)[i].is_wireable(type(o)[i]):
                 _logger.error(
                     WiringLog(f"Cannot wire {{}} (type={type(o)}, to "
                               f" {{}} (type={type(self)})"

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -334,7 +334,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
             return
 
         for k in self.keys():
-            if not type(self[k]).is_wireable(type(o[k])):
+            if not type(self)[k].is_wireable(type(o)[k]):
                 _logger.error(
                     WiringLog(f"Cannot wire {{}} (type={type(o)}, to "
                               f" {{}} (type={type(self)})"

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -172,8 +172,7 @@ class TupleKind(TupleMeta, Kind):
         if not isinstance(rhs, TupleKind) or len(cls.fields) != len(rhs.fields):
             return False
         for idx, T in enumerate(cls.fields):
-            T = magma_type(T)
-            if not T.is_bindable(magma_type(rhs[idx])):
+            if not magma_type(T).is_bindable(rhs[idx]):
                 return False
         return True
 
@@ -617,8 +616,7 @@ class AnonProductKind(AnonymousProductMeta, TupleKind, Kind):
         ):
             return False
         for k, v in cls.field_dict.items():
-            v = magma_type(v)
-            if not v.is_bindable(magma_type(rhs.field_dict[k])):
+            if not magma_type(v).is_bindable(rhs.field_dict[k]):
                 return False
         return True
 

--- a/magma/wire.py
+++ b/magma/wire.py
@@ -54,8 +54,11 @@ def wire(o, i, debug_info=None):
 
     i_T, o_T = type(i), type(o)
     if not i_T.is_wireable(o_T):
+        # Escape curly braces in type string for format call.
+        o_T_str = str(o_T).replace("{", "{{").replace("}", "}}")
+        i_T_str = str(i_T).replace("{", "{{").replace("}", "}}")
         _logger.error(
-            WiringLog(f"Cannot wire {{}} ({o_T}) to {{}} ({i_T})",
+            WiringLog(f"Cannot wire {{}} ({o_T_str}) to {{}} ({i_T_str})",
                       o, i),
             debug_info=debug_info
         )


### PR DESCRIPTION
Fixes https://github.com/phanrahan/magma/issues/1316

Ensures that recursive types check tuple key ordering