### PR TITLE
[Primitives] Rename list_lookup to seq_lookup

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -111,9 +111,10 @@ for the 1st input, `I1` for the second...).  The select input will select
 the input value in ascending order (`S == 0` will select `I0`, `S == 1` will
 select `I1`, ...).
 
-## Dict and List Lookup
-`magma` provides the helper functions `dict_lookup` and `list_lookup` to
-facilitate mux generation for looking up values stored in a dictionary or list.
+## Dict and Seq Lookup
+`magma` provides the helper functions `dict_lookup` and `seq_lookup` to
+facilitate mux generation for looking up values stored in a dictionary or
+sequence.
 
 Here are the interfaces to the functions:
 ```python
@@ -125,13 +126,13 @@ def dict_lookup(dict_, select, default=0):
     default value of 0
     """
 
-def list_lookup(list_, select, default=0):
+def seq_lookup(seq: Sequence, select, default=0):
     """
-    Use `select` as an index into `list` (similar to a case statement)
+    Use `select` as an index into `seq` (similar to a case statement)
 
     `default` is used when `select` does not match any of the indices (e.g.
-    when the select width is longer than the list) and has a default value of
-    0.
+    when the select width is longer than the sequence) and has a default value
+    of 0.
     """
 ```
 
@@ -152,7 +153,7 @@ class ListLookup(m.Circuit):
     io = m.IO(S=m.In(m.Bits[2]), O=m.Out(m.Bits[5]))
 
     list_ = [BitVector[5](0), BitVector[5](1), BitVector[5](2)]
-    io.O @= m.list_lookup(list_, io.S, default=BitVector[5](3))
+    io.O @= m.seq_lookup(list_, io.S, default=BitVector[5](3))
 ```
 
 

--- a/magma/primitives/mux.py
+++ b/magma/primitives/mux.py
@@ -205,15 +205,18 @@ def dict_lookup(dict_, select, default=0):
 
 
 @magma_helper_function
-def list_lookup(list_, select, default=0):
+def seq_lookup(seq: Sequence, select, default=0):
     """
-    Use `select` as an index into `list` (similar to a case statement)
+    Use `select` as an index into `seq` (similar to a case statement)
 
     `default` is used when `select` does not match any of the indices (e.g.
-    when the select width is longer than the list) and has a default value of
-    0.
+    when the select width is longer than the sequence) and has a default value
+    of 0.
     """
     output = default
-    for i, elem in enumerate(list_):
+    for i, elem in enumerate(seq):
         output = mux([output, elem], i == select)
     return output
+
+
+list_lookup = seq_lookup


### PR DESCRIPTION
* Name indicates support for more general pattern of arbitrary sequences
* Provide `list_lookup` as alias for backwards compatability