### PR TITLE
[MLIR] Fix issues with tuple compilation

### DIFF
--- a/magma/backend/mlir/hardware_module.py
+++ b/magma/backend/mlir/hardware_module.py
@@ -343,7 +343,13 @@ class ModuleVisitor:
         return operand
 
     @functools.lru_cache()
-    def make_struct_ref(self, struct: MlirValue, key: str) -> MlirValue:
+    def make_struct_ref(
+        self,
+        struct: MlirValue,
+        key: Union[int, str]
+    ) -> MlirValue:
+        if isinstance(key, int):
+            key = f"_{key}"
         operand = self.ctx.new_value(struct.type.get_field(key))
         hw.StructExtractOp(field=key, operands=[struct], results=[operand])
         return operand

--- a/magma/backend/mlir/when_utils.py
+++ b/magma/backend/mlir/when_utils.py
@@ -128,8 +128,8 @@ class WhenCompiler:
         return fields
 
     def _get_parent(self, val, collection, to_index):
-        """Search ancestor tree until we find either not an Array or we find a
-        an array that is in the index map.
+        """Search ancestor tree until we find either not an Array or Tuple or
+        we find an array or tuple that is in the index map.
         """
         for ref in val.name.root_iter(
             stop_if=lambda ref: not isinstance(ref, DerivedRef)
@@ -142,7 +142,7 @@ class WhenCompiler:
                 return collection[idx], ref.parent_value
         return None, None  # didn't find parent
 
-    def _check_array_child_wire(self, val, collection, to_index):
+    def _check_derived_wire(self, val, collection, to_index):
         """If val is a child of an array or tuple in the index map, get the
         parent wire (so we add to a collection of drivers for a bulk assign).
         """
@@ -181,7 +181,7 @@ class WhenCompiler:
             elts = zip(*map(self._flatten_value, (drivee, driver)))
             for drivee_elt, driver_elt in elts:
 
-                operand_wire, operand_index = self._check_array_child_wire(
+                operand_wire, operand_index = self._check_derived_wire(
                     driver_elt, self._operands, self._input_to_index)
                 if operand_wire:
                     operand = self._make_operand(operand_wire,
@@ -189,7 +189,7 @@ class WhenCompiler:
                 else:
                     operand = self._get_operand(driver_elt)
 
-                drivee_wire, drivee_index = self._check_array_child_wire(
+                drivee_wire, drivee_index = self._check_derived_wire(
                     drivee_elt, self._output_wires, self._output_to_index)
                 if drivee_wire:
                     wire_map.setdefault(drivee_wire, {})

--- a/magma/backend/mlir/when_utils.py
+++ b/magma/backend/mlir/when_utils.py
@@ -230,7 +230,7 @@ class WhenCompiler:
     def _create_struct_from_collection(self, T, value, result):
         value = [
             self._create_from_recursive_collection(v, value[k])
-            for k, v in sorted(T.fields, key=lambda x: x[0])
+            for k, v in T.fields
         ]
         hw.StructCreateOp(
             operands=value,

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -405,7 +405,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
                 j = keys[i]
             except IndexError:
                 return False
-            # elements should be in correct key order
+            # Elements should be in correct key order
             if ts[i].name.index != j:
                 return False
 

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -375,8 +375,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
     def wired(self):
         return all(t.wired() for t in self)
 
-    @staticmethod
-    def _iswhole(ts, keys):
+    def _iswhole(self, ts):
 
         for i in range(len(ts)):
             if ts[i].anon():
@@ -392,19 +391,28 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
             if ts[i].name.tuple is not ts[i - 1].name.tuple:
                 return False
 
-        for i in range(len(ts)):
-            # elements should be numbered consecutively
-            if ts[i].name.index != list(keys)[i]:
-                return False
-
         if len(ts) != len(ts[0].name.tuple):
             # elements should refer to a whole tuple
             return False
 
+        keys = list(ts[0].name.tuple.keys())
+
+        if keys != list(self.keys()):
+            return False
+
+        for i in range(len(ts)):
+            try:
+                j = keys[i]
+            except IndexError:
+                return False
+            # elements should be in correct key order
+            if ts[i].name.index != j:
+                return False
+
         return True
 
     def iswhole(self):
-        return Tuple._iswhole(list(self), self.keys())
+        return self._iswhole(list(self))
 
     @aggregate_wireable_method
     def trace(self, skip_self=True):
@@ -418,7 +426,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
             else:
                 return None
 
-        if len(ts) == len(self) and Tuple._iswhole(ts, self.keys()):
+        if self._iswhole(ts):
             return ts[0].name.tuple
 
         return type(self).flip()(*ts)
@@ -431,7 +439,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
             if t is None:
                 return None
 
-        if len(ts) == len(self) and Tuple._iswhole(ts, self.keys()):
+        if self._iswhole(ts):
             return ts[0].name.tuple
 
         return type(self).flip()(*ts)

--- a/magma/tuple.py
+++ b/magma/tuple.py
@@ -204,7 +204,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
                     t = T(t)
                 self._ts[i] = t
                 if not isinstance(self, AnonProduct):
-                    setattr(self, k, t)
+                    setattr(self, str(k), t)
             self._resolved = True
 
         self._keys_list = list(self.keys())
@@ -234,7 +234,7 @@ class Tuple(Type, Tuple_, AggregateWireable, metaclass=TupleKind):
 
     @classmethod
     def keys(cls):
-        return [str(i) for i in range(len(cls.fields))]
+        return list(range(len(cls.fields)))
 
     @output_only("Cannot use == on an input")
     def __eq__(self, rhs):

--- a/magma/value_utils.py
+++ b/magma/value_utils.py
@@ -1,5 +1,5 @@
 import dataclasses
-import typing
+from typing import Union
 
 from magma.ref import Ref, TupleRef, ArrayRef
 from magma.type_utils import (isprotocol, isdigital, isbits, isarray, istuple,
@@ -67,9 +67,11 @@ class Selector:
 
 @dataclasses.dataclass(frozen=True)
 class TupleSelector(Selector):
-    key: str
+    key: Union[int, str]
 
     def _select(self, value):
+        if isinstance(self.key, int):
+            return value[self.key]
         return getattr(value, self.key)
 
     def __str__(self):

--- a/tests/gold/test_when_emit_asserts_tuple_elab_False.mlir
+++ b/tests/gold/test_when_emit_asserts_tuple_elab_False.mlir
@@ -1,0 +1,63 @@
+module attributes {circt.loweringOptions = "locationInfoStyle=none,omitVersionComment"} {
+    hw.module @test_when_emit_asserts_tuple_elab_False(%I: !hw.array<2x!hw.struct<_0: i8, _1: i1>>, %S: i1, %CLK: i1) -> (O: !hw.struct<_0: i8, _1: i1>) {
+        %1 = hw.constant 0 : i1
+        %0 = hw.array_get %I[%1] : !hw.array<2x!hw.struct<_0: i8, _1: i1>>, i1
+        %2 = hw.struct_extract %0["_1"] : !hw.struct<_0: i8, _1: i1>
+        %5 = sv.reg : !hw.inout<!hw.struct<_0: i8, _1: i1>>
+        %4 = sv.read_inout %5 : !hw.inout<!hw.struct<_0: i8, _1: i1>>
+        sv.alwayscomb {
+            %8 = hw.struct_create (%6, %7) : !hw.struct<_0: i8, _1: i1>
+            sv.bpassign %5, %8 : !hw.struct<_0: i8, _1: i1>
+            sv.if %S {
+                %9 = hw.struct_create (%6, %7) : !hw.struct<_0: i8, _1: i1>
+                sv.bpassign %5, %9 : !hw.struct<_0: i8, _1: i1>
+            } else {
+                sv.if %2 {
+                    %10 = hw.struct_create (%6, %7) : !hw.struct<_0: i8, _1: i1>
+                    sv.bpassign %5, %10 : !hw.struct<_0: i8, _1: i1>
+                }
+            }
+        }
+        %6 = hw.struct_extract %3["_0"] : !hw.struct<_0: i8, _1: i1>
+        %7 = hw.struct_extract %3["_1"] : !hw.struct<_0: i8, _1: i1>
+        %11 = hw.struct_extract %4["_0"] : !hw.struct<_0: i8, _1: i1>
+        %13 = sv.wire sym @test_when_emit_asserts_tuple_elab_False._WHEN_ASSERT_1 name "_WHEN_ASSERT_1" : !hw.inout<i8>
+        sv.assign %13, %11 : i8
+        %12 = sv.read_inout %13 : !hw.inout<i8>
+        %14 = hw.struct_extract %4["_1"] : !hw.struct<_0: i8, _1: i1>
+        %16 = sv.wire sym @test_when_emit_asserts_tuple_elab_False._WHEN_ASSERT_2 name "_WHEN_ASSERT_2" : !hw.inout<i1>
+        sv.assign %16, %14 : i1
+        %15 = sv.read_inout %16 : !hw.inout<i1>
+        %17 = hw.struct_create (%12, %15) : !hw.struct<_0: i8, _1: i1>
+        %18 = sv.reg name "Register_inst0" : !hw.inout<!hw.struct<_0: i8, _1: i1>>
+        sv.alwaysff(posedge %CLK) {
+            sv.passign %18, %17 : !hw.struct<_0: i8, _1: i1>
+        }
+        %20 = hw.constant 0 : i8
+        %21 = hw.constant 0 : i1
+        %19 = hw.struct_create (%20, %21) : !hw.struct<_0: i8, _1: i1>
+        sv.initial {
+            sv.bpassign %18, %19 : !hw.struct<_0: i8, _1: i1>
+        }
+        %3 = sv.read_inout %18 : !hw.inout<!hw.struct<_0: i8, _1: i1>>
+        %22 = hw.struct_create (%12, %15) : !hw.struct<_0: i8, _1: i1>
+        %24 = sv.wire sym @test_when_emit_asserts_tuple_elab_False._WHEN_ASSERT_0 name "_WHEN_ASSERT_0" : !hw.inout<!hw.struct<_0: i8, _1: i1>>
+        sv.assign %24, %22 : !hw.struct<_0: i8, _1: i1>
+        %23 = sv.read_inout %24 : !hw.inout<!hw.struct<_0: i8, _1: i1>>
+        %25 = hw.struct_extract %23["_1"] : !hw.struct<_0: i8, _1: i1>
+        %26 = hw.struct_extract %23["_0"] : !hw.struct<_0: i8, _1: i1>
+        %27 = hw.struct_extract %3["_1"] : !hw.struct<_0: i8, _1: i1>
+        %28 = hw.struct_extract %3["_0"] : !hw.struct<_0: i8, _1: i1>
+        sv.verbatim "WHEN_ASSERT_0: assert property (({{0}}) |-> ({{{1}}, {{2}}} == {{{3}}, {{4}}}));" (%S, %25, %26, %27, %28) : i1, i1, i8, i1, i8
+        %30 = hw.constant -1 : i1
+        %29 = comb.xor %30, %S : i1
+        %31 = comb.and %29, %2 : i1
+        sv.verbatim "WHEN_ASSERT_1: assert property (({{0}}) |-> ({{1}} == {{2}}));" (%31, %12, %28) : i1, i8, i8
+        sv.verbatim "WHEN_ASSERT_2: assert property (({{0}}) |-> ({{1}} == {{2}}));" (%31, %15, %27) : i1, i1, i1
+        %32 = comb.xor %30, %31 : i1
+        sv.verbatim "WHEN_ASSERT_3: assert property (({{0}}) |-> ({{1}} == {{2}}));" (%32, %12, %28) : i1, i8, i8
+        %33 = comb.xor %30, %31 : i1
+        sv.verbatim "WHEN_ASSERT_4: assert property (({{0}}) |-> ({{1}} == {{2}}));" (%33, %15, %27) : i1, i1, i1
+        hw.output %3 : !hw.struct<_0: i8, _1: i1>
+    }
+}

--- a/tests/gold/test_when_emit_asserts_tuple_elab_True.mlir
+++ b/tests/gold/test_when_emit_asserts_tuple_elab_True.mlir
@@ -1,5 +1,5 @@
 module attributes {circt.loweringOptions = "locationInfoStyle=none,omitVersionComment"} {
-    hw.module @test_when_emit_asserts_tuple_elab(%I_0_0: i8, %I_0_1: i1, %I_1_0: i8, %I_1_1: i1, %S: i1, %CLK: i1) -> (O_0: i8, O_1: i1) {
+    hw.module @test_when_emit_asserts_tuple_elab_True(%I_0_0: i8, %I_0_1: i1, %I_1_0: i8, %I_1_1: i1, %S: i1, %CLK: i1) -> (O_0: i8, O_1: i1) {
         %4 = sv.reg : !hw.inout<i8>
         %2 = sv.read_inout %4 : !hw.inout<i8>
         %5 = sv.reg : !hw.inout<i1>
@@ -17,10 +17,10 @@ module attributes {circt.loweringOptions = "locationInfoStyle=none,omitVersionCo
                 }
             }
         }
-        %7 = sv.wire sym @test_when_emit_asserts_tuple_elab._WHEN_ASSERT_0 name "_WHEN_ASSERT_0" : !hw.inout<i8>
+        %7 = sv.wire sym @test_when_emit_asserts_tuple_elab_True._WHEN_ASSERT_0 name "_WHEN_ASSERT_0" : !hw.inout<i8>
         sv.assign %7, %2 : i8
         %6 = sv.read_inout %7 : !hw.inout<i8>
-        %9 = sv.wire sym @test_when_emit_asserts_tuple_elab._WHEN_ASSERT_1 name "_WHEN_ASSERT_1" : !hw.inout<i1>
+        %9 = sv.wire sym @test_when_emit_asserts_tuple_elab_True._WHEN_ASSERT_1 name "_WHEN_ASSERT_1" : !hw.inout<i1>
         sv.assign %9, %3 : i1
         %8 = sv.read_inout %9 : !hw.inout<i1>
         %10 = sv.reg name "Register_inst0" : !hw.inout<i8>

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -414,8 +414,8 @@ def test_tuple_same_key_value():
     T0 = m.AnonProduct[{"x": m.Bit, "y": m.Bits[8]}]
     T1 = m.AnonProduct[{"y": m.Bits[8], "x": m.Bit}]
 
-    class tuple_same_key_value(m.Circuit):
-        io = m.IO(I=m.In(T0), O=m.Out(T1))
-        io.O.x @= io.I.x
-        io.O.y @= io.I.y
-        assert isinstance(io.O.value(), m.Out(T1)), type(io.O.value())
+    a = m.Out(T0)()
+    b = m.In(T1)()
+    b.x @= a.x
+    b.y @= a.y
+    assert isinstance(b.value(), m.Out(T1)), type(b.value())

--- a/tests/test_type/test_tuple.py
+++ b/tests/test_type/test_tuple.py
@@ -408,3 +408,14 @@ def test_tuple_key_ordering_recursive_2(caplog):
 """
 
     assert has_error(caplog, msg)
+
+
+def test_tuple_same_key_value():
+    T0 = m.AnonProduct[{"x": m.Bit, "y": m.Bits[8]}]
+    T1 = m.AnonProduct[{"y": m.Bits[8], "x": m.Bit}]
+
+    class tuple_same_key_value(m.Circuit):
+        io = m.IO(I=m.In(T0), O=m.Out(T1))
+        io.O.x @= io.I.x
+        io.O.y @= io.I.y
+        assert isinstance(io.O.value(), m.Out(T1)), type(io.O.value())

--- a/tests/test_when.py
+++ b/tests/test_when.py
@@ -1791,11 +1791,13 @@ def test_when_emit_asserts_value():
     assert check_gold(__file__, "test_when_emit_asserts_value.mlir")
 
 
-def test_when_emit_asserts_tuple_elab():
+@pytest.mark.parametrize('flatten_all_tuples', [True, False])
+def test_when_emit_asserts_tuple_elab(flatten_all_tuples):
 
     T = m.Tuple[m.Bits[8], m.Bit]
 
     class test_when_emit_asserts_tuple_elab(m.Circuit):
+        name = f"test_when_emit_asserts_tuple_elab_{flatten_all_tuples}"
         io = m.IO(I=m.In(m.Array[2, T]), S=m.In(m.Bit), O=m.Out(T))
 
         x = m.Register(T)()
@@ -1805,12 +1807,17 @@ def test_when_emit_asserts_tuple_elab():
         with m.elsewhen(io.I[0][1]):
             x.I @= io.O.value()
 
-    m.compile("build/test_when_emit_asserts_tuple_elab",
-              test_when_emit_asserts_tuple_elab,
-              flatten_all_tuples=True,
-              output=_get_output_type(), emit_when_assertions=True)
+    m.compile(
+        f"build/{test_when_emit_asserts_tuple_elab.name}",
+        test_when_emit_asserts_tuple_elab,
+        flatten_all_tuples=flatten_all_tuples,
+        output=_get_output_type(),
+        emit_when_assertions=True
+    )
 
-    assert check_gold(__file__, "test_when_emit_asserts_tuple_elab.mlir")
+    assert check_gold(
+        __file__, f"{test_when_emit_asserts_tuple_elab.name}.mlir"
+    )
 
 
 def _check_or_update(circ):


### PR DESCRIPTION
* Fixes problem with `.value()` where `iswhole` would incorrectly return True when two tuples with different key orderings were wired (it's ok to wire two tuples when there keys don't match if you wire the children up explicitly, but `.value()` shouldn't return the source tuple because that's not a compatible type, instead it should construct a new flipped version).
* Fixes issue with tuple compile keys (need to prepend `_` to integer keys)
* Fixes sorting issue in when struct create (did not revert when other sorting code was reverted)
* Update names/comments in when recursive code (is general across array/tuples, but some code still referred to array)
