### PR TITLE
Add bitlen utility

### DIFF
--- a/magma/bitutils.py
+++ b/magma/bitutils.py
@@ -34,3 +34,6 @@ def clog2safe(x: int) -> int:
     if x == 1:
         return 1
     return clog2(x)
+
+def bitlen(x: int) -> int:
+    return math.floor(math.log2(x)) + 1

--- a/tests/test_bitutils.py
+++ b/tests/test_bitutils.py
@@ -21,7 +21,13 @@ _CLOG2SAFE_CASES = (
     (14, 4),
     (16, 4),
 )
-
+_BITLEN_CASES = (
+    (1, 1),
+    (7, 3),
+    (14, 4),
+    (16, 5),
+    (32, 6),
+)
 
 def test_seq2int():
     for s, i in _SEQ2INT_CASES:
@@ -41,3 +47,7 @@ def test_clog2():
 def test_clog2safe():
     for i, o in _CLOG2SAFE_CASES:
         assert m.bitutils.clog2safe(i) == o
+
+def test_bitlen():
+    for i, o in _BITLEN_CASES:
+        assert m.bitutils.bitlen(i) == o


### PR DESCRIPTION
- bitlen(x) provides number of bits in binary representation of x.

Although `clog2` is provided as a utility function for approximating bit lengths from values, it fails in edge cases where the value itself is a power of 2. For example, `clog2(16) = 4`, but 5 bits are needed to store the value 16. The right formula here would be: `floor(log_2(16)) + 1`. Although most hardware designers might be aware of this, a helper function for bit length of any generic value could be helpful. 